### PR TITLE
store some things in user browser store

### DIFF
--- a/lib/decorators/placeholder.vue
+++ b/lib/decorators/placeholder.vue
@@ -211,7 +211,7 @@
       <span v-if="isRequired" class="placeholder-required">Required</span>
     </div>
     <div v-if="canAddComponent" class="placeholder-bottom">
-      <span class="placeholder-add-component" title="Add Components" @click.stop="openAddComponentPane">Add Components</span>
+      <span class="placeholder-add-component" :title="addComponentTitle" @click.stop="openAddComponentPane">{{ addComponentTitle }}</span>
     </div>
   </div>
 </template>
@@ -222,6 +222,7 @@
   import { placeholderProp, componentListProp, componentProp } from '../utils/references';
   import { getData } from '../core-data/components';
   import { get } from '../core-data/groups';
+  import label from '../utils/label';
   import interpolate from '../utils/interpolate';
   import icon from '../utils/icon.vue';
 
@@ -235,7 +236,7 @@
     data() {
       return {
         permanentClass: 'kiln-permanent-placeholder',
-        temporaryClass: 'kiln-placeholder'
+        temporaryClass: 'kiln-placeholder',
       };
     },
     computed: {
@@ -262,6 +263,13 @@
         const subSchema = getSchema(this.$options);
 
         return !!subSchema[componentListProp] || !!subSchema[componentProp];
+      },
+      addComponentTitle() {
+        const subSchema = getSchema(this.$options),
+          componentsToAdd = _.get(subSchema, `${componentListProp}.include`) || _.get(subSchema, `${componentProp}.include`),
+          hasOneComponent = componentsToAdd.length === 1;
+
+        return hasOneComponent ? `Add ${label(componentsToAdd[0])}` : 'Add Components';
       },
       placeholderHeight() {
         const placeholderHeight = parseInt(getSchema(this.$options)[placeholderProp].height, 10) || 100, // default to 100px

--- a/lib/decorators/placeholder.vue
+++ b/lib/decorators/placeholder.vue
@@ -236,7 +236,7 @@
     data() {
       return {
         permanentClass: 'kiln-permanent-placeholder',
-        temporaryClass: 'kiln-placeholder',
+        temporaryClass: 'kiln-placeholder'
       };
     },
     computed: {
@@ -267,7 +267,7 @@
       addComponentTitle() {
         const subSchema = getSchema(this.$options),
           componentsToAdd = _.get(subSchema, `${componentListProp}.include`) || _.get(subSchema, `${componentProp}.include`),
-          hasOneComponent = componentsToAdd.length === 1;
+          hasOneComponent = componentsToAdd && componentsToAdd.length === 1;
 
         return hasOneComponent ? `Add ${label(componentsToAdd[0])}` : 'Add Components';
       },

--- a/lib/panes/pane-tabs.vue
+++ b/lib/panes/pane-tabs.vue
@@ -89,13 +89,14 @@
 
 <script>
   import _ from 'lodash';
+  import { setItem } from '../utils/local';
   import icon from '../utils/icon.vue';
 
   // TODO: FIGURE OUT THE BUG THAT WON'T INCLUDE THE `LEFT-CARET` ICON WITHOUT
   // PULLING IN THE SVG FOR THE RIGHT-CARET
 
   export default {
-    props: ['content'],
+    props: ['content', 'clayHeader'],
     data() {
       return {
         paneWidth: null,
@@ -172,6 +173,12 @@
         if (isDisabled !== true) {
           this.$store.commit('SWITCH_TAB', this.tabs[index] && this.tabs[index].header);
           this.activeTab = index;
+
+          if (this.clayHeader) {
+            // if this pane has a clay header (e.g. it's a clay menu),
+            // then persist the active tab so it becomes the default next time
+            setItem('claymenu:activetab', this.tabs[index].header);
+          }
         }
       }
     },

--- a/lib/panes/pane-tabs.vue
+++ b/lib/panes/pane-tabs.vue
@@ -96,7 +96,7 @@
   // PULLING IN THE SVG FOR THE RIGHT-CARET
 
   export default {
-    props: ['content', 'clayHeader'],
+    props: ['content', 'saveTab'],
     data() {
       return {
         paneWidth: null,
@@ -174,10 +174,10 @@
           this.$store.commit('SWITCH_TAB', this.tabs[index] && this.tabs[index].header);
           this.activeTab = index;
 
-          if (this.clayHeader) {
+          if (this.saveTab) {
             // if this pane has a clay header (e.g. it's a clay menu),
             // then persist the active tab so it becomes the default next time
-            setItem('claymenu:activetab', this.tabs[index].header);
+            setItem(`${this.saveTab}:activetab`, this.tabs[index].header);
           }
         }
       }

--- a/lib/panes/pane-tabs.vue
+++ b/lib/panes/pane-tabs.vue
@@ -175,8 +175,9 @@
           this.activeTab = index;
 
           if (this.saveTab) {
-            // if this pane has a clay header (e.g. it's a clay menu),
-            // then persist the active tab so it becomes the default next time
+            // if this pane has a saveTab key specified,
+            // then persist the active tab so it becomes the active one
+            // next time the pane is opened
             setItem(`${this.saveTab}:activetab`, this.tabs[index].header);
           }
         }

--- a/lib/panes/pane.vue
+++ b/lib/panes/pane.vue
@@ -15,7 +15,7 @@
     <div class="kiln-toolbar-pane" v-if="hasOpenPane" :class="[position, size, height]" :style="{ left: offsetLeft }" @click.stop>
       <pane-header :title="headerTitle" :buttonClick="closePane" check="close-edit" :clayHeader="clayHeader"></pane-header>
       <component v-if="singleTab" :is="singleComponent" :args="singleComponentArgs"></component>
-      <pane-tabs v-else :content="content"></pane-tabs>
+      <pane-tabs v-else :content="content" :clayHeader="clayHeader"></pane-tabs>
     </div>
   </transition>
 </template>
@@ -65,7 +65,7 @@
         return _.get(this, 'content.args');
       },
       headerTitle: (state) => _.get(state, 'ui.currentPane.title') || 'Pane',
-      clayHeader: (state) => _.get(state, 'ui.currentPane.clayHeader')
+      clayHeader: (state) => _.get(state, 'ui.currentPane.clayHeader'),
     }),
     methods: {
       closePane() {

--- a/lib/panes/pane.vue
+++ b/lib/panes/pane.vue
@@ -15,7 +15,7 @@
     <div class="kiln-toolbar-pane" v-if="hasOpenPane" :class="[position, size, height]" :style="{ left: offsetLeft }" @click.stop>
       <pane-header :title="headerTitle" :buttonClick="closePane" check="close-edit" :clayHeader="clayHeader"></pane-header>
       <component v-if="singleTab" :is="singleComponent" :args="singleComponentArgs"></component>
-      <pane-tabs v-else :content="content" :clayHeader="clayHeader"></pane-tabs>
+      <pane-tabs v-else :content="content" :saveTab="saveTab"></pane-tabs>
     </div>
   </transition>
 </template>
@@ -66,6 +66,7 @@
       },
       headerTitle: (state) => _.get(state, 'ui.currentPane.title') || 'Pane',
       clayHeader: (state) => _.get(state, 'ui.currentPane.clayHeader'),
+      saveTab: (state) => _.get(state, 'ui.currentPane.saveTab')
     }),
     methods: {
       closePane() {

--- a/lib/toolbar/edit-toolbar.vue
+++ b/lib/toolbar/edit-toolbar.vue
@@ -240,24 +240,38 @@
         return this.$store.dispatch('togglePane', { options, button });
       },
       toggleComponents(name, button) {
-        let options = {
-          name,
-          title: 'Find on Page',
-          height: 'medium-height',
-          content: [{
-            header: 'Visible',
-            content: {
-              component: 'visible-components'
-            }
-          }]
-        };
+        return getItem('findonpage:activetab').then((savedTab) => {
+          const activeTab = savedTab || 'Visible';
 
-        // add head components (from page and layout)
-        options.content = options.content.concat(getHeadTabs(this.$store.state));
-        // add invisible components (from layout)
-        options.content = options.content.concat(getInvisibleTabs(this.$store.state));
+          let options = {
+              name,
+              title: 'Find on Page',
+              saveTab: 'findonpage',
+              height: 'medium-height',
+              content: [{
+                header: 'Visible',
+                active: activeTab === 'Visible',
+                content: {
+                  component: 'visible-components'
+                }
+              }]
+            },
+            headTabs = _.map(getHeadTabs(this.$store.state), (tab) => {
+              tab.active = activeTab === tab.header;
+              return tab;
+            }),
+            invisibleTabs = _.map(getInvisibleTabs(this.$store.state), (tab) => {
+              tab.active = activeTab === tab.header;
+              return tab;
+            });
 
-        return this.$store.dispatch('togglePane', { options, button });
+          // add head components (from page and layout)
+          options.content = options.content.concat(headTabs);
+          // add invisible components (from layout)
+          options.content = options.content.concat(invisibleTabs);
+
+          return this.$store.dispatch('togglePane', { options, button });
+        });
       },
       togglePreview(name, button) {
         const options = {

--- a/lib/toolbar/edit-toolbar.vue
+++ b/lib/toolbar/edit-toolbar.vue
@@ -191,6 +191,7 @@
             options = {
               name,
               title: 'Clay Menu',
+              saveTab: 'claymenu',
               size: 'xlarge',
               height: 'tall',
               clayHeader: true,

--- a/lib/toolbar/edit-toolbar.vue
+++ b/lib/toolbar/edit-toolbar.vue
@@ -73,6 +73,7 @@
   import { layoutAttr, editAttr, componentListProp } from '../utils/references';
   import label from '../utils/label';
   import { getListsInHead } from '../utils/head-components';
+  import { getItem } from '../utils/local';
   import progressBar from './progress.vue';
   import button from './toolbar-button.vue';
   import background from './background.vue';
@@ -185,35 +186,40 @@
       // logic that is specific to each button,
       // e.g. running validation before opening the publish pane
       toggleMenu(name, button) {
-        const options = {
-          name,
-          title: 'Clay Menu',
-          size: 'xlarge',
-          height: 'tall',
-          clayHeader: true,
-          content: [{
-            header: 'My Pages',
-            content: {
-              component: 'page-list',
-              args: {
-                isMyPages: true
-              }
-            }
-          },{
-            header: 'All Pages',
-            active: true, // todo: save last tab in localstorage
-            content: {
-              component: 'page-list'
-            }
-          }, {
-            header: 'New Page',
-            content: {
-              component: 'new-page'
-            }
-          }]
-        };
+        return getItem('claymenu:activetab').then((savedTab) => {
+          const activeTab = savedTab || 'All Pages',
+            options = {
+              name,
+              title: 'Clay Menu',
+              size: 'xlarge',
+              height: 'tall',
+              clayHeader: true,
+              content: [{
+                header: 'My Pages',
+                active: activeTab === 'My Pages',
+                content: {
+                  component: 'page-list',
+                  args: {
+                    isMyPages: true
+                  }
+                }
+              },{
+                header: 'All Pages',
+                active: activeTab === 'All Pages', // note: this is the default
+                content: {
+                  component: 'page-list'
+                }
+              }, {
+                header: 'New Page',
+                active: activeTab === 'New Page',
+                content: {
+                  component: 'new-page'
+                }
+              }]
+            };
 
-        return this.$store.dispatch('togglePane', { options, button });
+          return this.$store.dispatch('togglePane', { options, button });
+        });
       },
       undo() {
         this.$store.dispatch('undo');

--- a/lib/toolbar/view-toolbar.vue
+++ b/lib/toolbar/view-toolbar.vue
@@ -71,6 +71,7 @@
   import _ from 'lodash';
   import { mapState } from 'vuex';
   import toggleEdit from '../utils/toggle-edit';
+  import { getItem } from '../utils/local';
   import button from './toolbar-button.vue';
   import background from './background.vue';
   import pane from '../panes/pane.vue';
@@ -89,35 +90,40 @@
         toggleEdit();
       },
       toggleMenu(name, button) {
-        const options = {
-          name,
-          title: 'Clay Menu',
-          size: 'xlarge',
-          height: 'tall',
-          clayHeader: true,
-          content: [{
-            header: 'My Pages',
-            content: {
-              component: 'page-list',
-              args: {
-                isMyPages: true
-              }
-            }
-          },{
-            header: 'All Pages',
-            active: true, // todo: save last tab in localstorage
-            content: {
-              component: 'page-list'
-            }
-          }, {
-            header: 'New Page',
-            content: {
-              component: 'new-page'
-            }
-          }]
-        };
+        return getItem('claymenu:activetab').then((savedTab) => {
+          const activeTab = savedTab || 'All Pages',
+            options = {
+              name,
+              title: 'Clay Menu',
+              size: 'xlarge',
+              height: 'tall',
+              clayHeader: true,
+              content: [{
+                header: 'My Pages',
+                active: activeTab === 'My Pages',
+                content: {
+                  component: 'page-list',
+                  args: {
+                    isMyPages: true
+                  }
+                }
+              },{
+                header: 'All Pages',
+                active: activeTab === 'All Pages', // note: this is the default
+                content: {
+                  component: 'page-list'
+                }
+              }, {
+                header: 'New Page',
+                active: activeTab === 'New Page',
+                content: {
+                  component: 'new-page'
+                }
+              }]
+            };
 
-        return this.$store.dispatch('togglePane', { options, button });
+          return this.$store.dispatch('togglePane', { options, button });
+        });
       }
     },
     components: _.merge({

--- a/lib/toolbar/view-toolbar.vue
+++ b/lib/toolbar/view-toolbar.vue
@@ -95,6 +95,7 @@
             options = {
               name,
               title: 'Clay Menu',
+              saveTab: 'claymenu',
               size: 'xlarge',
               height: 'tall',
               clayHeader: true,

--- a/lib/utils/api.js
+++ b/lib/utils/api.js
@@ -8,6 +8,7 @@ import * as promises from './promises';
 import * as references from './references';
 import * as urls from './urls';
 import getAvailableComponents from './available-components';
+import * as local from './local';
 
 // these utilities are exported so 3rd party plugins/validators/behaviors/panes can access them.
 // note: the store is passed into those things automatically, so don't export it here
@@ -22,6 +23,7 @@ const api = {
   references,
   urls,
   getAvailableComponents,
+  local,
   version: process.env.KILN_VERSION
 };
 

--- a/lib/utils/local.js
+++ b/lib/utils/local.js
@@ -1,0 +1,49 @@
+import _ from 'lodash';
+import { config, getItem, setItem } from 'localforage';
+
+// when using this module for the first time, configure the localforage instance
+config({
+  name: 'Kiln',
+  storeName: 'kiln',
+  description: 'Local browser store for Kiln, using localForage'
+});
+
+export { getItem, setItem }; // export these directly from localForage
+
+/**
+ * update counts of items in an array
+ * @param  {string} key
+ * @param  {object} itemToAdd
+ * @param  {string} [itemProp='name'] main property for items to match against
+ * @return {Promise}
+ */
+export function updateArray(key, itemToAdd, itemProp = 'name') {
+  return getItem(key)
+    .then((oldArray) => _.isNull(oldArray) ? [] : oldArray) // if the old array doesn't exist, create it
+    .then((oldArray) => {
+      // typecheck the stuff we're dealing with, so we can make assumptions below
+      if (!_.isArray(oldArray)) {
+        throw new Error(`Cannot update array in ${key}, it is actually: ${typeof oldArray}`);
+      } else if (!_.isObject(itemToAdd)) {
+        throw new Error(`Cannot update array with non-object: ${typeof itemToAdd}`);
+      } else {
+        return oldArray;
+      }
+    })
+    .then((oldArray) => {
+      const index = _.findIndex(oldArray, (item) => item[itemProp] === itemToAdd[itemProp]);
+
+      if (index > -1) {
+        oldArray[index].count++; // item is already in the array, update the count
+      } else {
+        itemToAdd.count = 1;
+        oldArray.push(itemToAdd);
+      }
+      return oldArray;
+    })
+    .then((newArray) => setItem(key, newArray))
+    .catch((e) => {
+      console.error(`Cannot update array in local browser store! ${e.message}`);
+      return Promise.reject(e);
+    });
+}

--- a/lib/utils/local.js
+++ b/lib/utils/local.js
@@ -1,14 +1,22 @@
 import _ from 'lodash';
-import { config, getItem, setItem } from 'localforage';
+import lf from 'localforage';
 
 // when using this module for the first time, configure the localforage instance
-config({
+// note: we're importing all of localForage because it won't let us simply import { config, getItem, setItem }
+lf.config({
   name: 'Kiln',
   storeName: 'kiln',
   description: 'Local browser store for Kiln, using localForage'
 });
 
-export { getItem, setItem }; // export these directly from localForage
+// export these directly from localForage
+export function getItem(key) {
+  return lf.getItem(key);
+}
+
+export function setItem(key, val) {
+  return lf.setItem(key, val);
+}
 
 /**
  * update counts of items in an array
@@ -18,7 +26,7 @@ export { getItem, setItem }; // export these directly from localForage
  * @return {Promise}
  */
 export function updateArray(key, itemToAdd, itemProp = 'name') {
-  return getItem(key)
+  return lf.getItem(key)
     .then((oldArray) => _.isNull(oldArray) ? [] : oldArray) // if the old array doesn't exist, create it
     .then((oldArray) => {
       // typecheck the stuff we're dealing with, so we can make assumptions below
@@ -41,7 +49,8 @@ export function updateArray(key, itemToAdd, itemProp = 'name') {
       }
       return oldArray;
     })
-    .then((newArray) => setItem(key, newArray))
+    .then((newArray) => _.reverse(_.sortBy(newArray, ['count', itemProp]))) // sort items before putting them back into the array (highest count first)
+    .then((newArray) => lf.setItem(key, newArray))
     .catch((e) => {
       console.error(`Cannot update array in local browser store! ${e.message}`);
       return Promise.reject(e);

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.2",
     "keycode": "^2.1.8",
+    "localforage": "^1.5.0",
     "lodash": "^4.14.2",
     "lodash-webpack-plugin": "^0.11.0",
     "mocha": "^3.2.0",

--- a/panes/add-component.vue
+++ b/panes/add-component.vue
@@ -50,9 +50,10 @@
             };
           });
 
-        return getItem(`${parentName}.${path}`).then((sortList) => {
-          const sortedComponents = _.unionWith(sortList, available, (val, otherVal) => {
-              return val.name === otherVal.id;
+        return getItem(`addcomponents:${parentName}.${path}`).then((sortList) => {
+          sortList = sortList || []; // initialize if it doesn't exist
+          const sortedComponents = _.intersectionWith(sortList, available, (val, otherVal) => {
+              return _.isObject(val) && _.isObject(otherVal) && val.name === otherVal.id;
             }),
             unsortedComponents = _.differenceWith(available, sortList, (val, otherVal) => {
               return val.id === otherVal.name;
@@ -73,7 +74,7 @@
           parentName = getComponentName(this.args.parentURI),
           path = this.args.path;
 
-        return updateArray(`${parentName}.${path}`, { name: id })
+        return updateArray(`addcomponents:${parentName}.${path}`, { name: id })
           .then(() => {
             return this.$store.dispatch('addComponents', {
               currentURI: this.args.currentURI,

--- a/panes/add-component.vue
+++ b/panes/add-component.vue
@@ -5,6 +5,8 @@
 <script>
   import _ from 'lodash';
   import label from '../lib/utils/label';
+  import { getItem, updateArray } from '../lib/utils/local';
+  import { getComponentName } from '../lib/utils/references';
   import filterableList from './filterable-list.vue';
 
   function openAllComponents() {
@@ -30,14 +32,6 @@
       return {};
     },
     computed: {
-      components() {
-        return _.map(this.args.available, (component) => {
-          return {
-            id: component,
-            title: label(component)
-          }; // todo: add fuzzy list
-        });
-      },
       fuzzyTitle() {
         return this.args.isFuzzy ? 'View All Components' : null;
       },
@@ -45,17 +39,50 @@
         return this.args.isFuzzy ? openAllComponents.bind(this) : null;
       }
     },
+    asyncComputed: {
+      components() {
+        const parentName = getComponentName(this.args.parentURI),
+          path = this.args.path,
+          available = _.map(this.args.available, (component) => {
+            return {
+              id: component,
+              title: label(component)
+            };
+          });
+
+        return getItem(`${parentName}.${path}`).then((sortList) => {
+          const sortedComponents = _.unionWith(sortList, available, (val, otherVal) => {
+              return val.name === otherVal.id;
+            }),
+            unsortedComponents = _.differenceWith(available, sortList, (val, otherVal) => {
+              return val.id === otherVal.name;
+            });
+
+          return _.map(sortedComponents, (component) => {
+            return {
+              id: component.name,
+              title: label(component.name)
+            };
+          }).concat(unsortedComponents);
+        });
+      }
+    },
     methods: {
       itemClick(id) {
-        const self = this;
+        const self = this,
+          parentName = getComponentName(this.args.parentURI),
+          path = this.args.path;
 
-        this.$store.dispatch('addComponents', {
-          currentURI: this.args.currentURI,
-          parentURI: this.args.parentURI,
-          path: this.args.path,
-          components: [{ name: id }]
-        })
-        .then(() => self.$nextTick(() => self.$store.dispatch('closePane')));
+        return updateArray(`${parentName}.${path}`, { name: id })
+          .then(() => {
+            return this.$store.dispatch('addComponents', {
+              currentURI: this.args.currentURI,
+              parentURI: this.args.parentURI,
+              path,
+              components: [{ name: id }]
+            })
+            .then(() => self.$nextTick(() => self.$store.dispatch('closePane')));
+          });
       }
     },
     components: {

--- a/panes/new-page.vue
+++ b/panes/new-page.vue
@@ -9,7 +9,10 @@
 
 
 <script>
+  import _ from 'lodash';
   import { getObject } from '../lib/core-data/api';
+  import { getItem, updateArray } from '../lib/utils/local';
+  import { props } from '../lib/utils/promises';
   import filterableList from './filterable-list.vue';
 
   export default {
@@ -19,14 +22,24 @@
     },
     asyncComputed: {
       pages() {
-        // Get the JSON response from the API passed in
-        return getObject(`${this.$store.state.site.prefix}/lists/new-pages`);
+        return props({
+          pages: getObject(`${this.$store.state.site.prefix}/lists/new-pages`),
+          sortList: getItem(`newpages:${this.$store.state.site.slug}`)
+        }).then(({ pages, sortList }) => {
+          sortList = sortList || [];
+          const sorted = _.intersectionBy(sortList, pages, 'id'),
+            unsorted = _.differenceBy(pages, sortList, 'id');
+
+          return sorted.concat(unsorted);
+        });
       }
     },
     methods: {
       itemClick(id, title) {
-        this.$store.commit('CREATE_PAGE', title);
-        this.$store.dispatch('createPage', id).then((url) => window.location.href = url);
+        return updateArray(`newpages:${this.$store.state.site.slug}`, { id, title }, 'id')
+          .then(() => this.$store.commit('CREATE_PAGE', title))
+          .then(() => this.$store.dispatch('createPage', id))
+          .then((url) => window.location.href = url);
       }
     },
     components: {


### PR DESCRIPTION
* adds and exposes `window.kiln.utils.local` service to get/set per-user settings via [`localForage`](https://github.com/localForage/localForage)
* placeholders for component lists now display the component's name (e.g. `Add Related Story`) in the button if only one type of component can be added
* all add-component panes are now auto-sorted by that user's usage (persisted to their browser) (in that specific component + field)
* default clay menu tab is now set per-user (persisted to their browser)
* default "Find on Page" tab is now set per-user (persisted to their browser)
* new page list is now auto-sorted by that user's usage (persisted to the browser) (specific for that site)
* any pane can set (+update) default tab by using the `saveTab` property