### PR TITLE
remove server.js and non-handlebars support from kiln

### DIFF
--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -4,7 +4,7 @@ import { UPDATE_COMPONENT, REVERT_COMPONENT, REMOVE_COMPONENT, CURRENTLY_SAVING 
 import { getData, getSchema } from '../core-data/components';
 import { getComponentName, refProp, refAttr, layoutAttr, editAttr, componentListProp, componentProp } from '../utils/references';
 import { save as modelSave, render as modelRender } from './model';
-import { save, saveForHTML, getObject } from '../core-data/api';
+import { save, getObject } from '../core-data/api';
 import { add as addToQueue } from '../core-data/queue';
 import label from '../utils/label';
 import { getComponentEl, getParentComponent, getPrevComponent, isComponentInPage } from '../utils/component-elements';

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { removeElement, find } from '@nymag/dom';
 import { UPDATE_COMPONENT, REVERT_COMPONENT, REMOVE_COMPONENT, CURRENTLY_SAVING } from './mutationTypes';
-import { getData, getModel, getTemplate, getSchema } from '../core-data/components';
+import { getData, getSchema } from '../core-data/components';
 import { getComponentName, refProp, refAttr, layoutAttr, editAttr, componentListProp, componentProp } from '../utils/references';
 import { save as modelSave, render as modelRender } from './model';
 import { save, saveForHTML, getObject } from '../core-data/api';
@@ -41,7 +41,8 @@ function revertReject({ uri, data, html, snapshot, paths }) {
 
 /**
  * save data client-side and queue up api call for the server
- * note: this uses the components' model.js and handlebars template
+ * note: this uses the components' model.js (if it exists) and handlebars template
+ * note: server-side saving and/or re-rendering has been removed in kiln v4.x
  * @param  {string} uri
  * @param  {object} data
  * @param {object} oldData
@@ -83,96 +84,6 @@ function clientSave(uri, data, oldData, store, {eventID, snapshot, paths}) { // 
 }
 
 /**
- * save data server-side, but re-render client-side afterwards
- * note: this uses deprecated server.js, but renders with handlebars template
- * @param  {string} uri
- * @param  {object} data
- * @param {object} oldData
- * @param {object} store
- * @param {boolean} [snapshot] passed through to render
- * @param {array} paths
- * @return {Promise}
- */
-function serverSave(uri, data, oldData, store, {snapshot, paths}) { // eslint-disable-line
-  return addToQueue(save, [uri, data], 'save')
-    .then((res) => {
-      store.commit(UPDATE_COMPONENT, {uri, data: res});
-      return store.dispatch('render', { uri, data: res, snapshot, paths });
-    })
-    .catch((e) => {
-      store.commit(REVERT_COMPONENT, {uri, oldData});
-      logSaveError(uri, e, store);
-      return revertReject({ uri, data: oldData, snapshot, paths });
-    });
-}
-
-// istanbul ignore next
-
-/**
- * find the old html, for reverting if the server save fails
- * note: this will be removed when server-side rendering is eliminated,
- * as we can re-render handlebars templates client-side with old data when we need to revert
- * @param  {string} uri
- * @param  {string} layoutURI
- * @return {Element|DocumentFragment|Document}
- */
-function findOldHTML(uri, layoutURI) {
-  let el, headNode;
-
-  if (uri === layoutURI) {
-    return document; // return the whole document
-  } else {
-    // don't search for component until we know we're not looking at the layout
-    el = find(`[${refAttr}="${uri}"]`);
-
-    if (el) {
-      return el;
-    } else {
-      headNode = getComponentNode(uri);
-
-      if (headNode) {
-        return headNode;
-      } else {
-        console.error(`Cannot find "${uri}" in the DOM!`);
-      }
-    }
-  }
-}
-
-// server save an rerender is difficult to test and deprecated
-// istanbul ignore next
-
-/**
- * save data AND re-render server-side
- * note: this uses deprecated server.js and deprecated server-dependent template
- * @param  {string} uri
- * @param  {object} data
- * @param {object} oldData
- * @param {object} store
- * @param {boolean} [snapshot] passed through to render
- * @param {array} paths
- * @return {Promise}
- */
-function serverSaveAndRerender(uri, data, oldData, store, {snapshot, paths}) { // eslint-disable-line
-  const oldHTML = findOldHTML(uri, _.get(store, 'state.page.data.layout')).cloneNode(true);
-
-  return addToQueue(saveForHTML, [uri, data], 'save')
-    .then((html) => { // PUT to html before getting new data
-      return addToQueue(getObject, [uri], 'save')
-        .then((res) => {
-          store.commit(UPDATE_COMPONENT, {uri, data: res});
-          return store.dispatch('render', { uri, html, snapshot, paths });
-        })
-        // otherwise revert the data
-        .catch((e) => {
-          store.commit(REVERT_COMPONENT, {uri, oldData});
-          logSaveError(uri, e, store);
-          return revertReject({ uri, html: oldHTML, snapshot, paths });
-        });
-    });
-}
-
-/**
  * save a component's data and re-render
  * @param {object} store
  * @param  {string} uri
@@ -184,8 +95,6 @@ function serverSaveAndRerender(uri, data, oldData, store, {snapshot, paths}) { /
  */
 export function saveComponent(store, {uri, data, eventID, snapshot, prevData}) {
   const oldData = prevData || getData(uri),
-    model = getModel(uri),
-    template = getTemplate(uri),
     // figure out what properties we've changed
     // (note: this does a shallow comparison, not deep)
     paths = _.reduce(data, (result, val, key) => _.isEqual(val, oldData[key]) ? result : result.concat(key), []),
@@ -214,22 +123,8 @@ export function saveComponent(store, {uri, data, eventID, snapshot, prevData}) {
     store.dispatch('setFixedPoint');
   }
 
-  // istanbul ignore else
-  if (model && template) {
-    // component has both model and template, so we can do optimistic save + re-rendering
-    // note: only clientSave can publish to pubsub, so pass the event ID (if it exists)
-    promise = clientSave(uri, dataToSave, oldData, store, {eventID, snapshot, paths});
-  } else if (template) {
-    // component only has handlebars template, but still has a server.js.
-    // send data to the server, then re-render client-side with the returned data
-    promise = serverSave(uri, dataToSave, oldData, store, {snapshot, paths});
-    console.warn(`${getComponentName(uri)}/server.js is deprecated and will be removed in the next major release`);
-  } else {
-    // component has server dependencies for their logic (server.js) and template.
-    // send data to the server and get the new html back, then send an extra GET to update the store
-    promise = serverSaveAndRerender(uri, dataToSave, oldData, store, {snapshot, paths});
-    console.warn(`${getComponentName(uri)}/server.js and non-handlebars templates are deprecated and will be removed in the next major release`);
-  }
+  // do optimistic save + re-render, passing data through model.save and model.render if they exist
+  promise = clientSave(uri, dataToSave, oldData, store, {eventID, snapshot, paths});
 
   // set the updatedTime and user in the page every time we update a component
   // note: only set this for components in the page, not components in the layout

--- a/lib/component-data/actions.test.js
+++ b/lib/component-data/actions.test.js
@@ -52,9 +52,7 @@ describe('component-data actions', () => {
       });
     });
 
-    it('saves client-side components', () => {
-      components.getModel.returns(true);
-      components.getTemplate.returns(true);
+    it('saves components with/without model.js', () => {
       model.save.returns(Promise.resolve(data));
       queue.add.returns(Promise.resolve());
       model.render.returns(Promise.resolve(data));
@@ -64,18 +62,14 @@ describe('component-data actions', () => {
       });
     });
 
-    it('reverts client-side components if model.js errors', () => {
-      components.getModel.returns(true);
-      components.getTemplate.returns(true);
+    it('reverts components with model.js if model.js errors', () => {
       model.save.returns(Promise.reject(new Error('nope')));
       return fn(store, { uri, data, prevData }).catch(() => {
         expect(console.error).to.have.been.calledWith('Error saving component (foo): nope');
       });
     });
 
-    it('queues client-side save to server', () => {
-      components.getModel.returns(true);
-      components.getTemplate.returns(true);
+    it('queues component with model.js save to server', () => {
       model.save.returns(Promise.resolve(data));
       queue.add.returns(Promise.resolve());
       model.render.returns(Promise.resolve(data));
@@ -84,9 +78,7 @@ describe('component-data actions', () => {
       });
     });
 
-    it('reverts client-side components if queued save errors', () => {
-      components.getModel.returns(true);
-      components.getTemplate.returns(true);
+    it('reverts components with model.js if queued save errors', () => {
       model.save.returns(Promise.resolve(data));
       queue.add.returns(Promise.reject(new Error('nope')));
       model.render.returns(Promise.resolve(data));
@@ -96,29 +88,7 @@ describe('component-data actions', () => {
       });
     });
 
-    it('saves server-side components', () => {
-      components.getModel.returns(false);
-      components.getTemplate.returns(true);
-      queue.add.returns(Promise.resolve(data));
-      return fn(store, { uri, data, prevData }).then(() => {
-        expect(store.commit).to.have.been.calledWith('UPDATE_COMPONENT', { uri, data });
-        expect(store.commit).to.have.callCount(3); // currently saving true, update, currently saving false
-      });
-    });
-
-    it('reverts server-side components if queued save errors', () => {
-      components.getModel.returns(false);
-      components.getTemplate.returns(true);
-      queue.add.returns(Promise.reject(new Error('nope')));
-      return fn(store, { uri, data, prevData }).catch(() => {
-        expect(queue.add).to.have.been.calledWith(api.save, [uri, _.assign({}, data, prevData)], 'save');
-        expect(console.error).to.have.been.calledWith('Error saving component (foo): nope');
-      });
-    });
-
     it('does not take snapshots when undoing', () => {
-      components.getModel.returns(true);
-      components.getTemplate.returns(true);
       model.save.returns(Promise.resolve(data));
       queue.add.returns(Promise.resolve());
       model.render.returns(Promise.resolve(data));
@@ -129,8 +99,6 @@ describe('component-data actions', () => {
 
     it('updates page list when saving page-specific components', () => {
       componentElements.isComponentInPage.returns(true);
-      components.getModel.returns(true);
-      components.getTemplate.returns(true);
       model.save.returns(Promise.resolve(data));
       queue.add.returns(Promise.resolve());
       model.render.returns(Promise.resolve(data));

--- a/lib/component-data/model.js
+++ b/lib/component-data/model.js
@@ -33,6 +33,6 @@ export function render(uri, data) {
   if (_.isFunction(model.render)) {
     return timeout(attempt(() => model.render(uri, data, getLocals())), MODEL_RENDER_TIMEOUT);
   } else {
-    return Promise.resolve(_.assign(data));
+    return Promise.resolve(data);
   }
 }

--- a/lib/component-data/reactive-render.js
+++ b/lib/component-data/reactive-render.js
@@ -132,7 +132,8 @@ export function updateDOM(uri, newEl, paths) {
 }
 
 /**
- * replace and decorate a component/page that was rendered server-side
+ * replace and decorate a page that was rendered server-side
+ * note: as of kiln v4.x, components will ALWAYS be rendered client-side. only pages will pass in server-side html
  * @param  {string} uri
  * @param  {Element} html
  * @param {array} paths that have changed

--- a/lib/component-data/template.js
+++ b/lib/component-data/template.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import { create } from '@nymag/dom';
 import { getTemplate, getLocals, getData } from '../core-data/components';
 import { attempt } from '../utils/promises';
-import { refProp } from '../utils/references';
+import { refProp, getComponentName } from '../utils/references';
 
 /**
  * list deep objects in another object, used for composing deep components
@@ -58,6 +58,10 @@ export function compose(uri, data) {
 export function render(uri, data) {
   const tpl = getTemplate(uri),
     renderableData = _.assign({}, _.cloneDeep(data), { locals: getLocals() });
+
+  if (!tpl) {
+    throw new Error(`Component "${getComponentName(uri)}" has no client-side template!`);
+  }
 
   if (!renderableData[refProp]) {
     // if it doesn't have a reference property, add it for rendering

--- a/lib/core-data/api.js
+++ b/lib/core-data/api.js
@@ -293,24 +293,6 @@ export function save(uri, data, hooks) {
 }
 
 /**
- * save, expecting html to be returned from the server
- * todo: this is deprecated and will be removed when all components can re-render client-side
- * @param {string} uri
- * @param {object} data
- * @returns {Promise}
- */
-export function saveForHTML(uri, data) {
-  assertUri(uri);
-
-  // note: no hooks, since this should only be used for legacy (server-side) components
-  return send(addJsonHeader({
-    method: 'PUT',
-    url: uri + htmlExt + editComponentExt,
-    body: JSON.stringify(data)
-  })).then(expectHTMLResult(uri));
-}
-
-/**
  * @param {string} uri
  * @param {object} data
  * @returns {Promise}

--- a/lib/core-data/api.test.js
+++ b/lib/core-data/api.test.js
@@ -206,31 +206,6 @@ describe('api', () => {
     });
   });
 
-  describe('saveForHTML (deprecated)', () => {
-    const fn = lib.saveForHTML;
-
-    createUriBlockTests(fn);
-
-    it('returns html', () => {
-      respond('<span>ok</span>');
-      return fn(uri).then((res) => {
-        expect(res.getAttribute(refAttr)).to.equal(uri);
-      });
-    });
-
-    it('handles full document', () => {
-      respond('<!DOCTYPE html><html><head></head><body><div>ok</div></body></html>');
-      return fn(uri).then((res) => {
-        expect(res.documentElement.getAttribute(layoutAttr)).to.equal(uri);
-      });
-    });
-
-    it('throws on bad data', (done) => {
-      respond(new Error('bad data'));
-      fn('foo').then(() => done('should throw')).catch(() => done());
-    });
-  });
-
   describe('saveText', () => {
     const fn = lib.saveText;
 

--- a/lib/page-state/actions.js
+++ b/lib/page-state/actions.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { postJSON } from '../core-data/api';
 import { UPDATE_PAGE_STATE } from './mutationTypes';
-import { searchRoute } from '../utils/references';
+import { searchRoute, replaceVersion } from '../utils/references';
 
 const postPageList = _.debounce(postJSON, 500); // only update the page list every 500ms
 
@@ -67,7 +67,7 @@ export function getListData(store, { uri, prefix }) {
       size: 1,
       query: {
         term: {
-          uri // match page uri
+          uri: replaceVersion(uri) // match page uri (removing @published or @scheduled)
         }
       }
     }

--- a/lib/utils/shift-clay.js
+++ b/lib/utils/shift-clay.js
@@ -26,7 +26,7 @@ export default function addListeners() {
   document.addEventListener('keydown', function (e) {
     const key = keycode(e);
 
-    if (includes(['c', 'l', 'a', 'y'], key) && e.shiftKey === true) {
+    if (_.includes(['c', 'l', 'a', 'y'], key) && e.shiftKey === true) {
       secretKilnKey += key;
     } else {
       // if we hit any other character, reset the key
@@ -36,7 +36,7 @@ export default function addListeners() {
     // check secret key
     if (secretKilnKey === 'clay') {
       showLogo();
-    } else if (secretKilnKey.length > 4 && includes(secretKilnKey, 'clay')) {
+    } else if (secretKilnKey.length > 4 && _.includes(secretKilnKey, 'clay')) {
       toggleEdit();
     } else if (secretKilnKey.length > 4) {
       // if we hit more than four characters, reset the key

--- a/lib/utils/shift-clay.js
+++ b/lib/utils/shift-clay.js
@@ -1,4 +1,4 @@
-import { includes } from 'lodash';
+import _ from 'lodash';
 import keycode from 'keycode';
 import toggleEdit from './toggle-edit';
 


### PR DESCRIPTION
* BREAKING CHANGE for kiln v4.0.0 (closes #890)
* removes support for `serverSave` and `serverSaveAndRerender`
* removes assumption that components _need_ a `model.js` in order to do client-side optimistic saving + re-rendering (no more passthrough `model.js` files!)
* small bugfix for displaying page state correctly when viewing a published page
* small bugfix to optimize `kiln-view-public.js` rendering size (28k → 12k unminified)