### PR TITLE
add duplicate components

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -17,6 +17,7 @@ import hScrollDirective from './directives/horizontal-scroll';
 import utilsAPI from './lib/utils/api';
 import { hasClickedFocusableEl } from './lib/decorators/focus';
 import { hasClickedSelectableEl } from './lib/decorators/select';
+import { META_PRESS, META_UNPRESS } from './lib/preloader/mutationTypes';
 
 // TODO: Figure out saving/closing and reverting in panes
 import { CLOSE_PANE } from './lib/panes/mutationTypes';
@@ -160,6 +161,19 @@ document.addEventListener('DOMContentLoaded', function () {
       if (_.get(store, 'state.ui.currentPane')) {
         store.commit(CLOSE_PANE, null);
       }
+    } else if (key === 'ctrl' || key === 'left command') {
+      // pressing and holding meta key will unlock additional functionality,
+      // such as the ability to duplicate the selected component
+      store.commit(META_PRESS);
+    }
+  });
+
+  // when user stops pressing a key, toggle this off
+  document.body.addEventListener('keyup', (e) => {
+    const key = keycode(e);
+
+    if (key === 'ctrl' || key === 'left command') {
+      store.commit(META_UNPRESS);
     }
   });
 

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -410,7 +410,7 @@ export function openAddComponents(store, { currentURI, parentURI, path }) {
       parentURI,
       path: path,
       components: [{ name: _.head(available) }]
-    });
+    }).then((newEl) => store.dispatch('select', newEl));
   } else {
     // open the add components pane
     return store.dispatch('openPane', {

--- a/lib/decorators/selector.vue
+++ b/lib/decorators/selector.vue
@@ -199,15 +199,19 @@
 
       .left &.quick-bar-add,
       .left &.quick-bar-replace,
+      .left &.quick-bar-dupe,
       .right &.quick-bar-add,
-      .right &.quick-bar-replace {
+      .right &.quick-bar-replace,
+      .right &.quick-bar-dupe {
         border-top: $thin-border;
       }
 
       .top &.quick-bar-add,
       .top &.quick-bar-replace,
+      .top &.quick-bar-dupe,
       .bottom &.quick-bar-add,
-      .bottom &.quick-bar-replace {
+      .bottom &.quick-bar-replace,
+      .bottom &.quick-bar-dupe {
         border-left: $thin-border;
       }
     }
@@ -221,6 +225,7 @@
         <button v-if="hasSettings" class="quick-bar-button quick-bar-settings" title="Component Settings" @click.stop="openSettings"><icon name="settings"></icon></button>
         <button v-if="hasRemove" class="quick-bar-button quick-bar-remove" title="Remove Component" @click.stop="removeComponent"><icon name="delete"></icon></button>
         <button v-if="hasAddComponent" class="quick-bar-button quick-bar-add" title="Add Component" @click.stop="openAddComponentPane"><icon name="add-icon"></icon></button>
+        <button v-if="hasDuplicateComponent" class="quick-bar-button quick-bar-dupe" title="Duplicate Component" @click.stop="duplicateComponent"><icon name="plusone"></icon></button>
         <button v-if="hasReplaceComponent" class="quick-bar-button quick-bar-replace" title="Replace Component"><icon name="replace-icon"></icon></button>
       </div>
     </aside>
@@ -233,6 +238,7 @@
   import store from '../core-data/store';
   import { getData, getSchema } from '../core-data/components';
   import { getSettingsFields } from '../core-data/groups';
+  import { getComponentName } from '../utils/references';
   import icon from '../utils/icon.vue';
 
   /**
@@ -285,7 +291,10 @@
         return this.parentField && this.parentField.type === 'list' && this.parentField.isEditable;
       },
       hasAddComponent() {
-        return this.parentField && this.parentField.type === 'list' && this.parentField.isEditable;
+        return this.parentField && this.parentField.type === 'list' && this.parentField.isEditable && !_.get(store, 'state.ui.metaKey');
+      },
+      hasDuplicateComponent() {
+        return this.parentField && this.parentField.type === 'list' && this.parentField.isEditable && _.get(store, 'state.ui.metaKey');
       },
       hasReplaceComponent() {
         return this.parentField && this.parentField.type === 'prop' && this.parentField.isEditable;
@@ -321,6 +330,16 @@
           parentURI: this.currentComponent.parentURI,
           path: this.parentField.path
         });
+      },
+      duplicateComponent() {
+        const name = getComponentName(this.uri);
+
+        return store.dispatch('addComponents', {
+          currentURI: this.uri,
+          parentURI: this.currentComponent.parentURI,
+          path: this.parentField.path,
+          components: [{ name }]
+        }).then((newEl) => store.dispatch('select', newEl));
       },
       removeComponent() {
         const el = this.currentComponent.el;

--- a/lib/preloader/default-state.js
+++ b/lib/preloader/default-state.js
@@ -17,7 +17,8 @@ export default {
     currentStatus: null, // gets { type, message, action, isPermanent }
     currentProgress: 0, // gets boolean
     progressColor: null, // gets string
-    currentlySaving: false // don't focus components while forms are saving
+    currentlySaving: false, // don't focus components while forms are saving
+    metaKey: false // set to true when meta key is pressed, enables additional functionality in kiln
   },
   // publishing validation
   validation: {

--- a/lib/preloader/mutationTypes.js
+++ b/lib/preloader/mutationTypes.js
@@ -5,3 +5,5 @@ export const LOADING_SUCCESS = 'LOADING_SUCCESS'; // used by view + edit
 export const PRELOAD_SITE = 'PRELOAD_SITE'; // only used by view
 export const PRELOAD_ALL_SITES = 'PRELOAD_ALL_SITES'; // only used by view
 export const PRELOAD_USER = 'PRELOAD_USER'; // only used by view
+export const META_PRESS = 'META_PRESS'; // only used by edit
+export const META_UNPRESS = 'META_UNPRESS'; // only used by edit

--- a/lib/preloader/mutations.js
+++ b/lib/preloader/mutations.js
@@ -1,11 +1,19 @@
-import { assign } from 'lodash';
-import { PRELOAD_PENDING, PRELOAD_SUCCESS, LOADING_SUCCESS, PRELOAD_SITE, PRELOAD_ALL_SITES, PRELOAD_USER } from './mutationTypes';
+import _ from 'lodash';
+import { PRELOAD_PENDING, PRELOAD_SUCCESS, LOADING_SUCCESS, PRELOAD_SITE, PRELOAD_ALL_SITES, PRELOAD_USER, META_PRESS, META_UNPRESS } from './mutationTypes';
 
 export default {
-  [PRELOAD_PENDING]: (state) => assign(state, { isLoading: true }),
-  [PRELOAD_SUCCESS]: (state, payload) => assign(state, payload, { isLoading: false }),
-  [LOADING_SUCCESS]: (state) => assign(state, { isLoading: false }),
-  [PRELOAD_SITE]: (state, site) => assign(state, { site }),
-  [PRELOAD_ALL_SITES]: (state, sites) => assign(state, { allSites: sites }),
-  [PRELOAD_USER]: (state, user) => assign(state, { user })
+  [PRELOAD_PENDING]: (state) => _.assign(state, { isLoading: true }),
+  [PRELOAD_SUCCESS]: (state, payload) => _.assign(state, payload, { isLoading: false }),
+  [LOADING_SUCCESS]: (state) => _.assign(state, { isLoading: false }),
+  [PRELOAD_SITE]: (state, site) => _.assign(state, { site }),
+  [PRELOAD_ALL_SITES]: (state, sites) => _.assign(state, { allSites: sites }),
+  [PRELOAD_USER]: (state, user) => _.assign(state, { user }),
+  [META_PRESS]: (state) => {
+    state.ui.metaKey = true;
+    return state;
+  },
+  [META_UNPRESS]: (state) => {
+    state.ui.metaKey = false;
+    return state;
+  }
 };

--- a/lib/toolbar/selector.vue
+++ b/lib/toolbar/selector.vue
@@ -45,6 +45,7 @@
       flex: 0 0 auto;
 
       &.expanded-selector-add,
+      &.expanded-selector-dupe,
       &.expanded-selector-replace {
         border-left: 1px solid $selector-divider;
       }
@@ -64,6 +65,7 @@
       <component v-for="button in customButtons" :is="button"></component>
       <button v-if="hasRemove" class="expanded-selector-button expanded-selector-remove" title="Remove Component" @click="removeComponent"><icon name="delete"></icon></button>
       <button v-if="hasAddComponent" class="expanded-selector-button expanded-selector-add" title="Add Component" @click.stop="openAddComponentPane"><icon name="add-icon"></icon></button>
+      <button v-if="hasDuplicateComponent" class="expanded-selector-button expanded-selector-dupe" title="Duplicate Component" @click.stop="duplicateComponent"><icon name="plusone"></icon></button>
       <button v-if="hasReplaceComponent" class="expanded-selector-button expanded-selector-replace" title="Replace Component"><icon name="replace-icon"></icon></button>
     </div>
   </transition>
@@ -108,7 +110,10 @@
         return this.parentField && this.parentField.type === 'list' && this.parentField.isEditable;
       },
       hasAddComponent() {
-        return this.parentField && this.parentField.type === 'list' && this.parentField.isEditable;
+        return this.parentField && this.parentField.type === 'list' && this.parentField.isEditable && !_.get(this.$store, 'state.ui.metaKey');
+      },
+      hasDuplicateComponent() {
+        return this.parentField && this.parentField.type === 'list' && this.parentField.isEditable && _.get(this.$store, 'state.ui.metaKey');
       },
       hasReplaceComponent() {
         return this.parentField && this.parentField.type === 'prop' && this.parentField.isEditable;
@@ -124,6 +129,16 @@
           parentURI: this.currentComponent.parentURI,
           path: this.parentField.path
         });
+      },
+      duplicateComponent() {
+        const name = getComponentName(this.uri);
+
+        return this.$store.dispatch('addComponents', {
+          currentURI: this.uri,
+          parentURI: this.currentComponent.parentURI,
+          path: this.parentField.path,
+          components: [{ name }]
+        }).then((newEl) => this.$store.dispatch('select', newEl));
       },
       removeComponent() {
         const el = this.currentComponent.el;

--- a/media/plusone.svg
+++ b/media/plusone.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="13" viewBox="0 0 16 13"><path fill="#78ADCC" d="M6,3 L4,3 L4,7 L0,7 L0,9 L4,9 L4,13 L6,13 L6,9 L10,9 L10,7 L6,7 L6,3 Z M11,1.08 L11,2.9 L13.7777778,2.4 L13.7777778,13 L16,13 L16,0 L11,1.08 Z"/></svg>

--- a/panes/add-component.vue
+++ b/panes/add-component.vue
@@ -82,6 +82,7 @@
               path,
               components: [{ name: id }]
             })
+            .then((newEl) => self.$store.dispatch('select', newEl))
             .then(() => self.$nextTick(() => self.$store.dispatch('closePane')));
           });
       }


### PR DESCRIPTION
* press ctrl or left command (on osx) to enable `state.ui.metaKey`, which we can use for a lot of additional functionality
* mini selector and expanded selector switch to "Duplicate Component" when meta key is pressed
* clicking "Duplicate Component" creates a new component of the same type as the currently selected, right after the selected component
* updated add components pane, add component (when only one type is allowed), and duplicate component to _select_ the newly added component afterwards

![8be3bd90-2712-4f99-ba28-a84c58c6b36a-608-0000b7c49399f33e](https://user-images.githubusercontent.com/447522/29832735-214c5c22-8cb7-11e7-8a28-78fba323b235.gif)

![51bb30a5-6bc3-44d8-9de3-17bf44df03fc-608-0000b7cf2605f7c2](https://user-images.githubusercontent.com/447522/29832740-2488d0f0-8cb7-11e7-9efc-fcd393374414.gif)
