### PR TITLE
 Make TK validator accept URIs

### DIFF
--- a/lib/validators/built-in/tk.js
+++ b/lib/validators/built-in/tk.js
@@ -8,10 +8,14 @@ export const label = 'TKs',
   description = 'There are TKs in your article. Make sure they\'re intentional',
   type = 'warning';
 
+function isUri(str) {
+  return !!/^[^\s]+[\/.][^\s]+$/.exec(str);
+}
+
 export function validate(state) {
   return _.reduce(state.components, (result, component, uri) => {
     _.forOwn(component, (val, key) => {
-      const text = _.isString(val) && striptags(val);
+      const text = _.isString(val) && !isUri(val) && striptags(val);
 
       if (key !== refProp && text && _.includes(text.toLowerCase(), 'tk')) {
         const index = text.toLowerCase().indexOf('tk');

--- a/lib/validators/built-in/tk.test.js
+++ b/lib/validators/built-in/tk.test.js
@@ -60,6 +60,19 @@ describe('validators: beyonce', () => {
       })).to.eql([]);
     });
 
+    it('passes if tk is in a uri', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: 'tktk.gawker.com' }
+        }
+      })).to.eql([]);
+      expect(fn({
+        components: {
+          [uri]: { a: 'host/components/whatever/instances/000tk00' }
+        }
+      }), 'passes amphora-style refs').to.eql([]);
+    });
+
     it('fails if field with tk', () => {
       expect(fn({
         components: {
@@ -78,6 +91,11 @@ describe('validators: beyonce', () => {
         location: 'Foo',
         preview: 'foo tk bar'
       }]);
+      expect(fn({
+        components: {
+          [uri]: { a: 'end of sentence tk. Start of sentence'}
+        }
+      }).length, 'fails tk at the end of a sentence').to.equal(1);
     });
   });
 });

--- a/lib/validators/built-in/tk.test.js
+++ b/lib/validators/built-in/tk.test.js
@@ -70,6 +70,11 @@ describe('validators: beyonce', () => {
         components: {
           [uri]: { a: 'host/components/whatever/instances/000tk00' }
         }
+      }), 'passes classic amphora-style refs').to.eql([]);
+      expect(fn({
+        components: {
+          [uri]: { a: 'host/_components/whatever/instances/000tk00' }
+        }
       }), 'passes amphora-style refs').to.eql([]);
     });
 


### PR DESCRIPTION
Make tk validation not fail on URIs.
Passes both URIs like slate.com and URIs
like localhost/components/foo/instances/00tk00

Fixes validation fail on component data like this:

![screen shot 2017-10-19 at 3 48 17 pm](https://user-images.githubusercontent.com/4691093/31796686-c2404e0e-b4f8-11e7-8230-bb6103a83e87.jpg)

But also fixes TK warn for bare URLs in articles. Example: "the domain bantk.com is available."