### PR TITLE
Clay Org Transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nymag/clay-kiln.git"
+    "url": "https://github.com/clay/clay-kiln.git"
   },
   "keywords": [
     "clay",
@@ -24,7 +24,7 @@
   "author": "New York Media",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/nymag/clay-kiln/issues"
+    "url": "https://github.com/clay/clay-kiln/issues"
   },
   "files": [
     "dist",
@@ -32,7 +32,7 @@
     "template.handlebars",
     "schema.yml"
   ],
-  "homepage": "https://github.com/nymag/clay-kiln",
+  "homepage": "https://github.com/clay/clay-kiln",
   "devDependencies": {
     "@nymag/cid": "^1.0.1",
     "@nymag/dom": "^1.3.1",


### PR DESCRIPTION
Changing links to `/clay/`