### PR TITLE
site-specific behaviors

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,19 @@
 {
-  "presets": ["es2015"],
+  "presets": [
+    ["env", {
+      "targets": {
+        "browsers": ["last 2 versions"],
+        "uglify": true
+      },
+      "useBuiltIns": true
+    }]
+  ],
   "env": {
     "test": {
-      "plugins": ["istanbul"]
+      "plugins": ["transform-object-rest-spread", "istanbul"]
     },
     "build": {
-      "plugins": ["lodash"]
+      "plugins": ["transform-object-rest-spread", "lodash"]
     }
   }
 }

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -21,7 +21,7 @@ A group of checkboxes, allowing the user to toggle on or off related items. You 
 
 ## Arguments
 
-* **options** _(required)_ an array of strings or objects (with `text`, `value`, and optionally `sites`)
+* **options** _(required)_ an array of strings or objects (with `name`, `value`, and optionally `sites`)
 
 If you specify options as strings, the label for each will simply be the option converted to Start Case.
 
@@ -32,10 +32,10 @@ field1:
     options:
       - foo
       -
-        text: Bar
+        name: Bar
         value: bar
       -
-        text: Baz Qux
+        name: Baz Qux
         value: baz-qux
         sites: site1, site2
 ```
@@ -317,7 +317,7 @@ _Notes:_
 
 ## Arguments
 
-* **options** _(required)_ an array of strings or objects (with `text`, `value`, and optionally `sites`)
+* **options** _(required)_ an array of strings or objects (with `name`, `value`, and optionally `sites`)
 
 If you specify options as strings, the label for each will simply be the option converted to Start Case.
 
@@ -328,10 +328,10 @@ field1:
     options:
       - foo
       -
-        text: Bar
+        name: Bar
         value: bar
       -
-        text: Baz Qux
+        name: Baz Qux
         value: baz-qux
         sites: site1, site2
 ```

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -9,19 +9,35 @@ Autocomplete
 
 # checkbox-group
 
