### PR TITLE
refactored pubsub to use a promise-based solution

### DIFF
--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -26,6 +26,20 @@ function logSaveError(uri, e, store) {
 }
 
 /**
+ * re-render (reverting) a component and stop the saving promise chain
+ * @param  {string} uri
+ * @param  {object} data
+ * @param {string} html
+ * @param  {boolean} [snapshot]
+ * @param  {array} paths
+ * @return {Promise}
+ */
+function revertReject({ uri, data, html, snapshot, paths }) {
+  return store.dispatch('render', { uri, data, html, snapshot, paths })
+    .then(() => Promise.reject(new Error(`Save failed, reverting ${uri}`))); // don't continue saving
+}
+
+/**
  * save data client-side and queue up api call for the server
  * note: this uses the components' model.js and handlebars template
  * @param  {string} uri
@@ -43,7 +57,7 @@ function clientSave(uri, data, oldData, store, {eventID, snapshot, paths}) { // 
       // if model.js errors (or times out), re-render component with old data
       // and show the end user an error message
       logSaveError(uri, e, store);
-      return Promise.reject(store.dispatch('render', { uri, data: oldData, snapshot, paths })); // don't continue saving
+      return revertReject({ uri, data: oldData, snapshot, paths });
     })
     .then((savedData) => {
       // kick api call off in the background
@@ -52,7 +66,7 @@ function clientSave(uri, data, oldData, store, {eventID, snapshot, paths}) { // 
         .catch((e) => {
           logSaveError(uri, e, store);
           store.commit(REVERT_COMPONENT, {uri, oldData});
-          return Promise.reject(store.dispatch('render', { uri, data: oldData, snapshot, paths }));
+          return revertReject({ uri, data: oldData, snapshot, paths });
         });
 
       return savedData;
@@ -88,7 +102,7 @@ function serverSave(uri, data, oldData, store, {snapshot, paths}) { // eslint-di
     .catch((e) => {
       store.commit(REVERT_COMPONENT, {uri, oldData});
       logSaveError(uri, e, store);
-      return Promise.reject(store.dispatch('render', { uri, data: oldData, snapshot, paths }));
+      return revertReject({ uri, data: oldData, snapshot, paths });
     });
 }
 
@@ -153,7 +167,7 @@ function serverSaveAndRerender(uri, data, oldData, store, {snapshot, paths}) { /
         .catch((e) => {
           store.commit(REVERT_COMPONENT, {uri, oldData});
           logSaveError(uri, e, store);
-          return Promise.reject(store.dispatch('render', { uri, html: oldHTML, snapshot, paths }));
+          return revertReject({ uri, html: oldHTML, snapshot, paths });
         });
     });
 }

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -11,6 +11,7 @@ import { getComponentEl, getParentComponent, getPrevComponent, isComponentInPage
 import getAvailableComponents from '../utils/available-components';
 import create from './create';
 import { getComponentNode, getComponentRef, getComponentListStartFromComponent } from '../utils/head-components';
+import { publish } from './pubsub';
 
 /**
  * log errors when components save and display them to the user
@@ -37,15 +38,12 @@ function logSaveError(uri, e, store) {
  * @return {Promise}
  */
 function clientSave(uri, data, oldData, store, {eventID, snapshot, paths}) { // eslint-disable-line
-  store.commit(CURRENTLY_SAVING, true);
-  return modelSave(uri, data, {eventID, snapshot})
+  return modelSave(uri, data)
     .catch((e) => {
       // if model.js errors (or times out), re-render component with old data
       // and show the end user an error message
       logSaveError(uri, e, store);
-      return Promise.reject(store.dispatch('render', { uri, data: oldData, snapshot, paths }).then(() => {
-        store.commit(CURRENTLY_SAVING, false);
-      })); // don't continue saving
+      return Promise.reject(store.dispatch('render', { uri, data: oldData, snapshot, paths })); // don't continue saving
     })
     .then((savedData) => {
       // kick api call off in the background
@@ -54,19 +52,19 @@ function clientSave(uri, data, oldData, store, {eventID, snapshot, paths}) { // 
         .catch((e) => {
           logSaveError(uri, e, store);
           store.commit(REVERT_COMPONENT, {uri, oldData});
-          return Promise.reject(store.dispatch('render', { uri, data: oldData, snapshot, paths }).then(() => {
-            store.commit(CURRENTLY_SAVING, false);
-          }));
+          return Promise.reject(store.dispatch('render', { uri, data: oldData, snapshot, paths }));
         });
 
       return savedData;
     })
+    // publish changes for other components after running through model.save(),
+    // but before model.render()
+    // note: pubsub is only allowed in components with model.js
+    .then((savedData) => publish(uri, savedData, eventID, snapshot, store))
     .then((savedData) => modelRender(uri, savedData))
     .then((renderableData) => {
       store.commit(UPDATE_COMPONENT, {uri, data: renderableData});
-      return store.dispatch('render', { uri, data: renderableData, snapshot, paths }).then(() => {
-        store.commit(CURRENTLY_SAVING, false);
-      });
+      return store.dispatch('render', { uri, data: renderableData, snapshot, paths });
     });
 }
 
@@ -82,20 +80,15 @@ function clientSave(uri, data, oldData, store, {eventID, snapshot, paths}) { // 
  * @return {Promise}
  */
 function serverSave(uri, data, oldData, store, {snapshot, paths}) { // eslint-disable-line
-  store.commit(CURRENTLY_SAVING, true);
   return addToQueue(save, [uri, data], 'save')
     .then((res) => {
       store.commit(UPDATE_COMPONENT, {uri, data: res});
-      return store.dispatch('render', { uri, data: res, snapshot, paths }).then(() => {
-        store.commit(CURRENTLY_SAVING, false);
-      });
+      return store.dispatch('render', { uri, data: res, snapshot, paths });
     })
     .catch((e) => {
       store.commit(REVERT_COMPONENT, {uri, oldData});
       logSaveError(uri, e, store);
-      return Promise.reject(store.dispatch('render', { uri, data: oldData, snapshot, paths }).then(() => {
-        store.commit(CURRENTLY_SAVING, false);
-      }));
+      return Promise.reject(store.dispatch('render', { uri, data: oldData, snapshot, paths }));
     });
 }
 
@@ -149,23 +142,18 @@ function findOldHTML(uri, layoutURI) {
 function serverSaveAndRerender(uri, data, oldData, store, {snapshot, paths}) { // eslint-disable-line
   const oldHTML = findOldHTML(uri, _.get(store, 'state.page.data.layout')).cloneNode(true);
 
-  store.commit(CURRENTLY_SAVING, true);
   return addToQueue(saveForHTML, [uri, data], 'save')
     .then((html) => { // PUT to html before getting new data
       return addToQueue(getObject, [uri], 'save')
         .then((res) => {
           store.commit(UPDATE_COMPONENT, {uri, data: res});
-          return store.dispatch('render', { uri, html, snapshot, paths }).then(() => {
-            store.commit(CURRENTLY_SAVING, false);
-          });
+          return store.dispatch('render', { uri, html, snapshot, paths });
         })
         // otherwise revert the data
         .catch((e) => {
           store.commit(REVERT_COMPONENT, {uri, oldData});
           logSaveError(uri, e, store);
-          return Promise.reject(store.dispatch('render', { uri, html: oldHTML, snapshot, paths }).then(() => {
-            store.commit(CURRENTLY_SAVING, false);
-          }));
+          return Promise.reject(store.dispatch('render', { uri, html: oldHTML, snapshot, paths }));
         });
     });
 }
@@ -198,6 +186,9 @@ export function saveComponent(store, {uri, data, eventID, snapshot, prevData}) {
     // saving all the components every time if their data hasn't changed
     return Promise.resolve();
   }
+
+  // kick off the save, and don't allow other things to happen
+  store.commit(CURRENTLY_SAVING, true);
 
   // start or briefly pause the progress bar when components are saved.
   // note: bar will finish when all items in the queue are flushed
@@ -232,7 +223,12 @@ export function saveComponent(store, {uri, data, eventID, snapshot, prevData}) {
     store.dispatch('updatePageList');
   }
 
-  return promise.catch(_.noop); // catch failed+reverted component saves, so the rest of the form teardown can happen
+  return promise.then(() => {
+    store.commit(CURRENTLY_SAVING, false);
+  }).catch(() => {
+    // catch failed+reverted component saves, so the rest of the form teardown can happen
+    store.commit(CURRENTLY_SAVING, false);
+  });
 }
 
 /**

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -53,12 +53,6 @@ function revertReject({ uri, data, html, snapshot, paths }) {
  */
 function clientSave(uri, data, oldData, store, {eventID, snapshot, paths}) { // eslint-disable-line
   return modelSave(uri, data)
-    .catch((e) => {
-      // if model.js errors (or times out), re-render component with old data
-      // and show the end user an error message
-      logSaveError(uri, e, store);
-      return revertReject({ uri, data: oldData, snapshot, paths });
-    })
     .then((savedData) => {
       // kick api call off in the background
       addToQueue(save, [uri, savedData, false], 'save') // add hooks=false to prevent models from re-running on server
@@ -79,6 +73,12 @@ function clientSave(uri, data, oldData, store, {eventID, snapshot, paths}) { // 
     .then((renderableData) => {
       store.commit(UPDATE_COMPONENT, {uri, data: renderableData});
       return store.dispatch('render', { uri, data: renderableData, snapshot, paths });
+    })
+    .catch((e) => {
+      // if there are any errors saving, publishing, or re-rendering component,
+      // show the end user an error and revert it!
+      logSaveError(uri, e, store);
+      return revertReject({ uri, data: oldData, snapshot, paths });
     });
 }
 

--- a/lib/component-data/model.js
+++ b/lib/component-data/model.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import { attempt, timeout } from '../utils/promises';
 import { getModel, getLocals } from '../core-data/components';
-import { publish } from './pubsub';
 
 const MODEL_SAVE_TIMEOUT = 8000, // timeout for model.js pre-save hook
   MODEL_RENDER_TIMEOUT = 2000; // timeout for model.js pre-render hook. should be smaller than pre-save
@@ -10,28 +9,16 @@ const MODEL_SAVE_TIMEOUT = 8000, // timeout for model.js pre-save hook
  * call a component's model.js pre-save hook
  * @param  {string} uri
  * @param  {object} data
- * @param {string} [eventID]
- * @param {boolean} [snapshot]
  * @return {Promise}
  */
-export function save(uri, data, {eventID, snapshot}) {
+export function save(uri, data) {
   const model = getModel(uri);
 
-  let promise;
-
   if (_.isFunction(model.save)) {
-    promise = timeout(attempt(() => model.save(uri, data, getLocals())), MODEL_SAVE_TIMEOUT);
+    return timeout(attempt(() => model.save(uri, data, getLocals())), MODEL_SAVE_TIMEOUT);
   } else {
-    promise = Promise.resolve(data);
+    return Promise.resolve(data);
   }
-
-  // publish changes for other components AFTER running through model.js (if component has one)
-  // note: components with server.js will never call this, and cannot publish to properties
-  // (though they can subscribe to changes)
-  return promise.then((dataToPersist) => {
-    publish(uri, dataToPersist, eventID, snapshot);
-    return dataToPersist;
-  });
 }
 
 /**

--- a/lib/component-data/pubsub.js
+++ b/lib/component-data/pubsub.js
@@ -1,221 +1,159 @@
-// cross-component updating via pubsub
 import _ from 'lodash';
-import { create } from 'eventify';
 import cuid from 'cuid';
 import { pubProp, subProp, componentRoute, getComponentName } from '../utils/references';
 import { ADD_SCHEMA } from './mutationTypes';
 import { PRELOAD_SUCCESS } from '../preloader/mutationTypes';
-import { getSchema } from '../core-data/components';
+import { props } from '../utils/promises';
 
-// Ask veit ek standa, heitir Yggdrasill
-// hár baðmr, ausinn hvíta auri;
-// þaðan koma döggvar þærs í dala falla;
-// stendr æ yfir grœnn Urðar brunni.
-export const yggdrasil = create();
-// Subscribers they made there, and life allotted
-// To the sons of components, and set their fates
-
-// exported for testing
-export let callStacks = {};
-// when we publish for the first time, we generate an eventID.
-// as components pub and sub, they add themselves to the call stack for that eventID
-// e.g. callStacks[a8s7c].history = ['A+', 'B-', 'C-'] for components A → B → C
-// when components pub, they're denoted with +, e.g. 'A+'
-// when components sub, they're denoted with -, e.g. 'B-'
-// this allows us to differentiate between cyclic regression (expected, but we stop the event chain at that point)
-// and nondeterministic updates (unexpected, and we warn the dev so they can eliminate them).
-// cyclic regression looks like [..., 'A+', 'A-'] (pub, then sub of the same component)
-// nondeterministic updates look like [..., 'B-', 'B-'] (sub, then sub of the same component)
-// note: they don't have to be right next to each other
-
-var subscriberRegistry = {};
-// when subscribers are registered, they add themselves to this registry.
-// when the subscribers are fired, they add their data here
-// (and check to see if all subcribers have been fired).
-// once all subscribers for a component have fired, the data gets merged, the component saves,
-// and the subscribed properties are nulled (ready for the next publish).
-// when registering, an entry looks like: { <component name>: { <subscribed prop>: null } }
-// when firing, it looks like { <component name>: { <subscribed prop>: { <field>: <value> } } }
+let callStacks = {},
+  // when we publish for the first time, we generate an eventID.
+  // as components publish, they add themselves to an array based on that eventID
+  // this allows us to prevents cyclic updates (e.g. a component publishing, then subscribing to itself)
+  // note: cyclic updates might be complex, and involve multiple intermediate pubs/subs across
+  // different components
+  publisherRegistery = {},
+  // when component publishers are added, they register themselves here.
+  // this allows us to quickly determing if a component needs to publish stuff,
+  // and what properties it should publish to
+  subscriberRegistery = {};
+  // when component subscribers are added, they register themselves here.
+  // this allows us to determine which component(s) should update when properties are published
 
 /**
- * update all instances of a component
- * @param  {Object} store
- * @param  {string} name  of the component
- * @param {string} [eventID]
- * @param {boolean} [snapshot]
- */
-function updateComponents(store, {name, eventID, snapshot}) {
-  _.forOwn(store.state.components, (componentData, uri) => {
-    if (_.includes(uri, `${componentRoute}${name}`)) {
-      // grab all the data to update
-      const data = _.reduce(subscriberRegistry[name], (result, field) => _.assign(result, field), {});
-
-      // null out the subscriberRegistry
-      _.forOwn(subscriberRegistry[name], (field, prop) => {
-        subscriberRegistry[name][prop] = null;
-      });
-      store.dispatch('saveComponent', {uri, data, eventID, snapshot});
-    }
-  });
-}
-
-/**
- * add listeners to all schemas after preloading them
- * @param {Object} schemae
- * @param {Object} store
- */
-function addPreloadedListeners(schemae, store) {
-  /* istanbul ignore next */
-  _.forOwn(schemae, (schema, name) => addListeners(name, schema, store));
-}
-
-/**
- * add listeners for updating the page list
- * @param {object} store
- */
-function addPageListListeners(store) {
-  // listen for page title
-  yggdrasil.on('kilnTitle', (data) => {
-    store.dispatch('updatePageList', { title: data });
-  });
-  // listen for page authors
-  yggdrasil.on('kilnAuthors', (data) => {
-    store.dispatch('updatePageList', { authors: data });
-  });
-}
-
-/**
- * trace a graph to find the path to a property
- * e.g. find 'D' in { A: { prop1: { B: { prop2: { C: {}, D: {}}}}}}
- * which would return 'A.prop1.B.prop2.D'
- * @param  {object} graph to search inside
- * @param  {string} propName to search for
- * @param {string} [currentPath] if searching deep in a graph
- * @param {string} [resultPath] final result path
- * @return {array}
- */
-function graphTrace(graph, propName, currentPath, resultPath) {
-  currentPath = currentPath || 'root';
-
-  // iterate through this level of the graph, recursing to the next level
-  _.forOwn(graph, (val, key) => {
-    if (key === propName) {
-      resultPath = `${currentPath}.${propName}`;
-      return false;
-    } else if (!resultPath) {
-      resultPath = graphTrace(val, propName, `${currentPath}.${key}`, resultPath);
-    }
-  });
-  return resultPath ? resultPath.replace('root.', '') : null;
-}
-
-/**
- * function to call when subscribe is triggered
- * @param  {Object} data
- * @param  {string} eventID
- * @param  {string} name
- * @param  {string} fieldName
- * @param {string} prop that this subscribed to
- * @param  {Object} store
- * @param {boolean} [snapshot]
- * @return {Promise|undefined}
- */
-function onSubscribe(data, eventID, {name, fieldName, prop, store, snapshot}) {
-  if (!_.includes(callStacks[eventID].history, `${name}+`)) {
-    // component has not already been published (that would be a cyclic update)
-    // cyclic updates are expected, but should be blocked as they lead to infinite regression
-    const path = graphTrace(callStacks[eventID].graph, prop);
-
-    let allSubscribersFinished;
-
-    callStacks[eventID].history.push(`${name}-`);
-    _.set(callStacks[eventID].graph, `${path}.${name}`, {});
-    subscriberRegistry[name][prop] = { [fieldName]: data };
-
-    allSubscribersFinished = _.every(subscriberRegistry[name], _.isObject);
-    if (allSubscribersFinished) {
-      return updateComponents(store, { name, eventID, snapshot });
-    }
-  }
-}
-
-/**
- * add listeners in a schema
+ * register publishers and subscribers for a component
  * note: exported for testing
- * @param {string} name   of component
- * @param {Object} schema
- * @param {Object} store
+ * @param  {string} name   of component
+ * @param  {object} schema
  */
-export function addListeners(name, schema, store) {
+export function register(name, schema) {
   _.forOwn(schema, (field, fieldName) => {
+    // register publisher, if it exists
+    if (_.isObject(field) && field[pubProp]) {
+      publisherRegistery[name] = publisherRegistery[name] || {};
+      publisherRegistery[name][fieldName] = field[pubProp];
+    }
+
+    // register subscriber, if it exists
     if (_.isObject(field) && field[subProp]) {
       const prop = field[subProp];
 
-      // fun undocumented api: eventify allows multiple space-delineated events
-      yggdrasil.on(prop, (data, eventID, snapshot) => onSubscribe(data, eventID, {name, fieldName, prop, store, snapshot}));
-      // add the subscribers to the registry
-      subscriberRegistry[name] = subscriberRegistry[name] || {};
-      subscriberRegistry[name][prop] = null;
+      subscriberRegistery[prop] = subscriberRegistery[prop] || {};
+      subscriberRegistery[prop][name] = subscriberRegistery[prop][name] || new Set();
+      subscriberRegistery[prop][name].add(fieldName);
     }
   });
+}
+
+/**
+ * unregister all components from pubsub
+ * note: exported for testing
+ */
+export function unregisterAll() {
+  publisherRegistery = {};
+  subscriberRegistery = {};
+  callStacks = {};
+}
+
+/**
+ * add subscribers for kiln page list
+ * note: other components cannot subscribe to internal kiln props
+ * note: exported for testing
+ */
+export function registerPageList() {
+  subscriberRegistery.kilnTitle = { kiln: new Set(['title']) };
+  subscriberRegistery.kilnAuthors = { kiln: new Set(['authors']) };
+}
+
+// istanbul ignore next
+
+/**
+ * register all schemas after they're preloaded (on initial page load)
+ * @param  {object} schemas
+ */
+function registerAll(schemas) {
+  _.forOwn(schemas, (schema, name) => register(name, schema));
 }
 
 /**
  * pubsub plugin
- * adds subscribers whenever we add new schemas
+ * registers publishers and subscribers whenever we add new schemas
  * those subscribers update ALL instances of a component when their subscribed properties change
  * @param  {object} store
  */
 export default function pubsub(store) {
   // after schemas are loaded (and when loading any new schemas),
-  // parse them for new subscribers
+  // parse them for new publishers and subscribers
   store.subscribe((mutation) => {
     /* istanbul ignore if */
     if (mutation.type === PRELOAD_SUCCESS) {
-      addPreloadedListeners(_.get(store, 'state.schemas'), store);
-      addPageListListeners(store);
+      registerAll(_.get(store, 'state.schemas'));
+      registerPageList();
     } else if (mutation.type === ADD_SCHEMA) {
-      addListeners(mutation.payload.name, mutation.payload.data, store);
+      register(mutation.payload.name, mutation.payload.data);
     }
   });
 }
 
 /**
- * quickly determine if a component has ANY fields that will trigger publish
- * @param  {object} schema
+ * determine if a component has anything it needs to publish
+ * @param  {string} name
  * @return {boolean}
  */
-function shouldPublish(schema) {
-  return !!_.find(schema, (field) => _.isObject(field) && field[pubProp]);
+function shouldPublish(name) {
+  return _.isObject(publisherRegistery[name]) && !!_.size(publisherRegistery[name]);
 }
 
 /**
- * when publishing for the first time after a manual save,
- * generate an event ID and add the component name to the call stack.
- * this ID will propagate out to all listeners, preventing
- * infinite cyclic recursion and warning devs about nondeterministic behavior
- * @param  {string} name
- * @param  {string} [eventID]
- * @return {string}
+ * determine if a property has any subscribers
+ * @param  {string}  prop
+ * @return {boolean}
  */
-function generateEventID(name, eventID) {
-  if (!eventID) {
-    eventID = cuid();
-    callStacks[eventID] = {
-      history: [`${name}+`],
-      graph: {
-        [name]: {}
-      }
-    };
-  } else {
-    const path = graphTrace(callStacks[eventID].graph, name);
+function hasSubscribers(prop) {
+  return _.isObject(subscriberRegistery[prop]) && !!_.size(subscriberRegistery[prop]);
+}
 
-    // if this publish was triggered in an event chain, just add the component to the call stack
-    callStacks[eventID].history.push(`${name}+`);
-    _.set(callStacks[eventID].graph, path, {});
-  }
+/**
+ * components should not have their subscriptions triggered if they've already published
+ * @param  {string} name
+ * @param  {string} eventID
+ * @return {boolean}
+ */
+function shouldSubscribe(name, eventID) {
+  return !_.includes(callStacks[eventID], name);
+}
 
-  return eventID;
+/**
+ * update all instances of a component
+ * @param  {string} eventID
+ * @param  {boolean} [snapshot]
+ * @param  {object} store
+ * @return {function}
+ */
+function updateComponentInstances(eventID, snapshot, store) {
+  return (data, name) => {
+    if (name === 'kiln') {
+      // we're updating the page list!
+      return store.dispatch('updatePageList', data);
+    } else {
+      // we're updating other components on the page!
+      // get all their instances from the store, then update them
+      const instances = _.filter(Object.keys(store.state.components), (uri) => _.includes(uri, `${componentRoute}${name}`));
+
+      return Promise.all(_.map(instances, (uri) => store.dispatch('saveComponent', { uri, data, eventID, snapshot })));
+    }
+  };
+}
+
+/**
+ * update all subscribing components
+ * @param  {object} payload
+ * @param  {string} eventID
+ * @param  {boolean} [snapshot]
+ * @param {object} store
+ * @return {Promise}
+ */
+function updateSubscribers(payload, eventID, snapshot, store) {
+  return props(_.mapValues(payload, updateComponentInstances(eventID, snapshot, store)));
 }
 
 /**
@@ -225,26 +163,43 @@ function generateEventID(name, eventID) {
  * @param  {Object} data
  * @param {string} [eventID]
  * @param {boolean} [snapshot]
+ * @param {object} store
+ * @returns {Promise}
  */
-export function publish(uri, data, eventID, snapshot) {
-  const schema = getSchema(uri),
-    name = getComponentName(uri);
+export function publish(uri, data, eventID, snapshot, store) { // eslint-disable-line
+  const name = getComponentName(uri);
 
-  if (shouldPublish(schema)) {
-    eventID = generateEventID(name, eventID);
+  let payload = {};
+
+  // if the component has nothing to publish, resolve quickly
+  if (!shouldPublish(name)) {
+    return Promise.resolve(data);
   }
 
-  _.forOwn(schema, (field, fieldName) => {
-    if (_.isObject(field) && field[pubProp]) {
-      const prop = field[pubProp],
-        path = graphTrace(callStacks[eventID].graph, name);
+  // generate eventID if it wasn't passed in
+  eventID = eventID || /* istanbul ignore next */ cuid();
 
-      // fun undocumented api: eventify allows multiple space-delineated events
-      _.set(callStacks[eventID].graph, `${path}.${prop}`, {});
-      yggdrasil.trigger(field[pubProp], data[fieldName], eventID, snapshot);
-      // note: this uses the same eventID for every prop/field, so a component
-      // will never save twice in the same event chain
-      // (even if the props/fields they're pub-subbing are different)
+  // create or add callstack for this eventID
+  callStacks[eventID] = callStacks[eventID] || [];
+  callStacks[eventID].push(name);
+
+  // construct a payload of props + values that should publish from this component,
+  // keyed by the potential subscribing comnponents
+  _.forOwn(publisherRegistery[name], (prop, field) => {
+    const value = data[field];
+
+    if (hasSubscribers(prop)) {
+      // there are subscribers to this property!
+      // see if they should subscribe (e.g. they haven't already published) and construct
+      // a payload of the data that needs to be sent to these components
+      _.forOwn(subscriberRegistery[prop], (subscribedFields, subscriberName) => {
+        if (shouldSubscribe(subscriberName, eventID)) {
+          payload[subscriberName] = _.reduce(Array.from(subscribedFields), (subData, subscribedField) => _.assign(subData, { [subscribedField]: value }), payload[subscriberName] || {});
+        }
+      });
     }
   });
+
+  // update all the subscribed components, then return the original component's data
+  return updateSubscribers(payload, eventID, snapshot, store).then(() => data);
 }

--- a/lib/component-data/pubsub.test.js
+++ b/lib/component-data/pubsub.test.js
@@ -1,52 +1,62 @@
-import _ from 'lodash';
-import * as components from '../core-data/components';
 import * as lib from './pubsub';
 
-const schemas = {
-    noPub: { foo: 'a', bar: { baz: 'qux' }},
+const data = { foo: 'harder', bar: 'better', baz: 'faster', qux: 'stronger' },
+  eventID = 'abcdef',
+  schemas = {
+    noPub: { foo: {} },
     pubSelf: {
       foo: {
-        _subscribe: 'able',
-        _publish: 'able'
+        _subscribe: '1',
+        _publish: '1'
       }
     },
-    pubA: {
-      bar: { _publish: 'able' }
+    pub1: {
+      foo: { _publish: '1' }
     },
-    subA: {
-      baz: { _subscribe: 'able' }
+    sub1: {
+      foo: { _subscribe: '1' }
     },
-    subApubB: {
-      qux: {
-        _subscribe: 'able',
-        _publish: 'baker'
-      }
+    pub2: {
+      bar: { _publish: '2' }
     },
-    subB: {
-      quux: { _subscribe: 'baker' }
+    sub2: {
+      bar: { _subscribe: '2' }
     },
-    pubAB: {
-      foo: { _publish: 'able' },
-      bar: { _publish: 'baker' }
+    pub12: {
+      foo: { _publish: '1' },
+      bar: { _publish: '2' }
     },
-    subApubC: {
-      foo: {
-        _subscribe: 'able',
-        _publish: 'charlie'
-      }
+    sub12: {
+      foo: { _subscribe: '1' },
+      bar: { _subscribe: '2' }
     },
-    subBpubC: {
-      foo: {
-        _subscribe: 'baker',
-        _publish: 'charlie'
-      }
+    sub1pub2: {
+      foo: { _subscribe: '1' },
+      bar: { _publish: '2' }
     },
-    subC: {
-      foo: { _subscribe: 'charlie' }
+    sub1pub3: {
+      foo: { _subscribe: '1' },
+      baz: { _publish: '3' }
     },
-    // end is assigned into the schema of the last component in the chain we're testing
-    end: {
-      end: { _publish: 'end' }
+    sub23: {
+      bar: { _subscribe: '2' },
+      baz: { _subscribe: '3' }
+    },
+    sub2pub3: {
+      bar: { _subscribe: '2' },
+      baz: { _publish: '3' }
+    },
+    sub13: {
+      foo: { _subscribe: '1' },
+      baz: { _subscribe: '3' }
+    },
+    sub2pub1: {
+      foo: { _publish: '1' },
+      bar: { _subscribe: '2' }
+    },
+    sub3pub1: {
+      foo: { _publish: '1' },
+      baz: { _subscribe: '3' }
     }
   },
   componentPrefix = 'domain.com/components/';
@@ -55,16 +65,16 @@ describe('pubsub', () => {
   let sandbox, store;
 
   beforeEach(() => {
-    lib.yggdrasil.off(); // remove all listeners
     sandbox = sinon.sandbox.create();
-    sandbox.stub(components, 'getSchema');
+    lib.unregisterAll(); // unregister all components from pubsub
     store = {
-      dispatch: sandbox.spy((action, {uri, data, eventID}) => lib.publish(uri, data, eventID)),
+      dispatch: sandbox.spy((action, {uri, eventID, snapshot}) => lib.publish(uri, store.state.components[uri], eventID, snapshot, store)),
       state: {
         components: {
-          [`${componentPrefix}A/instances/1`]: {},
-          [`${componentPrefix}B/instances/1`]: {},
-          [`${componentPrefix}C/instances/1`]: {}
+          [`${componentPrefix}A/instances/1`]: data,
+          [`${componentPrefix}B/instances/1`]: data,
+          [`${componentPrefix}C/instances/1`]: data,
+          [`${componentPrefix}D/instances/1`]: data
         }
       }
     };
@@ -74,72 +84,224 @@ describe('pubsub', () => {
     sandbox.restore();
   });
 
+  function expectBwith1() {
+    expect(store.dispatch).to.have.been.calledWith('saveComponent', {
+      uri: `${componentPrefix}B/instances/1`,
+      data: { foo: 'harder' },
+      eventID,
+      snapshot: null
+    });
+  }
+
+  function expectCwith1() {
+    expect(store.dispatch).to.have.been.calledWith('saveComponent', {
+      uri: `${componentPrefix}C/instances/1`,
+      data: { foo: 'harder' },
+      eventID,
+      snapshot: null
+    });
+  }
+
+  function expectCwith2() {
+    expect(store.dispatch).to.have.been.calledWith('saveComponent', {
+      uri: `${componentPrefix}C/instances/1`,
+      data: { bar: 'better' },
+      eventID,
+      snapshot: null
+    });
+  }
+
+  function expectCwith3() {
+    expect(store.dispatch).to.have.been.calledWith('saveComponent', {
+      uri: `${componentPrefix}C/instances/1`,
+      data: { baz: 'faster' },
+      eventID,
+      snapshot: null
+    });
+  }
+
+  function expectDwith2() {
+    expect(store.dispatch).to.have.been.calledWith('saveComponent', {
+      uri: `${componentPrefix}D/instances/1`,
+      data: { bar: 'better' },
+      eventID,
+      snapshot: null
+    });
+  }
+
+  function expectBwith12() {
+    expect(store.dispatch).to.have.been.calledWith('saveComponent', {
+      uri: `${componentPrefix}B/instances/1`,
+      data: { foo: 'harder', bar: 'better' },
+      eventID,
+      snapshot: null
+    });
+  }
+
   describe('publish', () => {
     const fn = lib.publish;
 
     it('does nothing if no publishable fields in the schema', () => {
-      lib.addListeners('A', schemas.noPub, store);
-      components.getSchema.returns(schemas.noPub);
-      fn(`${componentPrefix}A`, {count:0});
-      expect(_.size(lib.callStacks)).to.equal(0);
+      lib.register('A', schemas.noPub);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(0); // nothing else saves
+      });
     });
+
+    it('does nothing if no subscribers in the registery', () => {
+      lib.register('A', schemas.pub1);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(0); // nothing else saves
+      });
+    });
+
+    // components that publish will never save themselves twice (to prevent bad ux and cyclic regressions)
 
     it('prevents double saving when A pubs and subs to the same event (cyclic regression)', () => {
-      let data = { count: 0 };
-
-      components.getSchema.returns(schemas.pubSelf);
-      lib.addListeners('A', schemas.pubSelf, store);
-      fn(`${componentPrefix}A`, data);
-      expect(data.count).to.equal(0);
+      lib.register('A', schemas.pubSelf);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(0); // A doesn't save twice
+      });
     });
 
-    it('propagates A to B', (done) => {
-      let data = { count: 0 };
+    // components propagate changes to other components
 
-      components.getSchema.withArgs(`${componentPrefix}A`).returns(schemas.pubA);
-      components.getSchema.withArgs(`${componentPrefix}B/instances/1`).returns(_.assign({}, schemas.subA, schemas.end));
-      lib.addListeners('B', schemas.subA, store);
-      lib.yggdrasil.on('end', () => {
-        expect(store.dispatch.callCount).to.equal(1);
-        done();
+    it('propagates A → 1 → B', () => {
+      lib.register('A', schemas.pub1);
+      lib.register('B', schemas.sub1);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(1); // B saves once
+        expectBwith1();
       });
-      // trigger publish after adding the end listener
-      fn(`${componentPrefix}A`, data);
     });
 
-    it('propagates A to B to C', (done) => {
-      let data = { count: 0 };
-
-      components.getSchema.withArgs(`${componentPrefix}A`).returns(schemas.pubA);
-      components.getSchema.withArgs(`${componentPrefix}B/instances/1`).returns(schemas.subApubB);
-      components.getSchema.withArgs(`${componentPrefix}C/instances/1`).returns(_.assign({}, schemas.subB, schemas.end));
-      lib.addListeners('B', schemas.subApubB, store);
-      lib.addListeners('C', schemas.subB, store);
-      lib.yggdrasil.on('end', () => {
-        expect(store.dispatch.callCount).to.equal(2);
-        done();
+    it('propagates A → 1+2 → B', () => {
+      lib.register('A', schemas.pub12);
+      lib.register('B', schemas.sub12);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(1); // B saves once, with both props
+        expectBwith12();
       });
-      // trigger publish after adding the end listener
-      fn(`${componentPrefix}A`, data);
     });
 
-    it('merges subbed data on nondeterministic updates', () => {
-      // A pubs to B and C, B and C pub to D.
-      let data = { count: 0 };
-
-      components.getSchema.withArgs(`${componentPrefix}A`).returns(schemas.pubAB);
-      components.getSchema.withArgs(`${componentPrefix}B/instances/1`).returns(schemas.subApubC);
-      components.getSchema.withArgs(`${componentPrefix}C/instances/1`).returns(schemas.subBpubC);
-      components.getSchema.withArgs(`${componentPrefix}D/instances/1`).returns(_.assign({}, schemas.subC, schemas.end));
-      lib.addListeners('B', schemas.subApubC, store);
-      lib.addListeners('C', schemas.subBpubC, store);
-      lib.addListeners('D', schemas.subC, store);
-      lib.yggdrasil.on('end', () => {
-        expect(store.dispatch.callCount).to.equal(3); // D is only saved once, not twice
-        done();
+    it('propagates A+B → 1 → C', () => {
+      lib.register('A', schemas.pub1);
+      lib.register('B', schemas.pub1);
+      // note: B is never called, so it's equivalent to A → 1 → C
+      lib.register('C', schemas.sub1);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(1); // C saves once
+        expectCwith1();
       });
-      // trigger publish after adding the end listener
-      fn(`${componentPrefix}A`, data);
+    });
+
+    it('propagates A → 1 → C / B → 2 → C', () => {
+      lib.register('A', schemas.pub1);
+      lib.register('B', schemas.pub2);
+      // note: B is never called, so it's equivalent to A → 1 → C
+      lib.register('C', schemas.sub12);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(1); // C saves once
+        expectCwith1();
+      });
+    });
+
+    it('propagates A → 1 → B+C', () => {
+      lib.register('A', schemas.pub1);
+      lib.register('B', schemas.sub1);
+      lib.register('C', schemas.sub1);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(2); // B and C save
+        expectBwith1();
+        expectCwith1();
+      });
+    });
+
+    it('propagates A → 1 → B / A → 2 → C', () => {
+      lib.register('A', schemas.pub12);
+      lib.register('B', schemas.sub1);
+      lib.register('C', schemas.sub2);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(2); // B and C save
+        expectBwith1();
+        expectCwith2();
+      });
+    });
+
+    // there are some situations where components will save twice (if they don't also publish stuff)
+
+    it('propagates A → 1 → B+C / …B → 2 → C', () => {
+      lib.register('A', schemas.pub1);
+      lib.register('B', schemas.sub1pub2);
+      lib.register('C', schemas.sub12);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(3); // B and C save (C saves twice)
+        expectBwith1();
+        expectCwith1();
+        expectCwith2();
+      });
+    });
+
+    it('propagates A → 1 → B / A → 2 → C / …B → 3 → C', () => {
+      lib.register('A', schemas.pub12);
+      lib.register('B', schemas.sub1pub3);
+      lib.register('C', schemas.sub23);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(3); // B and C save (C saves twice)
+        expectBwith1();
+        expectCwith2();
+        expectCwith3();
+      });
+    });
+
+    it('propagates A → 1 → B+C / …B → 2 → D / …D → 3 → C', () => {
+      lib.register('A', schemas.pub1);
+      lib.register('B', schemas.sub1pub2);
+      lib.register('C', schemas.sub13);
+      lib.register('D', schemas.sub2pub3);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(4); // B, C, and D save (C saves twice)
+        expectBwith1();
+        expectCwith1();
+        expectDwith2();
+        expectCwith3();
+      });
+    });
+
+    // complex or deep cyclic dependencies will also be prevented
+
+    it('propagates A → 1 → B / …B → 2 → A', () => {
+      lib.register('A', schemas.sub2pub1);
+      lib.register('B', schemas.sub1pub2);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(1); // B saves (A does not)
+        expectBwith1();
+      });
+    });
+
+    it('propagates A → 1 → B / …B → 2 → C / …C → 3 → A', () => {
+      lib.register('A', schemas.sub3pub1);
+      lib.register('B', schemas.sub1pub2);
+      lib.register('C', schemas.sub2pub3);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(2); // B and C save (A does not)
+        expectBwith1();
+        expectCwith2();
+      });
+    });
+
+    it('propagates title and author to page list', () => {
+      lib.register('A', {
+        foo: { _publish: 'kilnTitle' },
+        bar: { _publish: 'kilnAuthors' }
+      });
+      lib.registerPageList();
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch).to.have.been.calledWith('updatePageList', {
+          title: 'harder',
+          authors: 'better'
+        });
+      });
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "element-client-rect": "^1.0.4",
     "eslint": "^3.2.2",
     "eslint-plugin-html": "^2.0.0",
-    "eventify": "^2.0.1",
     "extract-text-webpack-plugin": "^2.0.0-rc.2",
     "file-loader": "^0.10.1",
     "flatpickr": "^2.3.7",


### PR DESCRIPTION
* this fixes the issue where a component wants to subscribe to properties published by separate components, but not wait for them all to publish before saving
* pubsub now has 100% test coverage
* the walls of the scrum room are covered in diagrams

![img_0482](https://user-images.githubusercontent.com/447522/27979747-593818f0-6346-11e7-96b5-400f32889950.png)

* also consolidated the `CURRENTLY_SAVING` stuff in the save action