### PR TITLE
compare multiple fields

### DIFF
--- a/lib/decorators/placeholders.js
+++ b/lib/decorators/placeholders.js
@@ -8,22 +8,49 @@ import placeholderTpl from './placeholder.vue';
 const Placeholder = Vue.component('placeholder', placeholderTpl);
 
 /**
- * compare two fields to see if they're empty
- * comparators are case insensitive, so 'AND', 'and', 'OR', 'or', etc work
- * @param {array} tokens must have 3 items: first field, comparator, second field
- * @param {object} fields
+ * compare multiple fields to see if they're empty
+ * note: comparators are case insensitive, so 'AND', 'and', 'OR', 'or', etc work
+ * note: when comparing more than two fields, the same comparators must be used
+ * (e.g. 'foo and bar and baz', not 'foo and bar or baz')
+ * @param {array} tokens array of alternating fields and comparators, beginning with a field
+ * @param {object} fields object with data for all fields
+ * @param {string} statement from ifEmpty, used for giving more information to error messages
  * @returns {boolean}
  */
-export function compareTwoFields(tokens, fields) {
-  const isFirstEmpty = isEmpty(fields[_.head(tokens)]),
-    comparator = tokens[1].toLowerCase(), // comparator is case-insensitive
-    isSecondEmpty = isEmpty(fields[_.last(tokens)]);
+export function compareFields(tokens, fields, statement) {
+  const fieldNames = _.filter(tokens, (token, index) => index % 2 === 0), // first, third, etc item (in 0-indexed array)
+    // map through all fields, determining if each is empty
+    fieldBooleans = _.map(fieldNames, (fieldName) => isEmpty(fields[fieldName])),
+    // filter tokens to get comparators, then lowercase them
+    comparators = _.map(_.filter(tokens, (token, index) => index % 2 === 1), (token) => token.toLowerCase()),
+    // remove duplicates (if they're all the same comparator, the resulting array should have one item after going through _.uniq)
+    uniqueComparators = _.uniq(comparators);
 
+  let comparator, compareFn;
+
+  if (fieldNames.length !== comparators.length + 1) {
+    // there are either too many comparators, or too many fields
+    throw new Error(`'ifEmpty' statement has mismatched fields and comparators! You provided: '${statement}'`);
+  }
+
+  if (comparators.length > 1 && _.includes(comparators, 'xor')) {
+    // logically, only two boolean values can be compared with xor
+    throw new Error(`'ifEmpty' statement only supports comparing two fields with XOR! You provided: '${statement}'`)
+  }
+
+  if (uniqueComparators.length > 1) {
+    // there's more than one 'unique' comparator! this means the fields are being compared
+    // with _different_ comparators, rather than the same comparator
+    throw new Error(`'ifEmpty' statement only supports using identical comparators! You provided: '${statement}'`)
+  }
+
+  // if we didn't make any mistakes above, then set the comparator and the compareFn
+  comparator = _.head(uniqueComparators);
   switch (comparator) {
-    case 'and': return isFirstEmpty && isSecondEmpty;
-    case 'or': return isFirstEmpty || isSecondEmpty;
-    case 'xor': return isFirstEmpty && !isSecondEmpty || !isFirstEmpty && isSecondEmpty;
-    default: throw new Error('Unknown comparator: ' + tokens[1]);
+    case 'and': return _.every(fieldBooleans, (bool) => bool === true);
+    case 'or': return _.some(fieldBooleans, (bool) => bool === true);
+    case 'xor': return fieldBooleans[0] && !fieldBooleans[1] || !fieldBooleans[0] && fieldBooleans[1];
+    default: throw new Error(`Unknown comparator: ${comparator}`);
   }
 }
 
@@ -49,16 +76,9 @@ export function isGroupEmpty(fields, placeholder, path) {
   if (tokens.length === 1) {
     // check a single field to see if it's empty
     return isEmpty(fields[_.head(tokens)]);
-  } else if (tokens.length === 3) {
-    // check multiple fields
-    // note: for now (because order of operations is non-trivial and I'm lazy)
-    // this is limited to checking two fields.
-    // e.g. foo AND bar, foo OR bar, foo XOR bar
-    // feel free to make a pull request if you want to compare more than two fields!
-    return compareTwoFields(tokens, fields);
   } else {
-    // someone messed something up in their ifEmpty statement, let them know
-    throw new Error(`Too many arguments in 'ifEmpty' statement! (${ifEmpty})`);
+    // check multiple fields
+    return compareFields(tokens, fields, ifEmpty);
   }
 }
 

--- a/lib/decorators/placeholders.test.js
+++ b/lib/decorators/placeholders.test.js
@@ -14,36 +14,78 @@ describe('placeholders', () => {
     sandbox.restore();
   });
 
-  describe('compareTwoFields', () => {
-    const fn = lib.compareTwoFields;
+  describe('compareFields', () => {
+    const fn = lib.compareFields;
 
     it('throws error if unknown comparator', () => {
       expect(() => fn(['foo', 'NAND', 'bar'], { foo: null, bar: null })).to.throw(Error);
     });
 
+    it('throws error if unmatched fields and comparators', () => {
+      expect(() => fn(['foo', 'and', 'bar', 'and'], { foo: null, bar: null })).to.throw(Error);
+    });
+
+    it('throws error if mixed comparators', () => {
+      expect(() => fn(['foo', 'and', 'bar', 'or', 'baz'], { foo: null, bar: null })).to.throw(Error);
+    });
+
+    it('throws error if more than two fields compared with XOR', () => {
+      expect(() => fn(['foo', 'xor', 'bar', 'xor', 'baz'], { foo: null, bar: null, baz: null })).to.throw(Error);
+    });
+
+    // AND - two fields, multiple fields
+
     it('AND returns true if both a and b are empty', () => {
       expect(fn(['foo', 'and', 'bar'], { foo: null, bar: null })).to.equal(true);
+    });
+
+    it('AND returns true if all fields are empty', () => {
+      expect(fn(['foo', 'and', 'bar', 'and', 'baz'], { foo: null, bar: null, baz: null })).to.equal(true);
     });
 
     it('AND returns false if either a or b are non-empty', () => {
       expect(fn(['foo', 'and', 'bar'], { foo: 1, bar: null })).to.equal(false);
     });
 
+    it('AND returns false if any fields are non-empty', () => {
+      expect(fn(['foo', 'and', 'bar', 'and', 'baz'], { foo: null, bar: null, baz: 1 })).to.equal(false);
+    });
+
     it('AND returns false if both a and b are non-empty', () => {
       expect(fn(['foo', 'and', 'bar'], { foo: 1, bar: 1 })).to.equal(false);
     });
 
+    it('AND returns false if all fields are non-empty', () => {
+      expect(fn(['foo', 'and', 'bar', 'and', 'baz'], { foo: 1, bar: 1, baz: 1 })).to.equal(false);
+    });
+
+    // OR - two fields, multiple fields
+
     it('OR returns true if both a and b are empty', () => {
       expect(fn(['foo', 'or', 'bar'], { foo: null, bar: null })).to.equal(true);
+    });
+
+    it('OR returns true if all fields are empty', () => {
+      expect(fn(['foo', 'or', 'bar', 'or', 'baz'], { foo: null, bar: null, baz: null })).to.equal(true);
     });
 
     it('OR returns true if either a or b are non-empty', () => {
       expect(fn(['foo', 'or', 'bar'], { foo: 1, bar: null })).to.equal(true);
     });
 
+    it('OR returns true if any fields are non-empty', () => {
+      expect(fn(['foo', 'or', 'bar', 'or', 'baz'], { foo: null, bar: null, baz: 1 })).to.equal(true);
+    });
+
     it('OR returns false if both a and b are non-empty', () => {
       expect(fn(['foo', 'or', 'bar'], { foo: 1, bar: 1 })).to.equal(false);
     });
+
+    it('OR returns false if all fields are non-empty', () => {
+      expect(fn(['foo', 'or', 'bar', 'or', 'baz'], { foo: 1, bar: 1, baz: 1 })).to.equal(false);
+    });
+
+    // XOR - only two fields can logically be compared
 
     it('XOR returns false if both a and b are empty', () => {
       expect(fn(['foo', 'xor', 'bar'], { foo: null, bar: null })).to.equal(false);
@@ -85,18 +127,24 @@ describe('placeholders', () => {
       expect(fn({ foo: 1 }, { ifEmpty: 'foo' })).to.equal(false);
     });
 
+    // comparing multiple fields
+    // note: we're fully testing compareFields above, so we don't need to go through
+    // all the possible combinations and comparators here
+
     it('returns true if two empty fields', () => {
       expect(fn({ foo: null, bar: null }, { ifEmpty: 'foo and bar' })).to.equal(true);
     });
 
+    it('returns true if more than two empty fields', () => {
+      expect(fn({ foo: null, bar: null, baz: null }, { ifEmpty: 'foo and bar and baz' })).to.equal(true);
+    });
+
     it('returns false if two non-empty fields', () => {
-      // note: we're fully testing compareTwoFields above, so we don't need to go through
-      // all the possible combinations and comparators here
       expect(fn({ foo: 1, bar: 1 }, { ifEmpty: 'foo and bar' })).to.equal(false);
     });
 
-    it('throws error if more than two fields', () => {
-      expect(() => fn({}, { ifEmpty: 'foo and bar and baz' }, 'foo')).to.throw('Too many arguments in \'ifEmpty\' statement! (foo and bar and baz)');
+    it('returns false if more than two two non-empty fields', () => {
+      expect(fn({ foo: 1, bar: 1, baz: 1 }, { ifEmpty: 'foo and bar and baz' })).to.equal(false);
     });
   });
 


### PR DESCRIPTION
* compare more than two fields in `ifEmpty` statements (when creating placeholders for groups)
* based on an idea / reference implementation that @byronhulcher did (thanks Byron!)
* allows comparing more than two fields _only if using identical comparators_ (e.g. `foo and bar and baz`, not `foo and bar or baz`)
* `xor` can logically only compare two booleans