### PR TITLE
Bumps major version of nymag-handlebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "mocha": "^3.2.0",
     "node-sass": "^4.3.0",
     "nprogress": "^0.2.0",
-    "nymag-handlebars": "^2.0.0",
+    "nymag-handlebars": "^3.1.0",
     "optimize-css-assets-webpack-plugin": "^1.3.0",
     "postcss-loader": "^1.3.0",
     "promise-queue": "^2.2.3",


### PR DESCRIPTION
[Related](https://trello.com/c/3vmXKskn/24-homepage-latest-feed)

We need a helper added in nymag-handlebars 3.0. The shift from 2 to 3 just removes a helper addInArticleAds.