### PR TITLE
esc / clicking out unfocuses BEFORE unselecting

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -16,6 +16,7 @@ import conditionalFocus from './directives/conditional-focus';
 import hScrollDirective from './directives/horizontal-scroll';
 import utilsAPI from './lib/utils/api';
 import { hasClickedFocusableEl } from './lib/decorators/focus';
+import { hasClickedSelectableEl } from './lib/decorators/select';
 
 // TODO: Figure out saving/closing and reverting in panes
 import { CLOSE_PANE } from './lib/panes/mutationTypes';
@@ -128,7 +129,7 @@ document.addEventListener('DOMContentLoaded', function () {
       // note: isInvalidDrag is set when dragging to select text in a text/wysiwyg field,
       // since if you drag outside the form it'll trigger a click. ♥ browsers ♥
       store.dispatch('unfocus').catch(_.noop);
-    } else if (_.get(store, 'state.ui.currentSelection') && !window.kiln.isInvalidDrag) {
+    } else if (_.get(store, 'state.ui.currentSelection') && !hasClickedSelectableEl(e) && !window.kiln.isInvalidDrag) {
       // unselect if clicking out of the current selection (if user isn't trying to select text)
       // note: stopSelection is set in the 'select' action. see the comments there for details
       store.dispatch('unselect');

--- a/edit.js
+++ b/edit.js
@@ -123,16 +123,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // when clicks bubble up to the document, close the current form or pane / unselect components
   document.body.addEventListener('click', (e) => {
-    // unselect if clicking out of the current selection (if user isn't trying to select text)
-    // todo: handle panes where we want to stay selected
-    if (_.get(store, 'state.ui.currentSelection') && !window.kiln.isInvalidDrag) {
+    if (_.get(store, 'state.ui.currentFocus') && !hasClickedFocusableEl(e) && !window.kiln.isInvalidDrag) {
+      // always unfocus if clicking out of the current focus (and not directly clicking into another focusable el)
+      // note: isInvalidDrag is set when dragging to select text in a text/wysiwyg field,
+      // since if you drag outside the form it'll trigger a click. ♥ browsers ♥
+      store.dispatch('unfocus').catch(_.noop);
+    } else if (_.get(store, 'state.ui.currentSelection') && !window.kiln.isInvalidDrag) {
+      // unselect if clicking out of the current selection (if user isn't trying to select text)
       // note: stopSelection is set in the 'select' action. see the comments there for details
       store.dispatch('unselect');
-    }
-
-    // always unfocus if clicking out of the current focus (and not directly clicking into another focusable el)
-    if (_.get(store, 'state.ui.currentFocus') && !hasClickedFocusableEl(e) && !window.kiln.isInvalidDrag) {
-      store.dispatch('unfocus').catch(_.noop);
     }
 
     // unset isInvalidDrag after checking for unfocus / unselect
@@ -149,12 +148,12 @@ document.addEventListener('DOMContentLoaded', function () {
     const key = keycode(e);
 
     if (key === 'esc') {
-      if (_.get(store, 'state.ui.currentSelection')) {
-        store.dispatch('unselect');
-      }
-
+      // pressing esc when forms are focused unfocuses them but does NOT unselect the component.
+      // press esc again to unselect a component
       if (_.get(store, 'state.ui.currentFocus')) {
         store.dispatch('unfocus').catch(_.noop);
+      } else if (_.get(store, 'state.ui.currentSelection')) {
+        store.dispatch('unselect');
       }
 
       if (_.get(store, 'state.ui.currentPane')) {

--- a/lib/component-data/reactive-render.js
+++ b/lib/component-data/reactive-render.js
@@ -176,10 +176,27 @@ export function render(store, {uri, data, html, snapshot, paths}) {
   }
 
   return promise.then(() => {
-    if (isComponent(uri)) {
-      store.commit(RENDER_COMPONENT, { uri, data, html, snapshot, paths });
+    const currentSelected = _.get(store, 'state.ui.currentSelection.uri'),
+      newEl = currentSelected && find(`[${refAttr}="${currentSelected}"]`);
+
+    let selectionPromise;
+
+    // re-select the currently-selected component with a new element,
+    // just in case the currently-selected component was re-rendered
+    if (newEl) {
+      selectionPromise = store.dispatch('select', newEl);
     } else {
-      store.commit(RENDER_PAGE, { uri, data, html, snapshot, paths });
+      // if there's nothing selected, OR if the selected component was destroyed when
+      // re-rendering, make sure we trigger unselect
+      selectionPromise = store.dispatch('unselect');
     }
+
+    return selectionPromise.then(() => {
+      if (isComponent(uri)) {
+        store.commit(RENDER_COMPONENT, { uri, data, html, snapshot, paths });
+      } else {
+        store.commit(RENDER_PAGE, { uri, data, html, snapshot, paths });
+      }
+    });
   });
 }

--- a/lib/decorators/select.js
+++ b/lib/decorators/select.js
@@ -6,6 +6,7 @@ import { prependChild } from '@nymag/dom';
 import { refAttr, editAttr, refProp, componentListProp, componentProp, getComponentName } from '../utils/references';
 import { getComponentEl, getFieldEl } from '../utils/component-elements';
 import { getData, getSchema } from '../core-data/components';
+import { getEventPath } from '../utils/events';
 import selectorTpl from './selector.vue';
 
 const Selector = Vue.component('selector', selectorTpl),
@@ -93,4 +94,13 @@ export function addSelector(uri, el) {
     // add selector to the component el, BEHIND the component's children
     prependChild(el, selector.$el);
   }
+}
+
+/**
+ * determine if a user has clicked into a focusable element
+ * @param  {MouseEvent}  e
+ * @return {Boolean}
+ */
+export function hasClickedSelectableEl(e) {
+  return !!_.find(getEventPath(e), (node) => node.nodeType && node.nodeType === node.ELEMENT_NODE && node.hasAttribute(refAttr));
 }

--- a/lib/decorators/select.js
+++ b/lib/decorators/select.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import delegate from 'delegate';
 import store from '../core-data/store';
 import { prependChild } from '@nymag/dom';
-import { refAttr, editAttr, refProp, componentListProp, componentProp, getComponentName } from '../utils/references';
+import { refAttr, layoutAttr, editAttr, refProp, componentListProp, componentProp, getComponentName } from '../utils/references';
 import { getComponentEl, getFieldEl } from '../utils/component-elements';
 import { getData, getSchema } from '../core-data/components';
 import { getEventPath } from '../utils/events';
@@ -102,5 +102,5 @@ export function addSelector(uri, el) {
  * @return {Boolean}
  */
 export function hasClickedSelectableEl(e) {
-  return !!_.find(getEventPath(e), (node) => node.nodeType && node.nodeType === node.ELEMENT_NODE && node.hasAttribute(refAttr));
+  return !!_.find(getEventPath(e), (node) => node.nodeType && node.nodeType === node.ELEMENT_NODE && node.hasAttribute(refAttr) && !node.hasAttribute(layoutAttr));
 }

--- a/lib/decorators/selector.vue
+++ b/lib/decorators/selector.vue
@@ -299,6 +299,7 @@
     },
     watch: {
       isCurrentSelection(val) {
+        console.log(this.$options.componentEl === this.currentComponent.el, this.$options.componentEl, this.currentComponent.el)
         if (val) {
           // fires when selecting a component
           this.setSelectorPosition();

--- a/lib/decorators/selector.vue
+++ b/lib/decorators/selector.vue
@@ -299,7 +299,6 @@
     },
     watch: {
       isCurrentSelection(val) {
-        console.log(this.$options.componentEl === this.currentComponent.el, this.$options.componentEl, this.currentComponent.el)
         if (val) {
           // fires when selecting a component
           this.setSelectorPosition();


### PR DESCRIPTION
* back in old Kiln, clicking out (or hitting esc) would close the open form (unfocus) BEFORE unselecting the currently-selected component. this restores that functionality
* updates to selection when re-rendering: selected components that get re-rendered will still be selected afterwards. selected components that are removed when rendering will be unselected afterwards.
* better unselect handling when clicking around and selecting new components