### PR TITLE
Save empty array when adding cmpt list if prop is not set

### DIFF
--- a/lib/decorators/component-list.js
+++ b/lib/decorators/component-list.js
@@ -163,6 +163,7 @@ function addComponentList(el, componentList) {
  * decorate component list if specified in the schema
  * @param  {string} uri
  * @param  {Element} el with data-editable
+ * @returns {Promise|null}
  */
 export default function handler(uri, el) {
   const path = el.getAttribute(editAttr),
@@ -170,5 +171,8 @@ export default function handler(uri, el) {
 
   if (schema && schema[componentListProp]) {
     addComponentList(el, schema[componentListProp]);
+    if (getData(uri, path) === undefined) {
+      return store.dispatch('saveComponent', { uri, data: { [path]: [] }});
+    }
   }
 }


### PR DESCRIPTION
Currently, if a component list property is not set in a cmpt instance, attempts to add a child to the list fail without a meaningful error message. (`Uncaught (in promise) TypeError: Cannot read property 'getAttribute' of undefined`)

This change modifies the component-list decorator to add an empty array to the cmpt-list prop if it has no current value.