-A group of checkboxes, allowing the user to toggle on or off related items.
+A group of checkboxes, allowing the user to toggle on or off related items. You can specify site-specific options, [similar to components in a component-list](https://github.com/clay/clay-kiln/wiki/Component-Lists#site-specific-components)
+
+```yaml
+    fn: checkbox-group
+    options:
+      - foo (site1)
+      - bar (not: site1)
+      - baz (site1, site2)
+```
 
 ## Arguments
 
-* **options** _(required)_ an array of checkboxes
+* **options** _(required)_ an array of strings or objects (with `text`, `value`, and optionally `sites`)
 
-Each option should be an object with `name` and `value` properties. Use the bootstrap to specify which should be toggled by default, e.g.
+If you specify options as strings, the label for each will simply be the option converted to Start Case.
 
 ```yaml
 field1:
-  option1: true
-  option2: false
-  option3: false
+  _has:
+    fn: checkbox-group
+    options:
+      - foo
+      -
+        text: Bar
+        value: bar
+      -
+        text: Baz Qux
+        value: baz-qux
+        sites: site1, site2
 ```
 
 # checkbox
@@ -288,33 +304,36 @@ A standard browser `<select>` element, allowing the user to select one of a few 
 
 _Notes:_
 
-- the first item in `options` is pre-selected
-- you can force the user to select an option by adding a `required` behavior and by setting the options like this:
+- no/empty option is pre-selected by default (you don't need to specify an empty option in the schema)
+- you can specify site-specific options, [similar to components in a component-list](https://github.com/clay/clay-kiln/wiki/Component-Lists#site-specific-components)
 
 ```yaml
     fn: select
     options:
-      -
-      - foo
-      - bar
+      - foo (site1)
+      - bar (not: site1)
+      - baz (site1, site2)
 ```
-
-Since a blank option is selected by default, the validator will fail.
 
 ## Arguments
 
-* **options** _(required)_ an array of strings
+* **options** _(required)_ an array of strings or objects (with `text`, `value`, and optionally `sites`)
 
-Unlike [checkbox-group](https://github.com/nymag/clay-kiln/blob/master/behaviors/checkbox-group.md), each option should be a string rather than an object. The label for each option will simply be the option converted to Start Case.
+If you specify options as strings, the label for each will simply be the option converted to Start Case.
 
 ```yaml
 field1:
   _has:
     fn: select
     options:
-      - foo # looks like Foo
-      - bar # looks like Bar
-      - baz # looks like Baz
+      - foo
+      -
+        text: Bar
+        value: bar
+      -
+        text: Baz Qux
+        value: baz-qux
+        sites: site1, site2
 ```
 
 # simple-list-item

--- a/behaviors/checkbox-group.test.js
+++ b/behaviors/checkbox-group.test.js
@@ -1,41 +1,30 @@
 import _ from 'lodash';
 import lib from './checkbox-group.vue';
 
-const options = [{ name: 'One', value: 'one' }, { name: 'Two', value: 'two' }];
+const options = [{ text: 'One', value: 'one' }, { text: 'Two', value: 'two' }],
+  state = { site: { slug: 'foo' }};
 
 describe('checkbox-group behavior', () => {
-  let sandbox;
+  beforeEach(beforeEachHooks);
 
-  beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
+  afterEach(afterEachHooks);
 
   it('allows multiple inputs', () => {
     expect(renderWithArgs(lib, {
       args: { options }, data: {}
-    }).$el.querySelectorAll('input').length).to.equal(2);
+    }, state).$el.querySelectorAll('input').length).to.equal(2);
   });
 
   it('uses option.name as label', () => {
     expect(_.map(renderWithArgs(lib, {
       args: { options }, data: {}
-    }).$el.querySelectorAll('label'), (label) => label.textContent)).to.eql(['One', 'Two']);
+    }, state).$el.querySelectorAll('label'), (label) => label.textContent)).to.eql(['One', 'Two']);
   });
 
   it('uses option.value as the value', () => {
     expect(_.map(renderWithArgs(lib, {
       args: { options }, data: {}
-    }).$el.querySelectorAll('input'), (input) => input.value)).to.eql(['one', 'two']);
-  });
-
-  it('falls back to using option.value as label', () => {
-    expect(renderWithArgs(lib, {
-      args: { options: [{ value: 'foobar' }] }, data: {}
-    }).$el.querySelector('label').textContent).to.eql('foobar');
+    }, state).$el.querySelectorAll('input'), (input) => input.value)).to.eql(['one', 'two']);
   });
 
   it('goes in the main slot', () => {

--- a/behaviors/checkbox-group.test.js
+++ b/behaviors/checkbox-group.test.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import lib from './checkbox-group.vue';
 
-const options = [{ text: 'One', value: 'one' }, { text: 'Two', value: 'two' }],
+const options = [{ name: 'One', value: 'one' }, { name: 'Two', value: 'two' }],
   state = { site: { slug: 'foo' }};
 
 describe('checkbox-group behavior', () => {

--- a/behaviors/checkbox-group.vue
+++ b/behaviors/checkbox-group.vue
@@ -13,7 +13,7 @@
 
   ## Arguments
 
-  * **options** _(required)_ an array of strings or objects (with `text`, `value`, and optionally `sites`)
+  * **options** _(required)_ an array of strings or objects (with `name`, `value`, and optionally `sites`)
 
   If you specify options as strings, the label for each will simply be the option converted to Start Case.
 
@@ -24,10 +24,10 @@
       options:
         - foo
         -
-          text: Bar
+          name: Bar
           value: bar
         -
-          text: Baz Qux
+          name: Baz Qux
           value: baz-qux
           sites: site1, site2
   ```
@@ -97,7 +97,7 @@
           } else {
             return {
               value: option.value,
-              name: option.text,
+              name: option.name,
               id: cid()
             };
           }

--- a/behaviors/checkbox-group.vue
+++ b/behaviors/checkbox-group.vue
@@ -1,19 +1,35 @@
 <docs>
   # checkbox-group
 
-  A group of checkboxes, allowing the user to toggle on or off related items.
+  A group of checkboxes, allowing the user to toggle on or off related items. You can specify site-specific options, [similar to components in a component-list](https://github.com/clay/clay-kiln/wiki/Component-Lists#site-specific-components)
+
+  ```yaml
+      fn: checkbox-group
+      options:
+        - foo (site1)
+        - bar (not: site1)
+        - baz (site1, site2)
+  ```
 
   ## Arguments
 
-  * **options** _(required)_ an array of checkboxes
+  * **options** _(required)_ an array of strings or objects (with `text`, `value`, and optionally `sites`)
 
-  Each option should be an object with `name` and `value` properties. Use the bootstrap to specify which should be toggled by default, e.g.
+  If you specify options as strings, the label for each will simply be the option converted to Start Case.
 
   ```yaml
   field1:
-    option1: true
-    option2: false
-    option3: false
+    _has:
+      fn: checkbox-group
+      options:
+        - foo
+        -
+          text: Bar
+          value: bar
+        -
+          text: Baz Qux
+          value: baz-qux
+          sites: site1, site2
   ```
 </docs>
 
@@ -60,6 +76,7 @@
   import cid from '@nymag/cid';
   import _ from 'lodash';
   import { UPDATE_FORMDATA } from '../lib/forms/mutationTypes';
+  import { filterBySite } from '../lib/utils/site-filter';
 
   export default {
     props: ['name', 'data', 'schema', 'args'],
@@ -68,8 +85,22 @@
     },
     computed: {
       options() {
-        return this.args.options.map((o) => {
-          return { name: o.name || o.value, value: o.value, id: cid() };
+        const currentSlug = _.get(this.$store, 'state.site.slug');
+
+        return _.map(filterBySite(this.args.options, currentSlug), (option) => {
+          if (_.isString(option)) {
+            return {
+              value: option,
+              name: _.startCase(option),
+              id: cid()
+            };
+          } else {
+            return {
+              value: option.value,
+              name: option.text,
+              id: cid()
+            };
+          }
         });
       }
     },

--- a/behaviors/checkbox.test.js
+++ b/behaviors/checkbox.test.js
@@ -1,6 +1,10 @@
 import lib from './checkbox.vue';
 
 describe('checkbox behavior', () => {
+  beforeEach(beforeEachHooks);
+
+  afterEach(afterEachHooks);
+
   it('adds label', () => {
     expect(renderWithArgs(lib, {
       args: { label: 'Hi'}

--- a/behaviors/description.test.js
+++ b/behaviors/description.test.js
@@ -1,6 +1,10 @@
 import lib from './description.vue';
 
 describe('description behavior', () => {
+  beforeEach(beforeEachHooks);
+
+  afterEach(afterEachHooks);
+
   it('passes in value', () => {
     expect(renderWithArgs(lib, {
       args: { value: 'Hello'}

--- a/behaviors/label.test.js
+++ b/behaviors/label.test.js
@@ -1,10 +1,14 @@
 import lib from './label.vue';
 
 describe('label behavior', () => {
+  beforeEach(beforeEachHooks);
+
+  afterEach(afterEachHooks);
+
   it('adds label', () => {
     expect(renderWithArgs(lib, {
       name: 'test'
-    }).$el.innerText).to.equal('Test');
+    }).label).to.equal('Test');
   });
 
   it('goes in the before slot', () => {

--- a/behaviors/radio.test.js
+++ b/behaviors/radio.test.js
@@ -4,6 +4,10 @@ import lib from './radio.vue';
 const options = ['', 'one', 'two three'];
 
 describe('radio behavior', () => {
+  beforeEach(beforeEachHooks);
+
+  afterEach(afterEachHooks);
+
   it('adds radio buttons', () => {
     expect(renderWithArgs(lib, {
       args: { options }

--- a/behaviors/required.test.js
+++ b/behaviors/required.test.js
@@ -7,10 +7,12 @@ describe('required behavior', () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     sandbox.stub(behaviors, 'expand');
+    beforeEachHooks();
   });
 
   afterEach(() => {
     sandbox.restore();
+    afterEachHooks();
   });
 
   it('adds span if label behavior exists in the schema', () => {

--- a/behaviors/select.vue
+++ b/behaviors/select.vue
@@ -18,7 +18,7 @@
 
   ## Arguments
 
-  * **options** _(required)_ an array of strings or objects (with `text`, `value`, and optionally `sites`)
+  * **options** _(required)_ an array of strings or objects (with `name`, `value`, and optionally `sites`)
 
   If you specify options as strings, the label for each will simply be the option converted to Start Case.
 
@@ -29,10 +29,10 @@
       options:
         - foo
         -
-          text: Bar
+          name: Bar
           value: bar
         -
-          text: Baz Qux
+          name: Baz Qux
           value: baz-qux
           sites: site1, site2
   ```
@@ -48,7 +48,7 @@
 
 <template>
   <select class="editor-select" :value="data" @change="update">
-    <option v-for="option in options" :value="option.value">{{ option.text }}</option>
+    <option v-for="option in options" :value="option.value">{{ option.name }}</option>
   </select>
 </template>
 
@@ -68,17 +68,17 @@
 
         return [{
           value: null,
-          text: 'None'
+          name: 'None'
         }].concat(_.map(filterBySite(this.args.options, currentSlug), (option) => {
           if (_.isString(option)) {
             return {
               value: option,
-              text: _.startCase(option)
+              name: _.startCase(option)
             };
           } else {
             return {
               value: option.value,
-              text: option.text
+              name: option.name
             };
           }
         }));

--- a/behaviors/select.vue
+++ b/behaviors/select.vue
@@ -5,33 +5,36 @@
 
   _Notes:_
 
-  - the first item in `options` is pre-selected
-  - you can force the user to select an option by adding a `required` behavior and by setting the options like this:
+  - no/empty option is pre-selected by default (you don't need to specify an empty option in the schema)
+  - you can specify site-specific options, [similar to components in a component-list](https://github.com/clay/clay-kiln/wiki/Component-Lists#site-specific-components)
 
   ```yaml
       fn: select
       options:
-        -
-        - foo
-        - bar
+        - foo (site1)
+        - bar (not: site1)
+        - baz (site1, site2)
   ```
-
-  Since a blank option is selected by default, the validator will fail.
 
   ## Arguments
 
-  * **options** _(required)_ an array of strings
+  * **options** _(required)_ an array of strings or objects (with `text`, `value`, and optionally `sites`)
 
-  Unlike [checkbox-group](https://github.com/nymag/clay-kiln/blob/master/behaviors/checkbox-group.md), each option should be a string rather than an object. The label for each option will simply be the option converted to Start Case.
+  If you specify options as strings, the label for each will simply be the option converted to Start Case.
 
   ```yaml
   field1:
     _has:
       fn: select
       options:
-        - foo # looks like Foo
-        - bar # looks like Bar
-        - baz # looks like Baz
+        - foo
+        -
+          text: Bar
+          value: bar
+        -
+          text: Baz Qux
+          value: baz-qux
+          sites: site1, site2
   ```
 </docs>
 
@@ -52,6 +55,7 @@
 <script>
   import _ from 'lodash';
   import { UPDATE_FORMDATA } from '../lib/forms/mutationTypes';
+  import { filterBySite } from '../lib/utils/site-filter';
 
   export default {
     props: ['name', 'data', 'schema', 'args'],
@@ -60,12 +64,24 @@
     },
     computed: {
       options() {
-        return _.map(this.args.options, (option) => {
-          return {
-            value: option,
-            text: _.startCase(option) || 'None'
-          };
-        });
+        const currentSlug = _.get(this.$store, 'state.site.slug');
+
+        return [{
+          value: null,
+          text: 'None'
+        }].concat(_.map(filterBySite(this.args.options, currentSlug), (option) => {
+          if (_.isString(option)) {
+            return {
+              value: option,
+              text: _.startCase(option)
+            };
+          } else {
+            return {
+              value: option.value,
+              text: option.text
+            };
+          }
+        }));
       }
     },
     methods: {

--- a/behaviors/test.test.js
+++ b/behaviors/test.test.js
@@ -1,6 +1,10 @@
 import lib from './text.vue';
 
 describe('text behavior', () => {
+  beforeEach(beforeEachHooks);
+
+  afterEach(afterEachHooks);
+
   it('defaults to text input', () => {
     expect(renderWithArgs(lib, {
       args: {}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,6 +13,10 @@ const files = [
       target: 'web',
       module: {
         rules: [{
+          // todo: remove this (and update vue-unit dep) once vue-unit hits 0.3.0
+          test: /node_modules\/vue-unit\//,
+          loader: 'babel-loader'
+        }, {
           test: /\.js$/,
           exclude: /node_modules/,
           loader: 'babel-loader'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -52,28 +52,28 @@ const files = [
       chromeMac: {
         base: 'BrowserStack',
         browser: 'chrome',
-        browser_version: '55',
+        browser_version: '59',
         os: 'OS X',
         os_version: 'Sierra'
       },
       firefoxMac: {
         base: 'BrowserStack',
         browser: 'firefox',
-        browser_version: '50',
+        browser_version: '54',
         os: 'OS X',
         os_version: 'Sierra'
       },
       chromeWindows: {
         base: 'BrowserStack',
         browser: 'chrome',
-        browser_version: '55',
+        browser_version: '59',
         os: 'Windows',
         os_version: '10'
       },
       firefoxWindows: {
         base: 'BrowserStack',
         browser: 'firefox',
-        browser_version: '50',
+        browser_version: '54',
         os: 'Windows',
         os_version: '10'
       }

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -99,6 +99,8 @@ function serverSave(uri, data, oldData, store, {snapshot, paths}) { // eslint-di
     });
 }
 
+// istanbul ignore next
+
 /**
  * find the old html, for reverting if the server save fails
  * note: this will be removed when server-side rendering is eliminated,
@@ -129,6 +131,9 @@ function findOldHTML(uri, layoutURI) {
     }
   }
 }
+
+// server save an rerender is difficult to test and deprecated
+// istanbul ignore next
 
 /**
  * save data AND re-render server-side
@@ -204,6 +209,7 @@ export function saveComponent(store, {uri, data, eventID, snapshot, prevData}) {
     store.dispatch('setFixedPoint');
   }
 
+  // istanbul ignore else
   if (model && template) {
     // component has both model and template, so we can do optimistic save + re-rendering
     // note: only clientSave can publish to pubsub, so pass the event ID (if it exists)

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -232,7 +232,7 @@ export function saveComponent(store, {uri, data, eventID, snapshot, prevData}) {
     store.dispatch('updatePageList');
   }
 
-  return promise;
+  return promise.catch(_.noop); // catch failed+reverted component saves, so the rest of the form teardown can happen
 }
 
 /**

--- a/lib/component-data/actions.test.js
+++ b/lib/component-data/actions.test.js
@@ -2,15 +2,16 @@ import _ from 'lodash';
 import * as model from './model';
 import * as template from './template';
 import * as api from '../core-data/api';
-import * as component from '../core-data/components';
+import * as components from '../core-data/components';
+import * as componentElements from '../utils/component-elements';
+import * as queue from '../core-data/queue';
 import * as lib from './actions';
 
-describe('reactive render', () => {
+describe('component-data actions', () => {
   const uri = 'domain.com/components/foo',
-    data = { a: 'b' };
-    // eventID: 'kansdkfjansdf',
-    // snapshot: false,
-    // prevData: { c: 'd' };
+    data = { a: 'b' },
+    prevData = { c: 'd' },
+    store = {};
 
   let sandbox;
 
@@ -19,19 +20,122 @@ describe('reactive render', () => {
     sandbox.stub(model);
     sandbox.stub(template);
     sandbox.stub(api);
-    sandbox.stub(component);
+    sandbox.stub(components);
+    sandbox.stub(componentElements);
+    sandbox.stub(queue);
+
+    // stub store.commit so we can test for the correct mutations
+    store.commit = sandbox.spy();
+    store.dispatch = sandbox.spy(() => Promise.resolve());
   });
 
   afterEach(() => {
     sandbox.restore();
+
+    delete store.commit;
+    delete store.dispatch;
   });
 
   describe('saveComponent', () => {
     const fn = lib.saveComponent;
 
     it('does not save when data has not changed', () => {
-      return fn({ dispatch: _.noop }, { uri, data, prevData: data }).then((res) => {
-        expect(res).to.equal(undefined);
+      return fn(store, { uri, data, prevData: data }).then(() => {
+        expect(store.commit.called).to.equal(false);
+      });
+    });
+
+    it('fetches previous data from store', () => {
+      components.getData.returns(data);
+      return fn(store, { uri, data }).then(() => {
+        expect(store.commit.called).to.equal(false);
+      });
+    });
+
+    it('saves client-side components', () => {
+      components.getModel.returns(true);
+      components.getTemplate.returns(true);
+      model.save.returns(Promise.resolve(data));
+      queue.add.returns(Promise.resolve());
+      model.render.returns(Promise.resolve(data));
+      return fn(store, { uri, data, prevData }).then(() => {
+        expect(store.commit).to.have.been.calledWith('UPDATE_COMPONENT', { uri, data });
+        expect(store.commit).to.have.callCount(3); // currently saving true, update, currently saving false
+      });
+    });
+
+    it('reverts client-side components if model.js errors', () => {
+      components.getModel.returns(true);
+      components.getTemplate.returns(true);
+      model.save.returns(Promise.reject(new Error('nope')));
+      return fn(store, { uri, data, prevData }).catch(() => {
+        expect(console.error).to.have.been.calledWith('Error saving component (foo): nope');
+      });
+    });
+
+    it('queues client-side save to server', () => {
+      components.getModel.returns(true);
+      components.getTemplate.returns(true);
+      model.save.returns(Promise.resolve(data));
+      queue.add.returns(Promise.resolve());
+      model.render.returns(Promise.resolve(data));
+      return fn(store, { uri, data, prevData }).then(() => {
+        expect(queue.add).to.have.been.calledWith(api.save, [uri, data, false], 'save');
+      });
+    });
+
+    it('reverts client-side components if queued save errors', () => {
+      components.getModel.returns(true);
+      components.getTemplate.returns(true);
+      model.save.returns(Promise.resolve(data));
+      queue.add.returns(Promise.reject(new Error('nope')));
+      model.render.returns(Promise.resolve(data));
+      return fn(store, { uri, data, prevData }).catch(() => {
+        expect(queue.add).to.have.been.calledWith(api.save, [uri, data, false], 'save');
+        expect(console.error).to.have.been.calledWith('Error saving component (foo): nope');
+      });
+    });
+
+    it('saves server-side components', () => {
+      components.getModel.returns(false);
+      components.getTemplate.returns(true);
+      queue.add.returns(Promise.resolve(data));
+      return fn(store, { uri, data, prevData }).then(() => {
+        expect(store.commit).to.have.been.calledWith('UPDATE_COMPONENT', { uri, data });
+        expect(store.commit).to.have.callCount(3); // currently saving true, update, currently saving false
+      });
+    });
+
+    it('reverts server-side components if queued save errors', () => {
+      components.getModel.returns(false);
+      components.getTemplate.returns(true);
+      queue.add.returns(Promise.reject(new Error('nope')));
+      return fn(store, { uri, data, prevData }).catch(() => {
+        expect(queue.add).to.have.been.calledWith(api.save, [uri, _.assign({}, data, prevData)], 'save');
+        expect(console.error).to.have.been.calledWith('Error saving component (foo): nope');
+      });
+    });
+
+    it('does not take snapshots when undoing', () => {
+      components.getModel.returns(true);
+      components.getTemplate.returns(true);
+      model.save.returns(Promise.resolve(data));
+      queue.add.returns(Promise.resolve());
+      model.render.returns(Promise.resolve(data));
+      return fn(store, { uri, data, prevData, snapshot: false }).then(() => {
+        expect(store.dispatch).to.not.have.been.calledWith('setFixedPoint');
+      });
+    });
+
+    it('updates page list when saving page-specific components', () => {
+      componentElements.isComponentInPage.returns(true);
+      components.getModel.returns(true);
+      components.getTemplate.returns(true);
+      model.save.returns(Promise.resolve(data));
+      queue.add.returns(Promise.resolve());
+      model.render.returns(Promise.resolve(data));
+      return fn(store, { uri, data, prevData, snapshot: false }).then(() => {
+        expect(store.dispatch).to.not.have.been.calledWith('setFixedPoint');
       });
     });
   });

--- a/lib/decorators/actions.test.js
+++ b/lib/decorators/actions.test.js
@@ -1,0 +1,51 @@
+import * as componentElements from '../utils/component-elements';
+import * as scroll from '../utils/scroll';
+import * as validation from '../forms/native-validation';
+import * as select from './select';
+import * as lib from './actions';
+
+describe('decorator actions', () => {
+  const store = {};
+
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(scroll);
+    sandbox.stub(validation);
+    sandbox.stub(select);
+    sandbox.stub(componentElements);
+
+    // stub store.commit so we can test for the correct mutations
+    store.commit = sandbox.spy();
+    store.dispatch = sandbox.spy(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+
+    delete store.commit;
+    delete store.dispatch;
+    delete store.state;
+  });
+
+  describe('unselect', () => {
+    const fn = lib.unselect;
+
+    it('does not unselect if nothing selected', () => {
+      store.state = { ui: { currentSelection: {}}};
+      return fn(store);
+      expect(store.commit.called).to.equal(false);
+    });
+
+    it('unselects if something is selected', () => {
+      const el = document.createElement('div');
+
+      el.classList.add('selected');
+      store.state = { ui: { currentSelection: { el }}};
+      return fn(store);
+      expect(store.commit).to.have.been.calledWith('UN_SELECT');
+      expect(el.classList.contains('selected')).to.equal(false);
+    });
+  });
+});

--- a/lib/utils/available-components.js
+++ b/lib/utils/available-components.js
@@ -1,54 +1,6 @@
 import _ from 'lodash';
 import store from '../core-data/store';
-
-/**
- * determine if a component is available on the current site, based on logic
- * @param {string} slug e.g. "grubstreet"
- * @param {string} logic e.g. (di, press, thecut) or (not:di, not:press, not:thecut) or a mixture of both
- * @returns {boolean}
- */
-function availableOnCurrentSite(slug, logic) {
-  var tokens = logic.split(',').map((str) => str.trim()), // trim any extra whitespace
-    // list of site slugs to include
-    sitesToInclude = _.reject(tokens, (token) => _.includes(token, 'not:')),
-    // list of site slugs to exclude (remove the "not:" from the tokens)
-    sitesToExclude = _.map(_.filter(tokens, (token) => _.includes(token, 'not:')), (token) => token.replace(/not:\s?/ig, ''));
-
-  if (!_.isEmpty(sitesToInclude)) {
-    // if we have any sites explicitly included, then the component is available if we're
-    // on one of those sites AND we're not on any sites in the excluded list
-    // note: configuring "(siteName, otherSiteName, not:siteName)" is silly, but possible
-    return _.includes(sitesToInclude, slug) && !_.includes(sitesToExclude, slug);
-  } else {
-    // if we don't explicitly include certain sites, then just make sure the
-    // current site isn't excluded
-    return !_.includes(sitesToExclude, slug);
-  }
-}
-
-/**
- * see if a component can be added in this list,
- * by checking the exclude array and the current site
- * @param {string} str component name and optional site logic
- * @param {array} exclude
- * @returns {boolean}
- */
-function filterComponent(str, exclude) {
-  var matches = str.match(/([\w-]+)(?:\s?\((.*?)\))?/), // e.g. component-name (site logic)
-    name = matches[1],
-    siteLogic = matches[2];
-
-  if (_.includes(exclude, name)) {
-    // first, check to make sure a component isn't in the exclude list
-    return false;
-  } else if (siteLogic && !availableOnCurrentSite(_.get(store, 'state.site.slug'), siteLogic)) {
-    // then, check to make sure we can use this component on the current site
-    return false;
-  } else {
-    // we can add this component to this list on this site!
-    return true;
-  }
-}
+import { filterBySite } from './site-filter';
 
 /**
  * map through components, filtering out excluded
@@ -59,7 +11,8 @@ function filterComponent(str, exclude) {
  * @returns {array} array of elements
  */
 export default function getAvailable(possibleComponents, exclude) {
-  return _.map(_.filter(possibleComponents, (item) => filterComponent(item, exclude)), (str) => str.replace(/\s?\(.*?\)/g, ''));
-  // that regex removes anything in parenthesis (the site logic)
-  // as well as any spaces between the name of the component and the parenthesis
+  const currentSlug = _.get(store, 'state.site.slug'),
+    filteredComponents = filterBySite(possibleComponents, currentSlug);
+
+  return _.filter(filteredComponents, (component) => !_.includes(exclude, component));
 }

--- a/lib/utils/icon.test.js
+++ b/lib/utils/icon.test.js
@@ -2,6 +2,10 @@ import lib from './icon.vue';
 import icons from './icons';
 
 describe('references', () => {
+  beforeEach(beforeEachHooks);
+
+  afterEach(afterEachHooks);
+
   it('inserts the icon passed in', () => {
     expect(renderWithArgs(lib, {
       name: 'draft'

--- a/lib/utils/site-filter.js
+++ b/lib/utils/site-filter.js
@@ -1,0 +1,55 @@
+import _ from 'lodash';
+
+const itemRegex = /([^\(\n]+)(?:\((.*?)\))?/;
+
+/**
+ * determine if an item is available on a specific site, based on logic
+ * @param  {string} logic e.g. (di, press, thecut) or (not:di, not:press, not:thecut) or a mixture of both
+ * @param  {string} slug e.g. "grubstreet"
+ * @return {boolean}
+ */
+function matchLogic(logic, slug) {
+  const tokens = logic.split(',').map((str) => str.trim()),
+    // list of site slugs to include
+    sitesToInclude = _.reject(tokens, (token) => _.includes(token, 'not:')),
+    // list of site slugs to exclude (remove the "not:" from the tokens)
+    sitesToExclude = _.map(_.filter(tokens, (token) => _.includes(token, 'not:')), (token) => token.replace(/not:\s?/ig, ''));
+
+  if (!_.isEmpty(sitesToInclude)) {
+    // if the item is specifically included on certain sites, it's available
+    // note: if you've also excluded it, it won't be available
+    // doing that is silly (e.g. "foo-item (siteName, otherSiteName, not:siteName)") but possible
+    return _.includes(sitesToInclude, slug) && !_.includes(sitesToExclude, slug);
+  } else {
+    // if we don't explicitly include certain sites, then just make sure the
+    // current site isn't excluded
+    return !_.includes(sitesToExclude, slug);
+  }
+}
+
+/**
+ * filter an array of items by a site slug
+ * e.g. ['foo (site1, site2)', 'bar (not: site1)']
+ * @param  {array} items
+ * @param  {string} slug
+ * @return {array} items without site logic
+ */
+export function filterBySite(items, slug) {
+  if (!slug) {
+    throw new Error('Please specify a slug to match items against!');
+  }
+
+  return _.reduce(items, (result, item) => {
+    const matches = item.match(itemRegex),
+      value = matches[1] && matches[1].trim(),
+      logic = matches[2] && matches[2].trim();
+
+    if (!logic || matchLogic(logic, slug)) {
+      // items with no logic are available
+      // items with logic that matches the site slug are available
+      return result.concat(value);
+    } else {
+      return result;
+    }
+  }, []);
+}

--- a/lib/utils/site-filter.js
+++ b/lib/utils/site-filter.js
@@ -30,6 +30,7 @@ function matchLogic(logic, slug) {
 /**
  * filter an array of items by a site slug
  * e.g. ['foo (site1, site2)', 'bar (not: site1)']
+ * e.g. [{ value: 'foo', text: 'Foo', sites: 'not:site1' }]
  * @param  {array} items
  * @param  {string} slug
  * @return {array} items without site logic
@@ -40,9 +41,17 @@ export function filterBySite(items, slug) {
   }
 
   return _.reduce(items, (result, item) => {
-    const matches = item.match(itemRegex),
-      value = matches[1] && matches[1].trim(),
+    let value, logic;
+
+    if (_.isString(item)) {
+      const matches = item.match(itemRegex);
+
+      value = matches[1] && matches[1].trim();
       logic = matches[2] && matches[2].trim();
+    } else {
+      value = item;
+      logic = item.sites;
+    }
 
     if (!logic || matchLogic(logic, slug)) {
       // items with no logic are available

--- a/lib/utils/site-filter.test.js
+++ b/lib/utils/site-filter.test.js
@@ -1,0 +1,44 @@
+import * as lib from './site-filter';
+
+describe('references', () => {
+  describe('filterBySite', () => {
+    const fn = lib.filterBySite;
+
+    it('returns all items if no sites', () => {
+      // note: all characters except parenthesis are allowed in item names
+      expect(fn(['one', 'tw-o', 'th ree 3'], 'foo')).to.eql(['one', 'tw-o', 'th ree 3']);
+    });
+
+    it('returns only specific site items', () => {
+      expect(fn([
+        'one (foo)',
+        'tw-o (bar)',
+        'th ree 3 (foo)'
+      ], 'foo')).to.eql(['one', 'th ree 3']);
+    });
+
+    it('returns specific site items and general items', () => {
+      expect(fn([
+        'one (foo)',
+        'tw-o',
+        'th ree 3 (foo)'
+      ], 'foo')).to.eql(['one', 'tw-o', 'th ree 3']);
+    });
+
+    it('does not return excluded items', () => {
+      expect(fn([
+        'one (foo)',
+        'tw-o (not:foo)',
+        'th ree 3 (not: foo)'
+      ], 'foo')).to.eql(['one']);
+    });
+
+    it('trims site slugs', () => {
+      expect(fn(['one ( foo  )'], 'foo')).to.eql(['one']);
+    });
+
+    it('trims item value', () => {
+      expect(fn([' one two  ( foo  )'], 'foo')).to.eql(['one two']);
+    });
+  });
+});

--- a/lib/utils/site-filter.test.js
+++ b/lib/utils/site-filter.test.js
@@ -2,7 +2,11 @@ import * as lib from './site-filter';
 
 describe('references', () => {
   describe('filterBySite', () => {
-    const fn = lib.filterBySite;
+    const fn = lib.filterBySite,
+      obj1 = { text: 'One', value: 'one' },
+      obj2 = { text: 'Two', value: 'two', sites: 'foo' },
+      obj3 = { text: 'Three', value: 'three', sites: 'not:foo' },
+      obj4 = { text: 'Four', value: 'four', sites: 'foo, bar' };
 
     it('returns all items if no sites', () => {
       // note: all characters except parenthesis are allowed in item names
@@ -39,6 +43,38 @@ describe('references', () => {
 
     it('trims item value', () => {
       expect(fn([' one two  ( foo  )'], 'foo')).to.eql(['one two']);
+    });
+
+    it('returns all items (objects)', () => {
+      expect(fn([obj1], 'foo')).to.eql([obj1]);
+    });
+
+    it('returns specific site items (objects)', () => {
+      expect(fn([obj1, obj2, obj4], 'foo')).to.eql([obj1, obj2, obj4]);
+    });
+
+    it('does not return excluded items (objects)', () => {
+      expect(fn([obj1, obj3], 'foo')).to.eql([obj1]);
+    });
+
+    it('trims object sites', () => {
+      const longLogic = {
+        text: 'OK',
+        value: 'ok',
+        sites: ' foo, not: bar '
+      };
+
+      expect(fn([longLogic], 'foo')).to.eql([longLogic]);
+      expect(fn([longLogic], 'bar')).to.eql([]);
+    });
+
+    it('does not trim object text or value', () => {
+      const funnyObject = {
+        text: ' Hark! A Vagrant! ',
+        value: ' By Kate Beaton '
+      };
+
+      expect(fn([funnyObject], 'foo')).to.eql([funnyObject]);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "babel-loader": "^6.2.10",
     "babel-plugin-istanbul": "^3.1.2",
     "babel-plugin-lodash": "^3.2.11",
-    "babel-preset-es2015": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-preset-env": "^1.6.0",
     "caret-position": "0.0.1",
     "chai": "^3.5.0",
     "codemirror": "^5.23.0",
@@ -99,6 +100,7 @@
     "vue-nprogress": "^0.1.5",
     "vue-style-loader": "^2.0.5",
     "vue-template-compiler": "^2.3.4",
+    "vue-unit": "github:tom-kitchin/vue-unit",
     "vuex": "^2.3.1",
     "webpack": "^2.2.1",
     "whatwg-fetch": "^1.0.0"

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,13 +1,23 @@
+import _ from 'lodash';
 import Vue from 'vue';
+import Vuex from 'vuex';
+import { beforeEachHooks, afterEachHooks, mount } from 'vue-unit/src';
 
 const testsContext = require.context('../', true, /^\.\/(lib|behaviors)\/.*?\.test\.js$/);
 
-// add renderWithArgs function to all tests, allowing us to easily test vue components
-window.renderWithArgs = (Component, propsData) => {
-  const Ctor = Vue.extend(Component);
+let defaultStore;
 
-  return new Ctor({ propsData }).$mount();
+// allow store mocking
+Vue.use(Vuex);
+defaultStore = new Vuex.Store({ state: {} });
+
+// add renderWithArgs function to all tests, allowing us to easily test vue components
+window.renderWithArgs = (Component, props, state) => {
+  return mount(Component, { props, store: _.assign({}, defaultStore, { state }) });
 };
+
+window.beforeEachHooks = beforeEachHooks;
+window.afterEachHooks = afterEachHooks;
 
 // don't write to console
 sinon.stub(console);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,6 +84,10 @@ module.exports = {
   },
   module: {
     rules: [{
+      // todo: remove this (and update vue-unit dep) once vue-unit hits 0.3.0
+      test: /node_modules\/vue-unit\//,
+      loader: 'babel-loader'
+    }, {
       test: /\.js$/,
       exclude: /node_modules/,
       loader: 'babel-loader'


### PR DESCRIPTION
* [trello ticket](https://trello.com/c/rq3kJAbn/15-site-specific-behaviors)
* allows site-specific `select` and `checkbox-group` arguments
* implements a `site-filter` service to use that syntax in multiple places
* updates babelrc from `preset-2015` to `preset-env` which tracks the latest two versions of major browsers
* adds `rest spread operator` plugin for babel