### PR TITLE
support amphora 5

### DIFF
--- a/behaviors/magic-button-transformers.js
+++ b/behaviors/magic-button-transformers.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import speakingurl from 'speakingurl';
 import striptags from 'striptags';
 import { decode } from 'he';
-import { getComponentName, getComponentInstance, getComponentVersion } from '../lib/utils/references';
+import { getComponentName, getComponentInstance, getComponentVersion, componentRoute } from '../lib/utils/references';
 
 /**
  * Removes all unicode from string
@@ -57,7 +57,7 @@ export default {
       instance = getComponentInstance(data),
       version = getComponentVersion(data);
 
-    let path = '/components/' + name;
+    let path = componentRoute + name;
 
     if (instance) {
       // this allows us to get default component data as well as instance data

--- a/behaviors/magic-button.vue
+++ b/behaviors/magic-button.vue
@@ -121,7 +121,7 @@
   import _ from 'lodash';
   import { find } from '@nymag/dom';
   import { getFieldData } from '../lib/forms/field-helpers';
-  import { refAttr } from '../lib/utils/references';
+  import { refAttr, componentRoute } from '../lib/utils/references';
   import { send } from '../lib/utils/rest';
   import { reduce as reducePromise } from '../lib/utils/promises';
   import { uriToUrl } from '../lib/utils/urls';
@@ -136,7 +136,7 @@
    * @return {string}
    */
   function findComponent(component) {
-    const firstComponent = find(`[${refAttr}*="/components/${component}"]`);
+    const firstComponent = find(`[${refAttr}*="${componentRoute}${component}"]`);
 
     if (firstComponent) {
       return firstComponent.getAttribute(refAttr);

--- a/behaviors/wysiwyg-paste.js
+++ b/behaviors/wysiwyg-paste.js
@@ -1,6 +1,9 @@
 import _ from 'lodash';
 import striptags from 'striptags';
 import store from '../lib/core-data/store';
+import logger from '../lib/utils/log';
+
+const log = logger(__filename);
 
 /**
  * determine if a paragraph contains a specified tag
@@ -128,7 +131,7 @@ export function matchComponents(strings, rules) {
     try {
       val = striptags(component.value);
     } catch (e) {
-      console.warn('Cannot parse match:', e);
+      log.warn(`Cannot parse match: ${e.message}`, { action: 'filterMatches' });
       val = '';
     }
 
@@ -187,7 +190,7 @@ export function generatePasteRules(pasteRules, currentComponent, currentField) {
     try {
       rule.match = new RegExp(`${pre}${rule.match}${post}`);
     } catch (e) {
-      console.error(e.message);
+      log.error(`Error creating regex for matching: ${e.message}`, { action: 'generatePasteRules' });
       throw e;
     }
 

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -4,14 +4,17 @@ import { UPDATE_COMPONENT, REVERT_COMPONENT, REMOVE_COMPONENT, CURRENTLY_SAVING 
 import { getData, getSchema } from '../core-data/components';
 import { getComponentName, refProp, refAttr, layoutAttr, editAttr, componentListProp, componentProp } from '../utils/references';
 import { save as modelSave, render as modelRender } from './model';
-import { save, getObject } from '../core-data/api';
+import { save } from '../core-data/api';
 import { add as addToQueue } from '../core-data/queue';
 import label from '../utils/label';
 import { getComponentEl, getParentComponent, getPrevComponent, isComponentInPage } from '../utils/component-elements';
 import getAvailableComponents from '../utils/available-components';
 import create from './create';
-import { getComponentNode, getComponentRef, getComponentListStartFromComponent } from '../utils/head-components';
+import { getComponentRef, getComponentListStartFromComponent } from '../utils/head-components';
 import { publish } from './pubsub';
+import logger from '../utils/log';
+
+const log = logger(__filename);
 
 /**
  * log errors when components save and display them to the user
@@ -20,7 +23,7 @@ import { publish } from './pubsub';
  * @param  {object} store
  */
 function logSaveError(uri, e, store) {
-  console.error(`Error saving component (${getComponentName(uri)}): ${e.message}`);
+  log.error(`Error saving component (${getComponentName(uri)}): ${e.message}`, { action: 'saveComponent', uri });
   store.dispatch('finishProgress', 'error');
   store.dispatch('showStatus', { type: 'error', message: `Changes made to ${label(getComponentName(uri))} were not saved!` });
 }
@@ -166,7 +169,7 @@ export function removeComponent(store, el) {
     newList = _.without(list, currentData);
     promise = saveComponent(store, { uri: parentURI, data: { [path]: newList } });
   } else if (_.isObject(list)) {
-    console.error('Removing components from props (without replacing them) is not currently supported!');
+    log.error('Removing components from props (without replacing them) is not currently supported!', { action: 'removeComponent', uri });
   } else if (_.isString(list)) {
     // list in a page
     newList = _.without(list, uri); // we only need the uri, not a full object
@@ -287,7 +290,7 @@ function addComponentsToComponentProp(store, data, {parentURI, path, components}
   const oldURI = data[path][refProp];
 
   if (components.length > 1) {
-    console.warn(`Attempting to add multiple components to a component prop: ${getComponentName(parentURI)} » ${path}. Only the first component (${_.head(components).name}) will be added!`);
+    log.warn(`Attempting to add multiple components to a component prop: ${getComponentName(parentURI)} » ${path}. Only the first component (${_.head(components).name}) will be added!`, { action: 'addComponentsToComponentProp' });
   }
 
   // only create the first one

--- a/lib/component-data/actions.test.js
+++ b/lib/component-data/actions.test.js
@@ -64,7 +64,7 @@ describe('component-data actions', () => {
     it('reverts components with model.js if model.js errors', () => {
       model.save.returns(Promise.reject(new Error('nope')));
       return fn(store, { uri, data, prevData }).catch(() => {
-        expect(console.error).to.have.been.calledWith('Error saving component (foo): nope');
+        expect(loggerStub.error.called).to.equal(true);
       });
     });
 
@@ -83,7 +83,7 @@ describe('component-data actions', () => {
       model.render.returns(Promise.resolve(data));
       return fn(store, { uri, data, prevData }).catch(() => {
         expect(queue.add).to.have.been.calledWith(api.save, [uri, data, false], 'save');
-        expect(console.error).to.have.been.calledWith('Error saving component (foo): nope');
+        expect(loggerStub.error.called).to.equal(true);
       });
     });
 

--- a/lib/component-data/actions.test.js
+++ b/lib/component-data/actions.test.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import * as model from './model';
 import * as template from './template';
 import * as api from '../core-data/api';

--- a/lib/component-data/reactive-render.js
+++ b/lib/component-data/reactive-render.js
@@ -9,6 +9,9 @@ import { refAttr, editAttr, isComponent } from '../utils/references';
 import addPlaceholder from '../decorators/placeholders';
 import addComponentList from '../decorators/component-list';
 import { getComponentFragment, getComponentListFragment, replaceHeadComponent, replaceHeadList } from '../utils/head-components';
+import logger from '../utils/log';
+
+const log = logger(__filename);
 
 /**
  * intelligently update component in the <head>
@@ -127,7 +130,7 @@ export function updateDOM(uri, newEl, paths) {
     // page or layout. we'll have to find the invidividual component list and diff it with the old one
     updateRootDOM(uri, newEl, paths);
   } else {
-    console.error(`Unknown node type (${newEl.nodeType}) for "${uri}"`);
+    log.error(`Unknown node type (${newEl.nodeType}) for "${uri}"`, { action: 'updateDOM' });
   }
 }
 

--- a/lib/component-data/reactive-render.test.js
+++ b/lib/component-data/reactive-render.test.js
@@ -22,7 +22,7 @@ describe('reactive render', () => {
       const weirdNode = document.createComment('hi mom');
 
       fn('foo', weirdNode);
-      expect(console.error).to.have.been.calledWith('Unknown node type (8) for "foo"');
+      expect(loggerStub.error.called).to.equal(true);
     });
 
     it('updates body components when passed element', () => {

--- a/lib/decorators/actions.js
+++ b/lib/decorators/actions.js
@@ -5,6 +5,9 @@ import { refAttr, layoutAttr } from '../utils/references';
 import { scrollToY } from '../utils/scroll';
 import { checkValidity } from '../forms/native-validation';
 import { getParentField } from './select';
+import logger from '../utils/log';
+
+const log = logger(__filename);
 
 let isCurrentlyFocusing = false;
 
@@ -95,7 +98,7 @@ export function unfocus({ commit, dispatch, state }) {
     commit(UN_FOCUS);
     return dispatch('closeForm');
   } else if (current) {
-    console.warn('Unable to close form; Native validation failed.');
+    log.warn('Unable to close form: Native validation failed.', { action: 'unfocus' });
     return Promise.reject();
   } else {
     return Promise.resolve();

--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -12,6 +12,9 @@ import addPlaceholder from './placeholders';
 import addComponentList from './component-list';
 import addComponentProp from './component-prop';
 import addFocus from './focus';
+import logger from '../utils/log';
+
+const log = logger(__filename);
 
 /**
  * add checksum for more accurate dom diffing when re-rendering components
@@ -89,7 +92,7 @@ export function decorate(uri, el) {
   if (!_.get(store, `state.components['${uri}']`)) {
     // warn if we try to decorate a component that doesn't have data in the store for some reason,
     // e.g. dynamically-inserted components in legacy server.js files
-    console.warn(`No data in the store for ${uri}!`);
+    log.warn(`No data in the store for ${uri}!`, { action: 'decorate', uri });
   } else {
     // otherwise, decorate normally
     addDiffingChecksum(uri, el);

--- a/lib/decorators/select.js
+++ b/lib/decorators/select.js
@@ -7,9 +7,11 @@ import { refAttr, layoutAttr, editAttr, refProp, componentListProp, componentPro
 import { getComponentEl, getFieldEl } from '../utils/component-elements';
 import { getData, getSchema } from '../core-data/components';
 import { getEventPath } from '../utils/events';
+import logger from '../utils/log';
 import selectorTpl from './selector.vue';
 
-const Selector = Vue.component('selector', selectorTpl),
+const log = logger(__filename),
+  Selector = Vue.component('selector', selectorTpl),
   delegated = {};
 
 /**
@@ -63,7 +65,7 @@ export function getParentField(child, parent) {
     } else if (_.has(schema, `${path}.${componentProp}`)) {
       return { path, type: 'prop', isEditable: isFieldEditable };
     } else {
-      console.warn(`${getComponentName(parent)} has no field for ${path} in its schema, but has ${getComponentName(child)} in its data`);
+      log.warn(`${getComponentName(parent)} has no field for ${path} in its schema, but has ${getComponentName(child)} in its data`, { action: 'getParentField' });
       // note: the selector buttons that rely on isEditable will not display (since there's no type),
       // but this will expose more information for developers to troubleshoot their schemae
       return { path, isEditable: isFieldEditable };

--- a/lib/decorators/select.test.js
+++ b/lib/decorators/select.test.js
@@ -37,7 +37,7 @@ describe('select', () => {
       components.getData.returns({ fooProp: { [refProp]: '/components/foo' } });
       components.getSchema.returns({});
       fn('/components/foo', '/components/bar');
-      expect(console.warn).to.have.been.calledWith('bar has no field for fooProp in its schema, but has foo in its data');
+      expect(loggerStub.warn.called).to.equal(true);
     });
 
     it('returns path for component in list', () => {

--- a/lib/decorators/selector.vue
+++ b/lib/decorators/selector.vue
@@ -255,7 +255,10 @@
   import { getSettingsFields } from '../core-data/groups';
   import { getComponentName } from '../utils/references';
   import label from '../utils/label';
+  import logger from '../utils/log';
   import icon from '../utils/icon.vue';
+
+  const log = logger(__filename);
 
   /**
   * calculate the selector position, based on how much space is around the component
@@ -347,7 +350,7 @@
         const description = _.get(store, `state.schemas['${this.componentName}']._description`);
 
         if (!description) {
-          console.error(`Cannot open component information: "${this.componentLabel}" has no description!`);
+          log.error(`Cannot open component information: "${this.componentLabel}" has no description!`, { action: 'openInfo' });
         } else {
           return store.dispatch('openPane', {
             title: this.componentLabel,

--- a/lib/decorators/selector.vue
+++ b/lib/decorators/selector.vue
@@ -297,7 +297,7 @@
         return this.currentComponent.uri;
       },
       customButtons() {
-        return Object.keys(window.kiln.selectorButtons);
+        return Object.keys(_.get(window, 'kiln.selectorButtons', {}));
       },
       parentField() {
         return this.isCurrentSelection && this.currentComponent.parentField;
@@ -398,6 +398,6 @@
       // setup event listener, so it can be removed later
       setupResizeListener.call(this);
     },
-    components: _.merge(window.kiln.selectorButtons, { icon })
+    components: _.merge(_.get(window, 'kiln.selectorButtons', {}), { icon })
   };
 </script>

--- a/lib/forms/behaviors.js
+++ b/lib/forms/behaviors.js
@@ -1,6 +1,9 @@
 import _ from 'lodash';
-import { behaviorKey } from '../utils/references';
 import htmlTags from 'html-tags';
+import { behaviorKey } from '../utils/references';
+import logger from '../utils/log';
+
+const log = logger(__filename);
 
 // hash of all behaviors, added to global
 window.kiln = window.kiln || {}; // note: this is here for testing. it should already exist when this file is imported
@@ -41,7 +44,7 @@ function omitMissingBehaviors(behavior) {
     found = !!window.kiln.behaviors[name];
 
   if (!found) {
-    console.warn('Behavior "' + name + '" not found. Make sure you add it!');
+    log.warn('Behavior "' + name + '" not found. Make sure you add it!', { action: 'omitMissingBehaviors' });
   }
 
   return found;
@@ -98,7 +101,7 @@ function getBehaviorSlots(behavior) {
     slot = _.get(window, `kiln.behaviors.${name}.slot`);
 
   if (!slot) {
-    console.warn('Behavior "' + name + '" has no slot specified. Make sure you add it!');
+    log.warn('Behavior "' + name + '" has no slot specified. Make sure you add it!', { action: 'getBehaviorSlots' });
   } else {
     behavior.slot = slot;
   }

--- a/lib/forms/behaviors.test.js
+++ b/lib/forms/behaviors.test.js
@@ -69,7 +69,7 @@ describe('behaviors', () => {
 
     it('warns if behavior slot not found in definition', () => {
       fn('foo');
-      expect(console.warn).to.have.been.calledWith('Behavior "foo" has no slot specified. Make sure you add it!');
+      expect(loggerStub.warn.called).to.equal(true);
     });
 
     it('adds behavior slot from definition', () => {
@@ -78,7 +78,7 @@ describe('behaviors', () => {
 
     it('omits missing behaviors', () => {
       expect(fn('baz')).to.eql([]);
-      expect(console.warn).to.have.been.calledWith('Behavior "baz" not found. Make sure you add it!');
+      expect(loggerStub.warn.called).to.equal(true);
     });
 
     it('converts behavior names that match native tags', () => {
@@ -87,7 +87,7 @@ describe('behaviors', () => {
 
     it('converts behaviors name BEFORE omitting', () => {
       expect(fn('textarea')).to.eql([]);
-      expect(console.warn).to.have.been.calledWith('Behavior "input-textarea" not found. Make sure you add it!');
+      expect(loggerStub.warn.called).to.equal(true);
     });
   });
 });

--- a/lib/page-data/actions.js
+++ b/lib/page-data/actions.js
@@ -5,14 +5,16 @@ import { add as addToQueue } from '../core-data/queue';
 import { replaceVersion, pagesRoute, refProp, htmlExt, editExt, urisRoute, scheduleRoute } from '../utils/references';
 import { uriToUrl, urlToUri } from '../utils/urls';
 import { props } from '../utils/promises';
+import logger from '../utils/log';
 
 // saving these paths should NOT trigger a re-render of the page
-const internalPageProps = [
-  'layout',
-  'customUrl',
-  'url',
-  'urlHistory'
-];
+const log = logger(__filename),
+  internalPageProps = [
+    'layout',
+    'customUrl',
+    'url',
+    'urlHistory'
+  ];
 
 /**
  * iterate through the paths we're saving
@@ -25,27 +27,27 @@ function shouldRender(paths) {
 }
 
 function logSaveError(uri, e) {
-  console.error(`Error saving page: ${e.message}`);
+  log.error(`Error saving page: ${e.message}`, { action: 'savePage', uri });
   store.dispatch('showStatus', { type: 'error', message: 'Changes made to current page were not saved!' });
 }
 
 function queuePageSave(uri, data, oldData, store, {snapshot, paths}) { // eslint-disable-line
   addToQueue(save, [uri, data], 'save')
-  .then(() => getHTML(uri))
-  .then((html) => {
-    // note: we don't care about the data we got back from the api
-    store.commit(UPDATE_PAGE, data);
-    if (shouldRender(paths)) {
-      return store.dispatch('render', { uri, html, snapshot, paths });
-    }
-  })
-  .catch((e) => {
-    store.commit(REVERT_PAGE, oldData);
-    logSaveError(uri, e);
-    if (shouldRender(paths)) {
-      return store.dispatch('render', { uri, html: document, snapshot, paths });
-    }
-  });
+    .then(() => getHTML(uri))
+    .then((html) => {
+      // note: we don't care about the data we got back from the api
+      store.commit(UPDATE_PAGE, data);
+      if (shouldRender(paths)) {
+        return store.dispatch('render', { uri, html, snapshot, paths });
+      }
+    })
+    .catch((e) => {
+      store.commit(REVERT_PAGE, oldData);
+      logSaveError(uri, e);
+      if (shouldRender(paths)) {
+        return store.dispatch('render', { uri, html: document, snapshot, paths });
+      }
+    });
 }
 
 /**
@@ -81,7 +83,7 @@ export function createPage(store, id) {
       return `${uriToUrl(newPage[refProp])}${htmlExt}${editExt}`;
     })
     .catch((e) => {
-      console.error(`Error creating page: ${e.message}`);
+      log.error(`Error creating page: ${e.message}`, { action: 'createPage', uri: `${prefix}${pagesRoute}${id}` });
       store.dispatch('finishProgress', 'error');
       store.dispatch('showStatus', { type: 'error', message: 'Error creating page!' });
       throw e;

--- a/lib/utils/api.js
+++ b/lib/utils/api.js
@@ -11,6 +11,7 @@ import * as urls from './urls';
 import getAvailableComponents from './available-components';
 import * as local from './local';
 import * as validationHelpers from '../validators/helpers';
+import * as log from './log';
 
 // these utilities are exported so 3rd party plugins/validators/behaviors/panes can access them.
 // note: the store is passed into those things automatically, so don't export it here
@@ -28,6 +29,7 @@ const api = {
   getAvailableComponents,
   local,
   validationHelpers,
+  log,
   version: process.env.KILN_VERSION
 };
 

--- a/lib/utils/api.js
+++ b/lib/utils/api.js
@@ -11,7 +11,7 @@ import * as urls from './urls';
 import getAvailableComponents from './available-components';
 import * as local from './local';
 import * as validationHelpers from '../validators/helpers';
-import * as log from './log';
+import logger from './log';
 
 // these utilities are exported so 3rd party plugins/validators/behaviors/panes can access them.
 // note: the store is passed into those things automatically, so don't export it here
@@ -29,7 +29,7 @@ const api = {
   getAvailableComponents,
   local,
   validationHelpers,
-  log,
+  logger, // plugin authors, please instantiate a logger from this (passing in the filename / plugin used)
   version: process.env.KILN_VERSION
 };
 

--- a/lib/utils/local.js
+++ b/lib/utils/local.js
@@ -1,5 +1,8 @@
 import _ from 'lodash';
 import lf from 'localforage';
+import logger from './log';
+
+const log = logger(__filename);
 
 // when using this module for the first time, configure the localforage instance
 // note: we're importing all of localForage because it won't let us simply import { config, getItem, setItem }
@@ -51,7 +54,7 @@ export function updateArray(key, itemToAdd, itemProp = 'name') {
     .then((newArray) => _.reverse(_.sortBy(newArray, ['count', itemProp]))) // sort items before putting them back into the array (highest count first)
     .then((newArray) => lf.setItem(key, newArray))
     .catch((e) => {
-      console.error(`Cannot update array in local browser store! ${e.message}`);
+      log.error(`Cannot update array in local browser store! ${e.message}`, { action: 'updateArray' });
       return []; // fail gracefully
     });
 }

--- a/lib/utils/log.js
+++ b/lib/utils/log.js
@@ -1,0 +1,90 @@
+import _ from 'lodash';
+import clayLog from 'clay-log';
+
+clayLog.init({
+  name: 'kiln',
+  meta: {
+    kilnVersion: process.env.KILN_VERSION, // compile-time added
+    browserVersion: window.navigator.userAgent
+  }
+});
+
+/**
+ * log informational messages
+ * @param  {function} logger
+ * @returns {function}
+ */
+function info(logger) {
+  return (message, logObj) => logger('info', message, logObj);
+}
+
+/**
+ * log trace messages (with stack traces)
+ * @param  {function} logger
+ * @returns {function}
+ */
+function trace(logger) {
+  return (message, logObj) => logger('trace', message, logObj);
+}
+
+/**
+ * log debug messages (without stack traces)
+ * @param  {function} logger
+ * @returns {function}
+ */
+function debug(logger) {
+  return (message, logObj) => logger('debug', message, logObj);
+}
+
+/**
+ * log warning messages
+ * @param  {function} logger
+ * @returns {function}
+ */
+function warn(logger) {
+  return (message, logObj) => logger('warn', message, logObj);
+}
+
+/**
+ * log error messages
+ * note: you can simply pass in an Error and it will print nicely
+ * @param  {function} logger
+ * @returns {function}
+ */
+function error(logger) {
+  return (message, logObj) => {
+    if (_.isString(message)) {
+      logger('error', message, logObj);
+    } else {
+      logger('error', message); // pass in error object directly
+    }
+  };
+}
+
+/**
+ * instantiate a logger for your file
+ * note for plugin authors: when using the log service, please make use of the
+ * file-specific log metadata to provide additional info when debugging, e.g.
+ * plugin (plugin name), action (intended action of the code calling the logger), etc
+ * @param  {string|object} [filename] or file-specific log metadata
+ * @return {object}
+ */
+export default function (filename) {
+  let logger;
+
+  if (_.isString(filename)) {
+    logger = clayLog.meta({ file: filename });
+  } else if (_.isObject(filename)) {
+    logger = clayLog.meta(filename);
+  } else {
+    logger = clayLog.meta({}); // empty object for file-specific meta, maintains the syntax for other logs
+  }
+
+  return {
+    info: info(logger),
+    trace: trace(logger),
+    debug: debug(logger),
+    warn: warn(logger),
+    error: error(logger)
+  };
+}

--- a/lib/utils/references.js
+++ b/lib/utils/references.js
@@ -2,13 +2,18 @@ import _ from 'lodash';
 import dom from '@nymag/dom';
 import store from '../core-data/store';
 
+// route prefix (e.g. '_' or just '') is determined in the template when kiln loads.
+// amphora 4.x and below don't have a prefix, whereas amphora 5.x and above use
+// /_components, /_pages, /_uris, etc
+const routePrefix = _.get(window, 'kiln.routePrefix', '');
+
 /**
  * determine if a uri points to a component
  * @param  {string}  uri
  * @return {Boolean}
  */
 export function isComponent(uri) {
-  return _.includes(uri, '/components/');
+  return !!uri.match(/\/_?components\//);
 }
 
 /**
@@ -17,7 +22,7 @@ export function isComponent(uri) {
  * @return {Boolean}
  */
 export function isDefaultComponent(uri) {
-  return !!uri.match(/\/components\/[A-Za-z0-9\-]+$/);
+  return !!uri.match(/\/_?components\/[A-Za-z0-9\-]+$/);
 }
 
 /**
@@ -29,7 +34,7 @@ export function isDefaultComponent(uri) {
  * @return {string|null}
  */
 export function getComponentName(uri) {
-  const result = /components\/(.+?)[\/\.]/.exec(uri) || /components\/(.*)/.exec(uri);
+  const result = /_?components\/(.+?)[\/\.]/.exec(uri) || /_?components\/(.*)/.exec(uri);
 
   return result && result[1];
 }
@@ -40,13 +45,13 @@ export function getComponentName(uri) {
  * @return {string|null}
  */
 export function getComponentInstance(uri) {
-  const result = /\/components\/.+?\/instances\/([^\.@]+)/.exec(uri);
+  const result = /\/_?components\/.+?\/instances\/([^\.@]+)/.exec(uri);
 
   return result && result[1];
 }
 
 export function getComponentVersion(uri) {
-  const result = /\/components\/.+?@(.+)/.exec(uri);
+  const result = /\/_?components\/.+?@(.+)/.exec(uri);
 
   return result && result[1];
 }
@@ -83,7 +88,7 @@ export function getComponentByNameAndInstance(name, instance) {
     uri;
 
   if (name && instance && sitePrefix) {
-    uri = `${sitePrefix}/components/${name}/instances/${instance}`;
+    uri = `${sitePrefix}/${routePrefix}components/${name}/instances/${instance}`;
 
     return {
       uri,
@@ -116,12 +121,12 @@ export const pubProp = '_publish';
 export const subProp = '_subscribe';
 export const behaviorKey = 'fn'; // used to look up behavior function
 // api routes, extensions, and headers
-export const componentRoute = '/components/';
-export const pagesRoute = '/pages/';
-export const urisRoute = '/uris/';
-export const usersRoute = '/users/';
-export const listsRoute = '/lists/';
-export const scheduleRoute = '/schedule'; // no ending slash
+export const componentRoute = `/${routePrefix}components/`;
+export const pagesRoute = `/${routePrefix}pages/`;
+export const urisRoute = `/${routePrefix}uris/`;
+export const usersRoute = `/${routePrefix}users/`;
+export const listsRoute = `/${routePrefix}lists/`;
+export const scheduleRoute = `/${routePrefix}schedule`; // no ending slash
 export const schemaRoute = '/schema'; // no ending slash
 export const instancesRoute = '/instances'; // no ending slash
 export const searchRoute = '/_search';

--- a/lib/utils/references.test.js
+++ b/lib/utils/references.test.js
@@ -1,21 +1,28 @@
 import _ from 'lodash';
 import * as lib from './references';
 
+// note: all tests are doubled, so we can maintain both amphora 4.x (/components)
+// and amphora 5.x (/_components) compatibility
+
 describe('references', () => {
   describe('isComponent', () => {
     const fn = lib.isComponent;
 
     it('returns true if component reference', () => {
       expect(fn('domain.com/components/foo')).to.equal(true);
+      expect(fn('domain.com/_components/foo')).to.equal(true);
     });
 
     it('returns true if component instance reference', () => {
       expect(fn('domain.com/components/foo/instances/bar')).to.equal(true);
+      expect(fn('domain.com/_components/foo/instances/bar')).to.equal(true);
     });
 
     it('returns false if non-component reference', () => {
       expect(fn('domain.com/users/foo')).to.equal(false);
       expect(fn('domain.com/pages/foo')).to.equal(false);
+      expect(fn('domain.com/_users/foo')).to.equal(false);
+      expect(fn('domain.com/_pages/foo')).to.equal(false);
     });
   });
 
@@ -24,15 +31,19 @@ describe('references', () => {
 
     it('returns true if default component reference', () => {
       expect(fn('domain.com/components/foo')).to.equal(true);
+      expect(fn('domain.com/_components/foo')).to.equal(true);
     });
 
     it('returns false if component instance reference', () => {
       expect(fn('domain.com/components/foo/instances/bar')).to.equal(false);
+      expect(fn('domain.com/_components/foo/instances/bar')).to.equal(false);
     });
 
     it('returns false if non-component reference', () => {
       expect(fn('domain.com/users/foo')).to.equal(false);
       expect(fn('domain.com/pages/foo')).to.equal(false);
+      expect(fn('domain.com/_users/foo')).to.equal(false);
+      expect(fn('domain.com/_pages/foo')).to.equal(false);
     });
   });
 
@@ -41,23 +52,29 @@ describe('references', () => {
 
     it('gets name from default uri', function () {
       expect(fn('/components/base')).to.equal('base');
+      expect(fn('/_components/base')).to.equal('base');
     });
 
     it('gets name from instance uri', function () {
       expect(fn('/components/base/instances/0')).to.equal('base');
+      expect(fn('/_components/base/instances/0')).to.equal('base');
     });
 
     it('gets name from versioned uri', function () {
       expect(fn('/components/base/instances/0@published')).to.equal('base');
+      expect(fn('/_components/base/instances/0@published')).to.equal('base');
     });
 
     it('gets name from uri with extension', function () {
       expect(fn('/components/base.html')).to.equal('base');
       expect(fn('/components/base.json')).to.equal('base');
+      expect(fn('/_components/base.html')).to.equal('base');
+      expect(fn('/_components/base.json')).to.equal('base');
     });
 
     it('gets name from full uri', function () {
       expect(fn('nymag.com/press/components/base/instances/foobarbaz@published')).to.equal('base');
+      expect(fn('nymag.com/press/_components/base/instances/foobarbaz@published')).to.equal('base');
     });
   });
 
@@ -66,22 +83,27 @@ describe('references', () => {
 
     it('gets instance from uri', function () {
       expect(fn('/components/base/instances/0')).to.equal('0');
+      expect(fn('/_components/base/instances/0')).to.equal('0');
     });
 
     it('gets instance from uri with extension', function () {
       expect(fn('/components/base/instances/0.html')).to.equal('0');
+      expect(fn('/_components/base/instances/0.html')).to.equal('0');
     });
 
     it('gets instance from uri with version', function () {
       expect(fn('/components/base/instances/0@published')).to.equal('0');
+      expect(fn('/_components/base/instances/0@published')).to.equal('0');
     });
 
     it('gets instance from full uri', function () {
       expect(fn('nymag.com/press/components/base/instances/foobarbaz@published')).to.equal('foobarbaz');
+      expect(fn('nymag.com/press/_components/base/instances/foobarbaz@published')).to.equal('foobarbaz');
     });
 
     it('CANNOT get instance from default uri', function () {
       expect(fn('/components/base')).to.not.equal('0');
+      expect(fn('/_components/base')).to.not.equal('0');
     });
   });
 
@@ -90,15 +112,19 @@ describe('references', () => {
 
     it('gets version from instance uri', () => {
       expect(fn('/components/foo/instances/bar@published')).to.equal('published');
+      expect(fn('/_components/foo/instances/bar@published')).to.equal('published');
     });
 
     it('gets version from default uri', () => {
       expect(fn('/components/base@published')).to.equal('published');
+      expect(fn('/_components/base@published')).to.equal('published');
     });
 
     it('returns null if no version', () => {
       expect(fn('/components/foo/instances/bar')).to.equal(null);
       expect(fn('/components/base')).to.equal(null);
+      expect(fn('/_components/foo/instances/bar')).to.equal(null);
+      expect(fn('/_components/base')).to.equal(null);
     });
   });
 
@@ -107,14 +133,17 @@ describe('references', () => {
 
     it('adds version to base', function () {
       expect(fn('domain.com/pages/foo', 'bar')).to.equal('domain.com/pages/foo@bar');
+      expect(fn('domain.com/_pages/foo', 'bar')).to.equal('domain.com/_pages/foo@bar');
     });
 
     it('replaces version', function () {
       expect(fn('domain.com/pages/foo@bar', 'baz')).to.equal('domain.com/pages/foo@baz');
+      expect(fn('domain.com/_pages/foo@bar', 'baz')).to.equal('domain.com/_pages/foo@baz');
     });
 
     it('removes version', function () {
       expect(fn('domain.com/pages/foo@bar')).to.equal('domain.com/pages/foo');
+      expect(fn('domain.com/_pages/foo@bar')).to.equal('domain.com/_pages/foo');
     });
 
     it('throws if url is not a string', () => {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-preset-env": "^1.6.0",
     "caret-position": "0.0.1",
     "chai": "^3.5.0",
+    "clay-log": "^1.1.1",
     "codemirror": "^5.23.0",
     "coveralls": "^2.11.2",
     "css-loader": "^0.26.1",

--- a/panes/add-page-to-list.vue
+++ b/panes/add-page-to-list.vue
@@ -63,6 +63,9 @@
 
 <script>
   import _ from 'lodash';
+  import logger from '../lib/utils/log';
+
+  const log = logger(__filename);
 
   export default {
     data() {
@@ -83,7 +86,7 @@
             this.$store.dispatch('finishProgress', 'save');
             this.$store.dispatch('showStatus', { type: 'save', message: `Added ${title} to Page Templates!` });
           }).catch((e) => {
-            console.error(e);
+            log.error(e.message, { action: 'addPage', uri });
             this.$store.dispatch('finishProgress', 'error');
             this.$store.dispatch('showStatus', { type: 'error', message: `Error adding ${title} to Page Templates: ${e.message}` });
           });

--- a/panes/add-person-to-page.vue
+++ b/panes/add-person-to-page.vue
@@ -93,6 +93,9 @@
   import { find } from '@nymag/dom';
   import { postJSON } from '../lib/core-data/api';
   import { searchRoute } from '../lib/utils/references';
+  import logger from '../lib/utils/log';
+
+  const log = logger(__filename);
 
   function buildUserQuery(query) {
     const str = _.isString(query) && query.toLowerCase() || '';
@@ -153,7 +156,7 @@
             return this.$store.dispatch('closePane');
           })
           .catch((e) => {
-            console.error(e);
+            log.error(e.message, { action: 'addPersonToPage' });
             store.dispatch('finishProgress', 'error');
             store.dispatch('showStatus', { type: 'error', message: `Error adding ${user.username} to page: ${e.message}` });
           });

--- a/panes/add-person.vue
+++ b/panes/add-person.vue
@@ -104,6 +104,9 @@
   import _ from 'lodash';
   import { find } from '@nymag/dom';
   import { postJSON } from '../lib/core-data/api';
+  import logger from '../lib/utils/log';
+
+  const log = logger(__filename);
 
   export default {
     data() {
@@ -144,7 +147,7 @@
             store.dispatch('finishProgress', 'save');
             store.dispatch('showStatus', { type: 'save', message: `Added ${username} to all sites!` });
           }).catch((e) => {
-            console.error(e);
+            log.error(e.message, { action: 'createUser', username: user.username, provider: user.provider });
             store.dispatch('finishProgress', 'error');
             store.dispatch('showStatus', { type: 'error', message: `Error adding ${username} to Clay: ${e.message}` });
           });

--- a/panes/preview-share.vue
+++ b/panes/preview-share.vue
@@ -165,12 +165,14 @@
   import { uriToUrl } from '../lib/utils/urls';
   import icon from '../lib/utils/icon.vue';
   import { mapState } from 'vuex';
+  import logger from '../lib/utils/log';
 
-  const previewSizes = {
-    small: { w: 375, h: 660 },
-    medium: { w: 768, h: 1024 },
-    large: { w: 1024, h: 768 }
-  };
+  const log = logger(__filename),
+    previewSizes = {
+      small: { w: 375, h: 660 },
+      medium: { w: 768, h: 1024 },
+      large: { w: 1024, h: 768 }
+    };
 
   export default {
     components: {
@@ -206,7 +208,7 @@
           // some browsers can't do this.
           button.classList.remove('success');
           button.classList.add('error');
-          console.error(`Error copying preview link: ${e.message}`);
+          log.error(`Error copying preview link: ${e.message}`, { action: 'copyURL' });
         }
       }
     }

--- a/panes/publish-pane/page-actions.vue
+++ b/panes/publish-pane/page-actions.vue
@@ -87,6 +87,9 @@
   import distanceInWordsToNow from 'date-fns/distance_in_words_to_now';
   import { hasNativePicker, init as initPicker } from '../../lib/utils/datepicker';
   import { START_PROGRESS, FINISH_PROGRESS } from '../../lib/toolbar/mutationTypes';
+  import logger from '../../lib/utils/log';
+
+  const log = logger(__filename);
 
   function calendar(date) {
     if (isToday(date)) {
@@ -129,7 +132,7 @@
         this.$store.dispatch('closePane');
         this.$store.dispatch('publishPage', this.$store.state.page.uri)
           .catch((e) => {
-            console.error(`Error publishing page: ${e.message}`);
+            log.error(`Error publishing page: ${e.message}`, { action: 'onPublishClick' });
             store.dispatch('showStatus', { type: 'error', message: 'Error publishing page!'});
             throw e;
           })

--- a/panes/publish-pane/page-status.vue
+++ b/panes/publish-pane/page-status.vue
@@ -85,6 +85,9 @@
   import { htmlExt, editExt } from '../../lib/utils/references';
   import { START_PROGRESS, FINISH_PROGRESS } from '../../lib/toolbar/mutationTypes';
   import icon from '../../lib/utils/icon.vue';
+  import logger from '../../lib/utils/log';
+
+  const log = logger(__filename);
 
   export default {
     data() {
@@ -132,7 +135,7 @@
         this.$store.dispatch('unschedulePage', this.$store.state.page.uri)
           .catch((e) => {
             store.commit(FINISH_PROGRESS, 'error');
-            console.error(`Error unscheduling page: ${e.message}`);
+            log.error(`Error unscheduling page: ${e.message}`, { action: 'unschedulePage' });
             store.dispatch('showStatus', { type: 'error', message: 'Error unscheduling page!'});
             throw e;
           })
@@ -150,7 +153,7 @@
         this.$store.dispatch('unpublishPage', uri)
           .catch((e) => {
             store.commit(FINISH_PROGRESS, 'error');
-            console.error(`Error unpublishing page: ${e.message}`);
+            log.error(`Error unpublishing page: ${e.message}`, { action: 'unpublishPage' });
             store.dispatch('showStatus', { type: 'error', message: 'Error unpublishing page!'});
             throw e;
           })

--- a/template.handlebars
+++ b/template.handlebars
@@ -5,7 +5,7 @@
       // start scaffolding kiln stuff
       window.kiln = window.kiln || {};
       // figure out the route prefix (e.g. /components, or /_components) based on the _ref of kiln itself
-      window.kiln.routePrefix = '{{ default _ref _self }}'.indexOf('/_components/') ? '_' : '';
+      window.kiln.routePrefix = '{{ default _ref _self }}'.indexOf('/_components/') > -1 ? '_' : '';
     </script>
     {{#if @root.locals.edit}}
       {{! show edit mode styles and preload data}}

--- a/template.handlebars
+++ b/template.handlebars
@@ -1,6 +1,12 @@
 {{#if @root.locals.user}}
   {{! if a user is logged in, we display either the view-mode or edit-mode toolbar, and associated scripts, styles, and templates }}
   <div data-uri="{{ default _ref _self }}" class="clay-kiln">
+    <script>
+      // start scaffolding kiln stuff
+      window.kiln = window.kiln || {};
+      // figure out the route prefix (e.g. /components, or /_components) based on the _ref of kiln itself
+      window.kiln.routePrefix = '{{ default _ref _self }}'.indexOf('/_components/') ? '_' : '';
+    </script>
     {{#if @root.locals.edit}}
       {{! show edit mode styles and preload data}}
       <style>
@@ -9,7 +15,6 @@
 
       <script>
         // scaffold kiln preloading stuff (models, templates, schemae, data, locals),
-        window.kiln = window.kiln || {};
         window.kiln.componentModels = window.kiln.componentModels || {};
         window.kiln.componentTemplates = window.kiln.componentTemplates || {};
         window.kiln.preloadSchemas = window.kiln.preloadSchemas || {};
@@ -31,7 +36,6 @@
       </style>
 
       <script>
-        window.kiln = window.kiln || {};
         window.kiln.preloadSite = {{{ default (stringify @root.locals.site) '{}' }}};
         window.kiln.preloadUser = {{{ default (stringify @root.locals.user) '{}' }}};
       </script>

--- a/test/setup.js
+++ b/test/setup.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import Vue from 'vue';
 import Vuex from 'vuex';
 import { beforeEachHooks, afterEachHooks, mount } from 'vue-unit/src';
+import * as logger from '../lib/utils/log'; // allow us to stub the default
 
 const testsContext = require.context('../', true, /^\.\/(lib|behaviors)\/.*?\.test\.js$/);
 
@@ -16,11 +17,23 @@ window.renderWithArgs = (Component, props, state) => {
   return mount(Component, { props, store: _.assign({}, defaultStore, { state }) });
 };
 
+// stub logger
+window.loggerStub = {
+  info: sinon.spy(),
+  trace: sinon.spy(),
+  debug: sinon.spy(),
+  warn: sinon.spy(),
+  error: sinon.spy()
+};
+
+sinon.stub(logger, 'default', () => {
+  // return the same instances of our logging spies every time
+  // we create a new logger
+  return window.loggerStub;
+});
+
 window.beforeEachHooks = beforeEachHooks;
 window.afterEachHooks = afterEachHooks;
-
-// don't write to console
-sinon.stub(console);
 
 // run all tests
 testsContext.keys().forEach(testsContext);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,6 +73,10 @@ if (prod) {
 
 module.exports = {
   target: 'web',
+  node: {
+    __filename: true, // actually expand filenames, used for logging
+    __dirname: true
+  },
   entry: {
     edit: './edit.js',
     view: './view.js',


### PR DESCRIPTION
* adds support for underscores in api routes, e.g. `/_components`
* adds `clay-log` logging, using the same syntax as used in `sites`

Logging will have three levels of metadata:

* kiln stuff (`kilnVersion`, `browserVersion`)
* file stuff (`file`, possibly other file-specific metadata as needed)
* log stuff (log message and metadata. all built-in kiln logging provides `action`, and many provide the `uri` of the specific thing they're dealing with)