### PR TITLE
Freezing Quill Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "optimize-css-assets-webpack-plugin": "^1.3.0",
     "postcss-loader": "^1.3.0",
     "promise-queue": "^2.2.3",
-    "quill": "^1.2.6",
+    "quill": "1.2.6",
     "quill-delta": "^3.4.3",
     "raw-loader": "^0.5.1",
     "routable": "0.0.5",


### PR DESCRIPTION
Found a bug in Quill with the sanitize service and need to freeze version to `1.2.6`.

[Nelson filed a bug with Quill.](https://github.com/quilljs/quill/issues/1608)