### PR TITLE
add create method to public api

### DIFF
--- a/lib/utils/api.js
+++ b/lib/utils/api.js
@@ -1,5 +1,5 @@
 import * as caret from './caret';
-import * as create from './component-data/create';
+import * as create from '../component-data/create';
 import * as componentElements from './component-elements';
 import * as headComponents from './head-components';
 import icon from './icon.vue';

--- a/lib/utils/api.js
+++ b/lib/utils/api.js
@@ -1,4 +1,5 @@
 import * as caret from './caret';
+import * as create from './component-data/create';
 import * as componentElements from './component-elements';
 import * as headComponents from './head-components';
 import icon from './icon.vue';
@@ -16,6 +17,7 @@ import * as validationHelpers from '../validators/helpers';
 const api = {
   componentElements,
   caret,
+  create,
   headComponents,
   icon,
   interpolate,


### PR DESCRIPTION
... this will allow validators, plugins, behaviors and panes to create components without triggering a state change in `kiln`

While the `create` method is exposed via the `kiln` api, the logic for figuring out where the component does is NOT exposed and it is up to the developer to write this logic.  ie. which `component-list` does this component live?
