### PR TITLE
complex list

### DIFF
--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -157,8 +157,8 @@ Append a magic button to an input.
 
 ## Arguments
 
-* **field** _(optional)_ a field to grab the value from
-* **component** _(optional)_ a name of a component to grab the component ref from
+* **field** _(optional)_ a field to grab the value from (in the current complex list, form, or component)
+* **component** _(optional)_ a name of a component to grab the component ref/uri from
 * **transform** _(optional)_ a transform to apply to the grabbed value
 * **transformArg** _(optional)_ an argument to pass through to the transform
 * **store** _(optional)_ to grab data from the client-side store

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -80,7 +80,7 @@ A component which represents a single item in the `complex-list` component. Func
 
 # complex-list
 
-An array of objects with arbitrary properties. Each property may have any behaviors a field is allowed to have, including custom behaviors. Complex-list is similar to Angular's _transcluded directives_ or Advanced Custom Fields' _repeater field_, in that each item in the list is treated like a separate field. Items may also have `_label`, but may not have `_display` or `_placeholder`.
+An array of objects with arbitrary properties. Each property may have any behaviors a field is allowed to have, including custom behaviors. Complex-list is similar to [Angular's _transcluded directives_](https://nulogy.com/who-we-are/company-blog/articles/transclusion-in-angular/) or [Advanced Custom Fields' _repeater field_](https://www.advancedcustomfields.com/add-ons/repeater-field/), in that each item in the list is treated like a separate field. Items may also have `_label`, but may not have `_display` or `_placeholder`.
 
 ## Arguments
 

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -74,6 +74,26 @@ The mode of the editor sets syntax highlighting, linting, and other functionalit
 
 _Note:_ We will add more supported modes as we find use cases for them. See [this link](http://codemirror.net/mode/) for the full list of modes supported in codemirror.
 
+# complex-list-item
+
+A component which represents a single item in the `complex-list` component. Functionality is derived from its parent. Behaves similar to a field, as it transcludes other behaviors via the same "slot" mechanism that field uses.
+
+# complex-list
+
+An array of objects with arbitrary properties. Each property may have any behaviors a field is allowed to have, including custom behaviors. Complex-list is similar to Angular's _transcluded directives_ or Advanced Custom Fields' _repeater field_, in that each item in the list is treated like a separate field. Items may also have `_label`, but may not have `_display` or `_placeholder`.
+
+## Arguments
+
+* **props** an array of objects, represending the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as any `_label` or behaviors it needs.
+
+## Usage
+
+* When a complex-list is empty, it will display a plus button, styled similarly to components' mini-selector.
+* Items can be added by clicking the plus button.
+* When a complex-list is _not_ empty, the focused item will have a mini-selector below it, with add and remove buttons
+* Items can be removed by clicking the trashcan button.
+* Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list.
+
 # conditional-required
 
 Appends "required (field name)" to a field's label, to mark that field as required (based on another field).

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -100,7 +100,7 @@ Appends "required (field name)" to a field's label, to mark that field as requir
 
 ## Arguments
 
-* **field** to compare against
+* **field** to compare against (inside complex-list item, current form, or current component)
 * **operator** _(optional)_ to use for the comparison
 * **value** _(optional)_ to compare the field against
 
@@ -121,7 +121,7 @@ Operators:
 * `truthy` (only checks field data, no value needed)
 * `falsy` (only checks field data, no value needed)
 
-_Note:_ You can compare against deep fields (like checkbox-group) by using dot-separated paths, e.g. `featureTypes.New York Magazine Story`
+_Note:_ You can compare against deep fields (like checkbox-group) by using dot-separated paths, e.g. `featureTypes.New York Magazine Story` (don't worry about spaces!)
 
 # description
 
@@ -284,7 +284,7 @@ Conditionally shows/hides a field based on another field
 
 ## Arguments
 
-* **field** and/or **sites** to compare against
+* **field** and/or **sites** to compare against (inside complex-list item, current form, or current component)
 * **operator** _(optional)_ to use for the comparison
 * **value** _(optional)_ to compare the field against
 

--- a/behaviors/complex-list-item.vue
+++ b/behaviors/complex-list-item.vue
@@ -1,0 +1,155 @@
+<docs>
+  # complex-list-item
+
+  A component which represents a single item in the `complex-list` component. Functionality is derived from its parent. Behaves similar to a field, as it transcludes other behaviors via the same "slot" mechanism that field uses.
+</docs>
+
+<style lang="sass">
+  @import '../styleguide/forms';
+  @import '../styleguide/colors';
+  @import '../styleguide/buttons';
+
+  .complex-list-item {
+    @include form();
+
+    border-bottom: 1px solid $selector-divider;
+    padding-bottom: 20px;
+    z-index: auto;
+  }
+
+  .complex-list-item:first-of-type {
+    border-top: 1px solid $selector-divider;
+    padding-top: 20px;
+  }
+
+  .complex-list-item + .complex-list-item {
+    margin-top: 20px;
+  }
+
+  .complex-list-item-selector {
+    border-top: 3px solid $mini-selector-color;
+    left: 0;
+    position: absolute;
+    top: 100%;
+    width: 100%;
+    z-index: 2;
+  }
+
+  .complex-list-item-selector-menu {
+    align-items: center;
+    background: $selector-bg;
+    border: 1px solid $mini-selector-color;
+    border-top: none;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    position: absolute;
+    top: 0;
+    width: auto;
+
+    &:before {
+      border: 1px solid $mini-selector-border-padding;
+      border-top: none;
+      content: '';
+      height: calc(100% + 2px);
+      left: -2px;
+      position: absolute;
+      top: 0;
+      width: calc(100% + 4px);
+    }
+
+    &:after {
+      border-top: 1px solid $mini-selector-border-padding;
+      content: '';
+      height: 100%;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: calc(100% + 2px);
+    }
+  }
+
+  .complex-list-item-selector-button {
+    @include icon-button($mini-selector-color, 18px);
+
+    // note: 46px is width minus border
+    flex: 0 0 46px;
+    padding: 14px;
+    z-index: 1;
+
+    &.complex-list-item-selector-add {
+      border-left: 1px solid $mini-selector-border-padding;
+    }
+  }
+</style>
+
+<template>
+  <li class="complex-list-item" :ref="name">
+    <field v-for="(field, fieldIndex) in fieldNames" :class="{ 'first-field': fieldIndex === 0 }" :name="name + '.' + field" :data="fields[field]" :schema="fieldSchemas[field]"></field>
+    <transition name="selector-fade">
+      <aside v-show="isCurrentItem" class="complex-list-item-selector" @click.stop>
+        <div class="complex-list-item-selector-menu">
+          <button class="complex-list-item-selector-button complex-list-item-selector-remove" title="Remove Item" @click.stop.prevent="removeItem(index)"><icon name="delete"></icon></button>
+          <button class="complex-list-item-selector-button complex-list-item-selector-add" title="Add Item" @click.stop.prevent="addItem(index)"><icon name="add-icon"></icon></button>
+        </div>
+      </aside>
+    </transition>
+  </li>
+</template>
+
+<script>
+  import _ from 'lodash';
+  import field from '../lib/forms/field.vue';
+  import icon from '../lib/utils/icon.vue';
+
+  export default {
+    props: [
+      'index',
+      'name',
+      'data',
+      'schema',
+      'addItem',
+      'removeItem'
+    ],
+    data() {
+      return {
+        isCurrentItem: false
+      };
+    },
+    computed: {
+      fieldNames() {
+        return _.map(this.schema, (field) => field.prop); // names for all the fields in this item
+      },
+      fields() {
+        return this.data; // data for all the fields in this item
+      },
+      fieldSchemas() {
+        return _.reduce(this.schema, (obj, field) => {
+          const fieldName = field.prop,
+            fieldSchema = _.omit(field, ['prop']);
+
+          obj[fieldName] = fieldSchema;
+          return obj;
+        }, {});
+      }
+    },
+    methods: {
+      focusChanged() {
+        const activeEl = document.activeElement,
+          el = this.$el;
+
+        this.isCurrentItem = el.contains(activeEl);
+      }
+    },
+    mounted() {
+      document.addEventListener('focusin', this.focusChanged)
+    },
+    beforeDestroy() {
+      document.removeEventListener('focusin', this.focusChanged)
+    },
+    components: {
+      field,
+      icon
+    }
+  };
+</script>

--- a/behaviors/complex-list-item.vue
+++ b/behaviors/complex-list-item.vue
@@ -89,8 +89,8 @@
     <transition name="selector-fade">
       <aside v-show="isCurrentItem" class="complex-list-item-selector" @click.stop>
         <div class="complex-list-item-selector-menu">
-          <button class="complex-list-item-selector-button complex-list-item-selector-remove" title="Remove Item" @click.stop.prevent="removeItem(index)"><icon name="delete"></icon></button>
-          <button class="complex-list-item-selector-button complex-list-item-selector-add" title="Add Item" @click.stop.prevent="addItem(index)"><icon name="add-icon"></icon></button>
+          <button type="button" class="complex-list-item-selector-button complex-list-item-selector-remove" title="Remove Item" @click.stop.prevent="removeItem(index)"><icon name="delete"></icon></button>
+          <button type="button" class="complex-list-item-selector-button complex-list-item-selector-add" title="Add Item" @click.stop.prevent="addItem(index)"><icon name="add-icon"></icon></button>
         </div>
       </aside>
     </transition>

--- a/behaviors/complex-list.vue
+++ b/behaviors/complex-list.vue
@@ -95,7 +95,13 @@
         this.$store.commit(UPDATE_FORMDATA, { path: this.name, data: this.items });
       },
       addItem(index) {
-        this.items.splice(index + 1, 0, {}); // add new item after the specified index
+        const props = _.map(_.get(this.args, 'props', []), (item) => item.prop),
+          newObj = _.reduce(props, (obj, prop) => {
+            obj[prop] = null;
+            return obj;
+          }, {});
+
+        this.items.splice(index + 1, 0, newObj); // add new item after the specified index
         this.updateFormData(); // save the data
       },
       removeItem(index) {

--- a/behaviors/complex-list.vue
+++ b/behaviors/complex-list.vue
@@ -59,18 +59,18 @@
 
 <template>
   <div class="complex-list">
-    <ul class="complex-list-items">
+    <transition-group name="selector-fade" tag="ul" class="complex-list-items">
       <item v-for="(item, index) in items"
         :index="index"
         :name="name + '.' + index"
         :data="item"
         :schema="args.props"
-        key="index"
+        :key="index"
         :addItem="addItem"
         :removeItem="removeItem">
       </item>
-      <button v-if="items.length === 0" class="complex-list-add" title="Add Item" @click.stop.prevent="addItem(-1)"><icon name="add-icon" class="complex-list-add-icon"></icon><span class="complex-list-add-text">Add Items</span></button>
-    </ul>
+    </transition-group>
+    <button v-if="items.length === 0" class="complex-list-add" title="Add Item" @click.stop.prevent="addItem(-1)"><icon name="add-icon" class="complex-list-add-icon"></icon><span class="complex-list-add-text">Add Items</span></button>
   </div>
 </template>
 

--- a/behaviors/complex-list.vue
+++ b/behaviors/complex-list.vue
@@ -1,7 +1,7 @@
 <docs>
   # complex-list
 
-  An array of objects with arbitrary properties. Each property may have any behaviors a field is allowed to have, including custom behaviors. Complex-list is similar to Angular's _transcluded directives_ or Advanced Custom Fields' _repeater field_, in that each item in the list is treated like a separate field. Items may also have `_label`, but may not have `_display` or `_placeholder`.
+  An array of objects with arbitrary properties. Each property may have any behaviors a field is allowed to have, including custom behaviors. Complex-list is similar to [Angular's _transcluded directives_](https://nulogy.com/who-we-are/company-blog/articles/transclusion-in-angular/) or [Advanced Custom Fields' _repeater field_](https://www.advancedcustomfields.com/add-ons/repeater-field/), in that each item in the list is treated like a separate field. Items may also have `_label`, but may not have `_display` or `_placeholder`.
 
   ## Arguments
 

--- a/behaviors/complex-list.vue
+++ b/behaviors/complex-list.vue
@@ -1,0 +1,112 @@
+<docs>
+  # complex-list
+
+  An array of objects with arbitrary properties. Each property may have any behaviors a field is allowed to have, including custom behaviors. Complex-list is similar to Angular's _transcluded directives_ or Advanced Custom Fields' _repeater field_, in that each item in the list is treated like a separate field. Items may also have `_label`, but may not have `_display` or `_placeholder`.
+
+  ## Arguments
+
+  * **props** an array of objects, represending the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as any `_label` or behaviors it needs.
+
+  ## Usage
+
+  * When a complex-list is empty, it will display a plus button, styled similarly to components' mini-selector.
+  * Items can be added by clicking the plus button.
+  * When a complex-list is _not_ empty, the focused item will have a mini-selector below it, with add and remove buttons
+  * Items can be removed by clicking the trashcan button.
+  * Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list.
+</docs>
+
+<style lang="sass">
+  @import '../styleguide/buttons';
+  @import '../styleguide/colors';
+  @import '../styleguide/typography';
+
+  .complex-list {
+    margin-top: 10px;
+    width: 100%;
+  }
+
+  .complex-list-items {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .complex-list-add {
+    @include button-outlined($mini-selector-color, $mini-selector-border-padding);
+
+    align-items: center;
+    display: flex;
+    flex-flow: row nowrap;
+    height: auto;
+    justify-content: center;
+  }
+
+  .complex-list-add-icon {
+    @include icon-button($mini-selector-color, 18px);
+
+    padding: 0;
+  }
+
+  .complex-list-add-text {
+    @include input-label();
+
+    color: $mini-selector-color;
+    line-height: 13px;
+    margin-left: 10px;
+  }
+</style>
+
+<template>
+  <div class="complex-list">
+    <ul class="complex-list-items">
+      <item v-for="(item, index) in items"
+        :index="index"
+        :name="name + '.' + index"
+        :data="item"
+        :schema="args.props"
+        key="index"
+        :addItem="addItem"
+        :removeItem="removeItem">
+      </item>
+      <button v-if="items.length === 0" class="complex-list-add" title="Add Item" @click.stop.prevent="addItem(-1)"><icon name="add-icon" class="complex-list-add-icon"></icon><span class="complex-list-add-text">Add Items</span></button>
+    </ul>
+  </div>
+</template>
+
+<script>
+  import _ from 'lodash';
+  import item from './complex-list-item.vue';
+  import icon from '../lib/utils/icon.vue';
+  import { UPDATE_FORMDATA } from '../lib/forms/mutationTypes';
+
+  export default {
+    props: ['name', 'data', 'schema', 'args'],
+    data() {
+      return {};
+    },
+    computed: {
+      items() {
+        return _.isArray(this.data) ? _.cloneDeep(this.data) : [];
+      }
+    },
+    methods: {
+      updateFormData() {
+        this.$store.commit(UPDATE_FORMDATA, { path: this.name, data: this.items });
+      },
+      addItem(index) {
+        this.items.splice(index + 1, 0, {}); // add new item after the specified index
+        this.updateFormData(); // save the data
+      },
+      removeItem(index) {
+        this.items.splice(index, 1); // remove item at the specified index
+        this.updateFormData();
+      },
+    },
+    components: {
+      item,
+      icon
+    },
+    slot: 'main'
+  };
+</script>

--- a/behaviors/conditional-required.vue
+++ b/behaviors/conditional-required.vue
@@ -5,7 +5,7 @@
 
   ## Arguments
 
-  * **field** to compare against
+  * **field** to compare against (inside complex-list item, current form, or current component)
   * **operator** _(optional)_ to use for the comparison
   * **value** _(optional)_ to compare the field against
 
@@ -26,7 +26,7 @@
   * `truthy` (only checks field data, no value needed)
   * `falsy` (only checks field data, no value needed)
 
-  _Note:_ You can compare against deep fields (like checkbox-group) by using dot-separated paths, e.g. `featureTypes.New York Magazine Story`
+  _Note:_ You can compare against deep fields (like checkbox-group) by using dot-separated paths, e.g. `featureTypes.New York Magazine Story` (don't worry about spaces!)
 </docs>
 
 <style lang="sass">
@@ -48,6 +48,7 @@
 
 <script>
   import _ from 'lodash';
+  import { getFieldData } from '../lib/forms/field-helpers';
   import { fieldProp, behaviorKey } from '../lib/utils/references';
   import { expand, convertNativeTagName } from '../lib/forms/behaviors';
   import { getSchema, getData } from '../lib/core-data/components';
@@ -67,12 +68,8 @@
         const field = this.args.field,
           operator = this.args.operator,
           value = this.args.value,
-          // compare against the field if it's in the current form,
-          // but fall back to comparing against data in the component
-          // (this allows comparing to fields that might not be in the same form)
           uri = _.get(this.$store, 'state.ui.currentForm.uri'),
-          fieldPath = _.reduce(field.split('.'), (str, fieldPart) => str += `.${fieldPart}`, 'state.ui.currentForm.fields'),
-          data = _.get(this.$store, fieldPath) || getData(uri, field);
+          data = getFieldData(this.$store, field, this.name, uri);
 
         return compare({ data, operator, value });
       },

--- a/behaviors/lock.vue
+++ b/behaviors/lock.vue
@@ -63,7 +63,7 @@
 </style>
 
 <template>
-  <button class="lock-button" :class="{ unlocked: !locked }" @click.stop.prevent="toggleLock">
+  <button type="button" class="lock-button" :class="{ unlocked: !locked }" @click.stop.prevent="toggleLock">
     <icon name="locked" class="locked"></icon>
     <icon name="unlocked" class="unlocked"></icon>
   </button>

--- a/behaviors/magic-button.vue
+++ b/behaviors/magic-button.vue
@@ -112,7 +112,7 @@
 </style>
 
 <template>
-  <button class="magic-button" @click.prevent.stop="doMagic">
+  <button type="button" class="magic-button" @click.prevent.stop="doMagic">
     <icon name="magic-button"></icon>
   </button>
 </template>

--- a/behaviors/magic-button.vue
+++ b/behaviors/magic-button.vue
@@ -5,8 +5,8 @@
 
   ## Arguments
 
-  * **field** _(optional)_ a field to grab the value from
-  * **component** _(optional)_ a name of a component to grab the component ref from
+  * **field** _(optional)_ a field to grab the value from (in the current complex list, form, or component)
+  * **component** _(optional)_ a name of a component to grab the component ref/uri from
   * **transform** _(optional)_ a transform to apply to the grabbed value
   * **transformArg** _(optional)_ an argument to pass through to the transform
   * **store** _(optional)_ to grab data from the client-side store
@@ -120,6 +120,7 @@
 <script>
   import _ from 'lodash';
   import { find } from '@nymag/dom';
+  import { getFieldData } from '../lib/forms/field-helpers';
   import { refAttr } from '../lib/utils/references';
   import { send } from '../lib/utils/rest';
   import { reduce as reducePromise } from '../lib/utils/promises';
@@ -128,15 +129,6 @@
   import { UPDATE_FORMDATA } from '../lib/forms/mutationTypes';
   import transformers from './magic-button-transformers';
   import icon from '../lib/utils/icon.vue';
-
-  /**
-   * get data from a field in the current form
-   * @param  {string} field
-   * @return {string}
-   */
-  function getFieldData(field) {
-    return _.get(this, `$store.state.ui.currentForm.fields.${field}`) || '';
-  }
 
   /**
    * get the uri of the first component that matches
@@ -164,7 +156,7 @@
     // otherwise, if they specify a component to pull data from, find it on the page
     // otherwise, return emptystring (it may be transformed)
     if (!_.isEmpty(field)) {
-      return getFieldData.call(this, field);
+      return getFieldData(this.$store, field, this.name, _.get(this.$store, 'state.ui.currentForm.uri'));
     } else if (!_.isEmpty(component)) {
       return findComponent(component);
     } else {

--- a/behaviors/reveal.vue
+++ b/behaviors/reveal.vue
@@ -5,7 +5,7 @@
 
   ## Arguments
 
-  * **field** and/or **sites** to compare against
+  * **field** and/or **sites** to compare against (inside complex-list item, current form, or current component)
   * **operator** _(optional)_ to use for the comparison
   * **value** _(optional)_ to compare the field against
 
@@ -39,7 +39,7 @@
 
 <script>
   import _ from 'lodash';
-  import { getField } from '../lib/forms/field-helpers';
+  import { getField, getFieldData } from '../lib/forms/field-helpers';
   import { compare } from '../lib/utils/comparators';
   import { filterBySite } from '../lib/utils/site-filter';
   import { getData } from '../lib/core-data/components';
@@ -70,11 +70,7 @@
           operator = this.args.operator,
           value = this.args.value,
           sites = this.args.sites,
-          fieldPath = field && _.reduce(field.split('.'), (str, fieldPart) => str += `.${fieldPart}`, 'state.ui.currentForm.fields'),
-          // compare against the field if it's in the current form,
-          // but fall back to comparing against data in the component
-          // (this allows comparing to fields that might not be in the same form)
-          data = field && (_.get(this.$store, fieldPath) || getData(uri, field));
+          data = getFieldData(this.$store, field, this.name, uri);
 
         if (sites && field) {
           // if there is site logic, run it before field logic

--- a/directives/conditional-focus.js
+++ b/directives/conditional-focus.js
@@ -1,7 +1,7 @@
 export default function conditionalFocus() {
   return {
-    componentUpdated: (el, { value }) => {
-      if (value) {
+    componentUpdated: (el, { value, oldValue }) => {
+      if (value && value !== oldValue) {
         el.focus();
       }
     }

--- a/lib/component-data/model.js
+++ b/lib/component-data/model.js
@@ -14,7 +14,7 @@ const MODEL_SAVE_TIMEOUT = 8000, // timeout for model.js pre-save hook
 export function save(uri, data) {
   const model = getModel(uri);
 
-  if (_.isFunction(model.save)) {
+  if (_.isObject(model) && _.isFunction(model.save)) {
     return timeout(attempt(() => model.save(uri, data, getLocals())), MODEL_SAVE_TIMEOUT);
   } else {
     return Promise.resolve(data);
@@ -30,7 +30,7 @@ export function save(uri, data) {
 export function render(uri, data) {
   const model = getModel(uri);
 
-  if (_.isFunction(model.render)) {
+  if (_.isObject(model) && _.isFunction(model.render)) {
     return timeout(attempt(() => model.render(uri, data, getLocals())), MODEL_RENDER_TIMEOUT);
   } else {
     return Promise.resolve(data);

--- a/lib/decorators/placeholders.js
+++ b/lib/decorators/placeholders.js
@@ -2,25 +2,10 @@ import Vue from 'vue';
 import _ from 'lodash';
 import { editAttr, placeholderAttr, placeholderProp, fieldProp, componentListProp, componentProp } from '../utils/references';
 import { get } from '../core-data/groups';
+import { isEmpty } from '../utils/comparators';
 import placeholderTpl from './placeholder.vue';
 
 const Placeholder = Vue.component('placeholder', placeholderTpl);
-
-/**
- * test to see if a field is empty
- * note: 0, false, etc are valid bits of data for numbers, booleans, etc so they shouldn't be masked
- * note: but emptystring IS empty (for strings)
- * @param  {*}  data
- * @return {Boolean}
- */
-export function isFieldEmpty(data) {
-  if (_.isArray(data)) {
-    // empty arrays and arrays with empty values (or arrays of objects where all properties are falsy)
-    return _.isEmpty(data) || _.every(data, (item) => _.isObject(item) ? _.every(item, (value) => isFieldEmpty(value)) : isFieldEmpty(item));
-  } else {
-    return !_.isBoolean(data) && !_.isNumber(data) && _.isEmpty(data);
-  }
-}
 
 /**
  * compare two fields to see if they're empty
@@ -30,9 +15,9 @@ export function isFieldEmpty(data) {
  * @returns {boolean}
  */
 export function compareTwoFields(tokens, fields) {
-  const isFirstEmpty = isFieldEmpty(fields[_.head(tokens)]),
+  const isFirstEmpty = isEmpty(fields[_.head(tokens)]),
     comparator = tokens[1].toLowerCase(), // comparator is case-insensitive
-    isSecondEmpty = isFieldEmpty(fields[_.last(tokens)]);
+    isSecondEmpty = isEmpty(fields[_.last(tokens)]);
 
   switch (comparator) {
     case 'and': return isFirstEmpty && isSecondEmpty;
@@ -63,7 +48,7 @@ export function isGroupEmpty(fields, placeholder, path) {
 
   if (tokens.length === 1) {
     // check a single field to see if it's empty
-    return isFieldEmpty(fields[_.head(tokens)]);
+    return isEmpty(fields[_.head(tokens)]);
   } else if (tokens.length === 3) {
     // check multiple fields
     // note: for now (because order of operations is non-trivial and I'm lazy)
@@ -129,7 +114,7 @@ export function hasPlaceholder(uri, path) {
   if (isPermanentPlaceholder) {
     return true;
   } else if (isField) {
-    return isFieldEmpty(fields[path]);
+    return isEmpty(fields[path]);
   } else if (isGroup) {
     return isGroupEmpty(fields, placeholder, path);
   } else if (isComponentList) {

--- a/lib/decorators/placeholders.js
+++ b/lib/decorators/placeholders.js
@@ -14,7 +14,12 @@ const Placeholder = Vue.component('placeholder', placeholderTpl);
  * @return {Boolean}
  */
 export function isFieldEmpty(data) {
-  return !_.isBoolean(data) && !_.isNumber(data) && _.isEmpty(data);
+  if (_.isArray(data)) {
+    // empty arrays and arrays with empty values (or arrays of objects where all properties are falsy)
+    return _.isEmpty(data) || _.every(data, (item) => _.isObject(item) ? _.every(item, (value) => isFieldEmpty(value)) : isFieldEmpty(item));
+  } else {
+    return !_.isBoolean(data) && !_.isNumber(data) && _.isEmpty(data);
+  }
 }
 
 /**

--- a/lib/decorators/placeholders.test.js
+++ b/lib/decorators/placeholders.test.js
@@ -14,60 +14,6 @@ describe('placeholders', () => {
     sandbox.restore();
   });
 
-  describe('isFieldEmpty', () => {
-    const fn = lib.isFieldEmpty;
-
-    it('is false if boolean', () => {
-      expect(fn(true)).to.equal(false);
-      expect(fn(false)).to.equal(false);
-    });
-
-    it('is false if number', () => {
-      expect(fn(1)).to.equal(false);
-      expect(fn(0)).to.equal(false);
-    });
-
-    it('is false if non-empty string', () => {
-      expect(fn('hello')).to.equal(false);
-    });
-
-    it('is false if non-empty array', () => {
-      expect(fn([0])).to.equal(false);
-    });
-
-    it('is false if non-empty object', () => {
-      expect(fn({ foo: false })).to.equal(false);
-    });
-
-    it('is true if undefined', () => {
-      expect(fn()).to.equal(true);
-    });
-
-    it('is true if null', () => {
-      expect(fn(null)).to.equal(true);
-    });
-
-    it('is true if empty string', () => {
-      expect(fn('')).to.equal(true);
-    });
-
-    it('is true if empty array', () => {
-      expect(fn([])).to.equal(true);
-    });
-
-    it('is true if empty object', () => {
-      expect(fn({})).to.equal(true);
-    });
-
-    it('is true if array with empty objects', () => {
-      expect(fn([{}])).to.equal(true);
-    });
-
-    it('is true if array with objects whose props are considered empty', () => {
-      expect(fn([{ foo: '' }])).to.equal(true);
-    });
-  });
-
   describe('compareTwoFields', () => {
     const fn = lib.compareTwoFields;
 

--- a/lib/decorators/placeholders.test.js
+++ b/lib/decorators/placeholders.test.js
@@ -58,6 +58,14 @@ describe('placeholders', () => {
     it('is true if empty object', () => {
       expect(fn({})).to.equal(true);
     });
+
+    it('is true if array with empty objects', () => {
+      expect(fn([{}])).to.equal(true);
+    });
+
+    it('is true if array with objects whose props are considered empty', () => {
+      expect(fn([{ foo: '' }])).to.equal(true);
+    });
   });
 
   describe('compareTwoFields', () => {

--- a/lib/forms/behaviors.js
+++ b/lib/forms/behaviors.js
@@ -108,17 +108,25 @@ function getBehaviorSlots(behavior) {
 
 /**
  * get an array of expanded behaviors
+ * used by expand(), but also used in validation helpers
+ * @param  {string|object|array} behaviors
+ * @return {array}
+ */
+export function rawExpand(behaviors) {
+  if (isShortHandDefinition(behaviors)) {
+    return [expandBehavior(behaviors)];
+  } else {
+    return _.map(behaviors, expandBehavior);
+  }
+}
+
+/**
+ * get an array of expanded behaviors, for use in forms
+ * note: as opposed to rawExpand, this will munge the names so they can be used in forms,
+ * omit missing ones, and get the correct slots for each behavior
  * @param  {*} behaviors
  * @return {[]}           array of {fn: string, args: {}}
  */
 export function expand(behaviors) {
-  let expanded;
-
-  if (isShortHandDefinition(behaviors)) {
-    expanded = [expandBehavior(behaviors)];
-  } else {
-    expanded = behaviors.map(expandBehavior);
-  }
-
-  return expanded.map(mungeNativeTagNames).filter(omitMissingBehaviors).map(getBehaviorSlots);
+  return rawExpand(behaviors).map(mungeNativeTagNames).filter(omitMissingBehaviors).map(getBehaviorSlots);
 }

--- a/lib/forms/field-helpers.js
+++ b/lib/forms/field-helpers.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { set } from 'caret-position';
 import { closest, find } from '@nymag/dom';
 import { fieldClass, mainBehaviorClass, firstFieldClass } from '../utils/references';
@@ -50,5 +51,72 @@ export function setCaret(el, offset, data) {
     set(el, data.length - 1);
   } else {
     set(el, offset);
+  }
+}
+
+/**
+ * find data in the same list item, recursing upwards in case we're inside
+ * multiple complex-lists
+ * @param  {object} data
+ * @param  {string} prop
+ * @param  {string} path
+ * @return {*}
+ */
+function findDataInList(data, prop, path) {
+  const pathArray = path.split('.');
+
+  let found = null,
+    i = pathArray.length - 1;
+
+  for (; i >= 0; i--) {
+    const part = pathArray[i];
+
+    if (!_.isNaN(_.toNumber(part))) {
+      // this is inside an array! that means it's in a complex list
+      const beforeIndex = pathArray.slice(0, i).join('.'),
+        index = part;
+
+      found = _.get(data, `${beforeIndex}.${index}.${prop}`);
+      if (found) {
+        break;
+      }
+    }
+  }
+
+  return found;
+}
+
+/**
+ * get data from a field
+ * looks inside current complex-list item first,
+ * then up to other lists this may be inside,
+ * then looks in the current form,
+ * then (finally) looks in the component data
+ * @param  {object} store
+ * @param  {string} prop to look for
+ * @param  {string} path of current field (to check for nested complex-lists)
+ * @param {string} uri to check inside current component
+ * @return {*}
+ */
+export function getFieldData(store, prop, path, uri) {
+  const currentFormData = _.get(store, 'state.ui.currentForm.fields', {}),
+    insideComplexLists = path.match(/\.\d+\./); // determine if a field is inside an array
+
+  if (insideComplexLists) {
+    // inside one (or more) complex lists
+    let found = findDataInList(currentFormData, prop, path);
+
+    if (found) {
+      return found;
+    }
+  }
+
+  // if we haven't found anything, check to see if it's in the current form (or component data)
+  if (_.includes(Object.keys(currentFormData), prop)) {
+    // inside current form
+    return currentFormData[prop];
+  } else {
+    // inside the component data
+    return _.get(store, `state.components['${uri}'].${prop}`);
   }
 }

--- a/lib/forms/field-helpers.test.js
+++ b/lib/forms/field-helpers.test.js
@@ -1,0 +1,95 @@
+import * as lib from './field-helpers';
+
+describe('field helpers', () => {
+  describe('getFieldData', () => {
+    const fn = lib.getFieldData,
+      prop = 'foo',
+      uri = 'domain.com/components/abc/instances/def',
+      storeWithList = {
+        state: {
+          ui: {
+            currentForm: {
+              fields: {
+                bar: [{ foo: 'hi' }]
+              }
+            }
+          }
+        }
+      },
+      storeWithTwoLists = {
+        state: {
+          ui: {
+            currentForm: {
+              fields: {
+                bar: [{
+                  baz: [{ qux: 'no' }] ,
+                  foo: 'hi'
+                }]
+              }
+            }
+          }
+        }
+      },
+      storeWithForm = {
+        state: {
+          ui: {
+            currentForm: {
+              fields: {
+                foo: 'hi'
+              }
+            }
+          }
+        }
+      },
+      storeWithComponent = {
+        state: {
+          components: {
+            [uri]: {
+              foo: 'hi'
+            }
+          }
+        }
+      },
+      storeWithoutAnything = {};
+
+    it('returns data from current list item', () => {
+      expect(fn(storeWithList, prop, 'bar.0.baz', uri)).to.eql('hi');
+    });
+
+    it('returns data from current parent list item', () => {
+      expect(fn(storeWithList, prop, 'bar.0.baz.0.qux', uri)).to.eql('hi');
+    });
+
+    it('returns data from current form', () => {
+      expect(fn(storeWithForm, prop, 'bar', uri)).to.eql('hi');
+    });
+
+    it('returns data from current form (even in list)', () => {
+      expect(fn(storeWithForm, prop, 'bar.0.baz', uri)).to.eql('hi');
+    });
+
+    it('returns data from current form (even in nested list)', () => {
+      expect(fn(storeWithForm, prop, 'bar.0.baz.0.qux', uri)).to.eql('hi');
+    });
+
+    it('returns data from current component', () => {
+      expect(fn(storeWithComponent, prop, 'bar', uri)).to.eql('hi');
+    });
+
+    it('returns data from current component (even in list)', () => {
+      expect(fn(storeWithComponent, prop, 'bar.0.baz', uri)).to.eql('hi');
+    });
+
+    it('returns data from current component (even in nested list)', () => {
+      expect(fn(storeWithComponent, prop, 'bar.0.baz.0.qux', uri)).to.eql('hi');
+    });
+
+    it('returns undefined if not found anywhere', () => {
+      expect(fn(storeWithoutAnything, prop, 'bar.baz', uri)).to.eql(undefined);
+    });
+
+    it('returns undefined if not found anywhere (even in list)', () => {
+      expect(fn(storeWithoutAnything, prop, 'bar.0.baz', uri)).to.eql(undefined);
+    });
+  });
+});

--- a/lib/forms/mutations.test.js
+++ b/lib/forms/mutations.test.js
@@ -23,6 +23,6 @@ define('form mutations', () => {
   });
 
   it('updates form data with deep path', () => {
-    expect(lib[UPDATE_FORMDATA]({ ui: { currentForm: { fields: {} }}}, { path: 'foo.1.bar', data: 'sup' })).to.eql({ ui: { currentForm: { fields: { foo: [{ bar: 'sup' }] }}}});
+    expect(lib[UPDATE_FORMDATA]({ ui: { currentForm: { fields: { foo: [{ bar: 'hi' }] } }}}, { path: 'foo.0.bar', data: 'sup' })).to.eql({ ui: { currentForm: { fields: { foo: [{ bar: 'sup' }] }}}});
   });
 });

--- a/lib/forms/mutations.test.js
+++ b/lib/forms/mutations.test.js
@@ -21,4 +21,8 @@ define('form mutations', () => {
   it('updates form data', () => {
     expect(lib[UPDATE_FORMDATA]({ ui: { currentForm: { fields: {} }}}, { path: 'foo', data: 'sup' })).to.eql({ ui: { currentForm: { fields: { foo: 'sup' }}}});
   });
+
+  it('updates form data with deep path', () => {
+    expect(lib[UPDATE_FORMDATA]({ ui: { currentForm: { fields: {} }}}, { path: 'foo.1.bar', data: 'sup' })).to.eql({ ui: { currentForm: { fields: { foo: [{ bar: 'sup' }] }}}});
+  });
 });

--- a/lib/page-data/actions.js
+++ b/lib/page-data/actions.js
@@ -111,7 +111,7 @@ export function publishPage(store, uri) {
 
   return promise.then(() => {
     return props({
-      page: addToQueue(save, [`${replaceVersion(uri, 'published')}`, data], 'published'),
+      page: addToQueue(save, [`${replaceVersion(uri, 'published')}`], 'published'),
       layout: addToQueue(save, [`${replaceVersion(layoutUri, 'published')}`], 'published') // PUT @published with empty data, and it'll clone the latest data
     }).then((promises) => {
       const url = promises.page.url;

--- a/lib/utils/api.js
+++ b/lib/utils/api.js
@@ -9,6 +9,7 @@ import * as references from './references';
 import * as urls from './urls';
 import getAvailableComponents from './available-components';
 import * as local from './local';
+import * as validationHelpers from '../validators/helpers';
 
 // these utilities are exported so 3rd party plugins/validators/behaviors/panes can access them.
 // note: the store is passed into those things automatically, so don't export it here
@@ -24,6 +25,7 @@ const api = {
   urls,
   getAvailableComponents,
   local,
+  validationHelpers,
   version: process.env.KILN_VERSION
 };
 

--- a/lib/utils/comparators.js
+++ b/lib/utils/comparators.js
@@ -22,7 +22,9 @@ const operators = {
  */
 export function isEmpty(val) {
   if (_.isArray(val)) {
-    return _.isEmpty(val);
+    // an array is empty if it has no items, if all of the items are considered empty, or if the item contains props that are considered empty
+    // (e.g. complex-list items)
+    return _.isEmpty(val) || _.every(val, (item) => _.isObject(item) ? _.every(item, (itemVal) => isEmpty(itemVal)) : isEmpty(item))
   } else if (_.isObject(val)) {
     // an object is empty if it's empty or all its props are falsy (e.g. checkbox-group)
     return _.isEmpty(val) || _.every(val, (prop) => !prop);

--- a/lib/utils/comparators.test.js
+++ b/lib/utils/comparators.test.js
@@ -7,11 +7,15 @@ describe('comparators', () => {
     it('returns false if non-empty string', () => expect(fn('hi')).to.equal(false));
     it('returns false if any number', () => expect(fn(0)).to.equal(false));
     it('returns false if any boolean', () => expect(fn(false)).to.equal(false));
+    it('returns false if non-empty array', () => expect(fn([1, 2, 3])).to.equal(false));
+    it('returns false if non-empty object', () => expect(fn({ a: '1' })).to.equal(false));
     it('returns true if empty string', () => expect(fn('')).to.equal(true));
     it('returns true if null', () => expect(fn(null)).to.equal(true));
     it('returns true if undefined', () => expect(fn('')).to.equal(true));
     it('returns true if empty array', () => expect(fn([])).to.equal(true));
     it('returns true if empty object', () => expect(fn({})).to.equal(true));
+    it('returns true if array with empty objects', () => expect(fn([{}])).to.equal(true));
+    it('returns true if array with objects with empty props', () => expect(fn([{ foo: '' }])).to.equal(true));
   });
 
   describe('compare', () => {

--- a/lib/validators/built-in/conditional-required.js
+++ b/lib/validators/built-in/conditional-required.js
@@ -2,28 +2,46 @@ import _ from 'lodash';
 import { getComponentName, fieldProp } from '../../utils/references';
 import labelUtil from '../../utils/label';
 import { isEmpty, compare } from '../../utils/comparators';
+import { getBehavior, hasBehavior, getListProps } from '../helpers';
 
 export const label = 'Conditionally Required',
   description = 'Some fields are required for publication, based on other fields',
   type = 'error';
 
+function hasEmptyRequiredListItems(val, fieldSchema) {
+  const props = getListProps(fieldSchema);
+
+  // look through the complex-list props for anything that's required,
+  // then look through the field's data seeing if that prop is empty
+  return !!_.find(props, (propConfig) => hasBehavior('conditional-required', propConfig) && !!_.find(val, (item) => isEmpty(item[propConfig.prop])));
+}
+
 export function validate(state) {
   return _.reduce(state.components, (result, component, uri) => {
     _.forOwn(component, (val, key) => {
-      if (isEmpty(val)) {
+      const name = getComponentName(uri),
+        schema = _.get(state, `schemas[${name}][${key}]`);
+
+      if (isEmpty(val) || hasEmptyRequiredListItems(val, schema)) {
         // first, check empty values. if it's empty, then we should
         // look in the schema to see if it was required
-        const name = getComponentName(uri),
-          schema = _.get(state, `schemas[${name}][${key}]`),
-          behaviors = schema && schema[fieldProp],
-          conditionalRequired = _.isArray(behaviors) && _.find(behaviors, { fn: 'conditional-required' });
+        const conditionalRequired = getBehavior('conditional-required', schema),
+          compareField = conditionalRequired && conditionalRequired.args.field;
+
+        let compareSchema, emptyItemIndex, compareData, shouldBeRequired;
+
+        if (conditionalRequired && conditionalRequired._path) {
+          // check the list item OR field it's based on, to see if it's required
+          compareSchema = _.find(_.get(getBehavior('complex-list', schema), 'args.props'), (prop) => prop.prop === compareField);
+          emptyItemIndex = _.findIndex(val, (item) => isEmpty(item[conditionalRequired._path]));
+          compareData = _.get(val, `${emptyItemIndex}.${compareField}`);
+        }
 
         if (conditionalRequired) {
           // check the field it's based on, to see if it's actually required here
-          const compareField = conditionalRequired.field,
-            compareSchema = _.get(state, `schemas[${name}][${compareField}]`),
-            compareData = _.get(component, compareField),
-            shouldBeRequired = compare({ data: compareData, operator: conditionalRequired.operator, value: conditionalRequired.value });
+          compareSchema = compareSchema || _.get(state, `schemas[${name}][${compareField}]`);
+          compareData = compareData || _.get(component, compareField);
+          shouldBeRequired = compare({ data: compareData, operator: conditionalRequired.args.operator, value: conditionalRequired.args.value });
 
           if (shouldBeRequired) {
             result.push({

--- a/lib/validators/built-in/conditional-required.test.js
+++ b/lib/validators/built-in/conditional-required.test.js
@@ -14,6 +14,21 @@ describe('validators: required', () => {
       expect(fn({})).to.eql([]);
     });
 
+    it('passes if deleted component', () => {
+      expect(fn({
+        components: {
+          [uri]: {}
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: 'text'
+            }
+          }
+        }
+      })).to.eql([]);
+    });
+
     it('passes if no required fields', () => {
       expect(fn({
         components: {

--- a/lib/validators/built-in/required.js
+++ b/lib/validators/built-in/required.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { getComponentName, fieldProp } from '../../utils/references';
 import labelUtil from '../../utils/label';
 import { isEmpty } from '../../utils/comparators';
+import { hasBehavior } from '../helpers';
 
 export const label = 'Required',
   description = 'Some fields are required for publication',
@@ -18,11 +19,7 @@ export function validate(state) {
         schema = _.get(state, `schemas[${name}]`);
 
       _.forOwn(schema, (fieldSchema, fieldName) => {
-        const behaviors = fieldSchema[fieldProp];
-
-        // 'required' has no arguments and must be included with other behaviors in the field,
-        // so we can make some assumptions to make this check more efficient
-        if (_.isArray(behaviors) && _.includes(behaviors, 'required')) {
+        if (hasBehavior('required', fieldSchema)) {
           const val = component[fieldName];
 
           // this field is required! check the component data

--- a/lib/validators/built-in/required.js
+++ b/lib/validators/built-in/required.js
@@ -2,11 +2,19 @@ import _ from 'lodash';
 import { getComponentName, fieldProp } from '../../utils/references';
 import labelUtil from '../../utils/label';
 import { isEmpty } from '../../utils/comparators';
-import { hasBehavior } from '../helpers';
+import { hasBehavior, getListProps } from '../helpers';
 
 export const label = 'Required',
   description = 'Some fields are required for publication',
   type = 'error';
+
+function hasEmptyRequiredListItems(val, fieldSchema) {
+  const props = getListProps(fieldSchema);
+
+  // look through the complex-list props for anything that's required,
+  // then look through the field's data seeing if that prop is empty
+  return !!_.find(props, (propConfig) => hasBehavior('required', propConfig) && !!_.find(val, (item) => isEmpty(item[propConfig.prop])));
+}
 
 export function validate(state) {
   return _.reduce(state.components, (result, component, uri) => {
@@ -23,7 +31,7 @@ export function validate(state) {
           const val = component[fieldName];
 
           // this field is required! check the component data
-          if (isEmpty(val)) {
+          if (isEmpty(val) || hasEmptyRequiredListItems(val, fieldSchema)) {
             result.push({
               uri,
               field: fieldName,

--- a/lib/validators/built-in/soft-maxlength.js
+++ b/lib/validators/built-in/soft-maxlength.js
@@ -3,6 +3,7 @@ import { decode } from 'he';
 import striptags from 'striptags';
 import { getComponentName, fieldProp, behaviorKey } from '../../utils/references';
 import labelUtil from '../../utils/label';
+import { getBehavior } from '../helpers';
 
 export const label = 'Max Length',
   description = 'Some fields must be less than a certain length for consistent formatting across all syndications',
@@ -23,20 +24,19 @@ export function validate(state) {
     _.forOwn(component, (val, key) => {
       const name = getComponentName(uri),
         schema = _.get(state, `schemas[${name}][${key}]`),
-        behaviors = schema && schema[fieldProp],
-        softMaxlength = _.isArray(behaviors) && _.find(behaviors, (behavior) => behavior[behaviorKey] === 'soft-maxlength');
+        softMaxlength = getBehavior('soft-maxlength', schema);
 
       if (_.isString(val) && softMaxlength) {
         const cleanVal = cleanValue(val);
 
         // assume that we're only checking strings, and that the soft-maxlength behavior will only be
         // in behavior ARRAYS (since it requires other behaviors in that field, and always has a value argument)
-        if (cleanVal.length > softMaxlength.value) {
+        if (cleanVal.length > softMaxlength.args.value) {
           result.push({
             uri,
             field: key,
             location: `${labelUtil(name)} » ${labelUtil(key, schema)}`,
-            preview: _.truncate(`…${cleanVal.substr(softMaxlength.value)}`, {
+            preview: _.truncate(`…${cleanVal.substr(softMaxlength.args.value)}`, {
               length: 40,
               omission: '…'
             })

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -1,4 +1,9 @@
-// some little helpers to make writing validators easier
+// some little helpers to make writing validators easier.
+// these are exported through the api for use in custom validators
+import _ from 'lodash';
+import { rawExpand } from '../forms/behaviors';
+import { fieldProp, behaviorKey } from '../utils/references';
+
 /**
  * get the text to preview
  * @param  {string} text  without htmltags
@@ -23,4 +28,31 @@ export function getPreviewText(text, index, length) {
   }
 
   return previewText;
+}
+
+/**
+ * determind if a field's schema contains a specific behavior
+ * note: this will return true if the field contains n-number of complex-lists
+ * whose fields contain the behavior
+ * @param  {string}  behavior
+ * @param  {object}  fieldSchema
+ * @return {Boolean}
+ */
+export function hasBehavior(behavior, fieldSchema) {
+  if (_.isObject(fieldSchema) && _.has(fieldSchema, fieldProp)) {
+    const expanded = rawExpand(fieldSchema[fieldProp]);
+
+    return !!_.find(expanded, (behaviorConfig) => {
+      if (behaviorConfig[behaviorKey] === behavior) {
+        return true;
+      } else if (behaviorConfig[behaviorKey] === 'complex-list') {
+        // recurse, in case there are nested lists
+        return !!_.find(_.get(behaviorConfig, 'args.props'), (field) => hasBehavior(behavior, field));
+      } else {
+        return false;
+      }
+    });
+  } else {
+    return false; // _version, _description, _component, _componentList, etc
+  }
 }

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -31,7 +31,7 @@ export function getPreviewText(text, index, length) {
 }
 
 /**
- * determind if a field's schema contains a specific behavior
+ * determine if a field's schema contains a specific behavior
  * note: this will return true if the field contains n-number of complex-lists
  * whose fields contain the behavior
  * @param  {string}  behavior
@@ -54,5 +54,20 @@ export function hasBehavior(behavior, fieldSchema) {
     });
   } else {
     return false; // _version, _description, _component, _componentList, etc
+  }
+}
+
+/**
+ * get props of a complex-list
+ * @param  {object} fieldSchema
+ * @return {array}
+ */
+export function getListProps(fieldSchema) {
+  if (hasBehavior('complex-list', fieldSchema)) {
+    const expanded = rawExpand(fieldSchema[fieldProp]);
+
+    return _.get(_.find(expanded, (behavior) => behavior[behaviorKey] === 'complex-list'), 'args.props');
+  } else {
+    return null;
   }
 }

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -31,6 +31,47 @@ export function getPreviewText(text, index, length) {
 }
 
 /**
+ * get a behavior config from a field's schema, if it contains that specific behavior
+ * note: if a complex-list item contains a behavior, the returned config will contain a `_path` property
+ * note: in complex-lists, this will return the _first_ instance of the behavior
+ * @param  {string}  behavior
+ * @param  {object}  fieldSchema
+ * @param {string} [path] if recursing through complex-lists
+ * @return {object|null}
+ */
+export function getBehavior(behavior, fieldSchema, path) {
+  if (_.isObject(fieldSchema) && _.has(fieldSchema, fieldProp)) {
+    const expanded = rawExpand(fieldSchema[fieldProp]);
+
+    let listBehavior,
+      rootBehavior = _.find(expanded, (behaviorConfig) => {
+        if (behaviorConfig[behaviorKey] === behavior) {
+          return true;
+        } else if (behaviorConfig[behaviorKey] === 'complex-list') {
+          // recurse, in case there are nested lists
+          return !!_.find(_.get(behaviorConfig, 'args.props'), (prop) => {
+            const foundChild = getBehavior(behavior, prop, prop.prop);
+
+            if (foundChild) {
+              foundChild._path = foundChild._path ? `${prop.prop}.${foundChild._path}` : prop.prop;
+              listBehavior = foundChild;
+              return true;
+            } else {
+              return false;
+            }
+          });
+        } else {
+          return false;
+        }
+      });
+
+      return listBehavior || rootBehavior || null;
+  } else {
+    return null; // _version, _description, _component, _componentList, etc
+  }
+}
+
+/**
  * determine if a field's schema contains a specific behavior
  * note: this will return true if the field contains n-number of complex-lists
  * whose fields contain the behavior
@@ -39,22 +80,7 @@ export function getPreviewText(text, index, length) {
  * @return {Boolean}
  */
 export function hasBehavior(behavior, fieldSchema) {
-  if (_.isObject(fieldSchema) && _.has(fieldSchema, fieldProp)) {
-    const expanded = rawExpand(fieldSchema[fieldProp]);
-
-    return !!_.find(expanded, (behaviorConfig) => {
-      if (behaviorConfig[behaviorKey] === behavior) {
-        return true;
-      } else if (behaviorConfig[behaviorKey] === 'complex-list') {
-        // recurse, in case there are nested lists
-        return !!_.find(_.get(behaviorConfig, 'args.props'), (field) => hasBehavior(behavior, field));
-      } else {
-        return false;
-      }
-    });
-  } else {
-    return false; // _version, _description, _component, _componentList, etc
-  }
+  return !!getBehavior(behavior, fieldSchema);
 }
 
 /**

--- a/lib/validators/helpers.test.js
+++ b/lib/validators/helpers.test.js
@@ -80,4 +80,12 @@ describe('validation helpers', () => {
       } })).to.equal(true);
     });
   });
+
+  describe('getListProps', () => {
+    const fn = lib.getListProps;
+
+    it('returns null if no complex-list', () => {
+      expect(fn({})).to.equal(null);
+    });
+  });
 });

--- a/lib/validators/helpers.test.js
+++ b/lib/validators/helpers.test.js
@@ -13,6 +13,74 @@ describe('validation helpers', () => {
     });
   });
 
+  describe('getBehavior', () => {
+    const fn = lib.getBehavior;
+
+    it('returns null if no behaviors', () => {
+      expect(fn('foo', { _has: [] })).to.equal(null);
+    });
+
+    it('returns null if behavior not found in root', () => {
+      expect(fn('foo', { _has: 'text' })).to.equal(null);
+    });
+
+    it('returns null if behavior not found in complex list', () => {
+      expect(fn('foo', { _has: {
+        fn: 'complex-list',
+        props: [{
+          prop: 'someProp',
+          _has: 'text'
+        }]
+      } })).to.equal(null);
+    });
+
+    it('returns null if behavior not found in nested complex list', () => {
+      expect(fn('foo', { _has: {
+        fn: 'complex-list',
+        props: [{
+          prop: 'someProp',
+          _has: {
+            fn: 'complex-list',
+            props: [{
+              prop: 'someOtherProp',
+              _has: 'text'
+            }]
+          }
+        }]
+      } })).to.equal(null);
+    });
+
+    it('returns behavior config if behavior found in root', () => {
+      expect(fn('foo', { _has: 'foo' })).to.eql({ fn: 'foo', args: {}});
+    });
+
+    it('returns behavior config if behavior found in complex list', () => {
+      expect(fn('foo', { _has: {
+        fn: 'complex-list',
+        props: [{
+          prop: 'someProp',
+          _has: 'foo'
+        }]
+      } })).to.eql({ fn: 'foo', args: {}, _path: 'someProp' });
+    });
+
+    it('returns behavior config if behavior found in nested complex list', () => {
+      expect(fn('foo', { _has: {
+        fn: 'complex-list',
+        props: [{
+          prop: 'someProp',
+          _has: {
+            fn: 'complex-list',
+            props: [{
+              prop: 'someOtherProp',
+              _has: 'foo'
+            }]
+          }
+        }]
+      } })).to.eql({ fn: 'foo', args: {}, _path: 'someProp.someOtherProp' });
+    });
+  });
+
   describe('hasBehavior', () => {
     const fn = lib.hasBehavior;
 

--- a/lib/validators/helpers.test.js
+++ b/lib/validators/helpers.test.js
@@ -12,4 +12,72 @@ describe('validation helpers', () => {
       expect(fn('O brave new world, that has such people in\'t!', 21, 0)).to.equal('… brave new world, that has such people i…');
     });
   });
+
+  describe('hasBehavior', () => {
+    const fn = lib.hasBehavior;
+
+    it('returns false if no behaviors', () => {
+      expect(fn('foo', { _has: [] })).to.equal(false);
+    });
+
+    it('returns false if behavior not found in root', () => {
+      expect(fn('foo', { _has: 'text' })).to.equal(false);
+    });
+
+    it('returns false if behavior not found in complex list', () => {
+      expect(fn('foo', { _has: {
+        fn: 'complex-list',
+        props: [{
+          prop: 'someProp',
+          _has: 'text'
+        }]
+      } })).to.equal(false);
+    });
+
+    it('returns false if behavior not found in nested complex list', () => {
+      expect(fn('foo', { _has: {
+        fn: 'complex-list',
+        props: [{
+          prop: 'someProp',
+          _has: {
+            fn: 'complex-list',
+            props: [{
+              prop: 'someOtherProp',
+              _has: 'text'
+            }]
+          }
+        }]
+      } })).to.equal(false);
+    });
+
+    it('returns true if behavior found in root', () => {
+      expect(fn('foo', { _has: 'foo' })).to.equal(true);
+    });
+
+    it('returns true if behavior found in complex list', () => {
+      expect(fn('foo', { _has: {
+        fn: 'complex-list',
+        props: [{
+          prop: 'someProp',
+          _has: 'foo'
+        }]
+      } })).to.equal(true);
+    });
+
+    it('returns true if behavior found in nested complex list', () => {
+      expect(fn('foo', { _has: {
+        fn: 'complex-list',
+        props: [{
+          prop: 'someProp',
+          _has: {
+            fn: 'complex-list',
+            props: [{
+              prop: 'someOtherProp',
+              _has: 'foo'
+            }]
+          }
+        }]
+      } })).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
* MINOR new behavior, `complex-list`
* allows array of arbitrary fields
* MINOR export validation helpers in client-side api (so custom validators can use them)

## What is a Complex List?
* array of objects
* each object has properties defined by the schema
* yes, complex-lists can include complex-lists

## How does this work with behaviors that look at other fields' data?

* `reveal`, `magic-button`, and `conditional-required` now all use the same consolidated code, which looks at the _current list item_, then field in the _current form_, then field in the _current component_ to grab data.
* placeholders are displayed if there are no list items _or if all list items' fields are empty_
* placeholders, validators, and comparitors now use consolidated code to determine if a field is empty

## What does this look like?

![923cb8b9-7e8f-417e-b6fd-c24101e6cc94-608-00014666afca3bdb](https://user-images.githubusercontent.com/447522/30178826-5373b7cc-93d8-11e7-8036-7769add206be.gif)
