### PR TITLE
Allow checkbox group to render and update when data is null

### DIFF
--- a/behaviors/checkbox-group.vue
+++ b/behaviors/checkbox-group.vue
@@ -107,7 +107,7 @@
     methods: {
       update(e) {
         const key = e.target.value,
-          newData = { [key]: !this.data[key] }; // toggle the check
+          newData = { [key]: this.data ? !this.data[key] : true }; // toggle the check
 
         this.$store.commit(UPDATE_FORMDATA, { path: this.name, data: _.assign({}, this.data, newData) });
       }

--- a/behaviors/checkbox-group.vue
+++ b/behaviors/checkbox-group.vue
@@ -66,7 +66,7 @@
 <template>
   <div class="checkbox-group">
     <div class="checkbox-group-item" v-for="option in options">
-      <input :name="option.name" type="checkbox" :id="option.id" :checked="data[option.value]" :value="option.value" @change="update" />
+      <input :name="option.name" type="checkbox" :id="option.id" :checked="data && data[option.value]" :value="option.value" @change="update" />
       <label :for="option.id">{{ option.name }}</label>
     </div>
   </div>


### PR DESCRIPTION
We're adding a new checkbox-group field to article called `storyCharacteristics`. Checkbox-group fails to render and update when data is not yet set. This fix allows it to render even when data is `null`.

Related to [Trello](https://trello.com/c/53JYafeU/105-story-characteristics)