### PR TITLE
use colorful default avatars with initials

### DIFF
--- a/lib/nav/collaborator.vue
+++ b/lib/nav/collaborator.vue
@@ -10,7 +10,7 @@
 
 <template>
   <div class="collaborator" @click.stop="selectCollaborator">
-    <avatar class="collaborator-image" :url="user.imageUrl" size="small" ref="avatar"></avatar>
+    <avatar class="collaborator-image" :url="user.imageUrl" size="small" :name="user.name || user.username" ref="avatar"></avatar>
     <ui-tooltip trigger="avatar" position="bottom left">{{ user.name || user.username }}</ui-tooltip>
   </div>
 </template>

--- a/lib/utils/avatar.vue
+++ b/lib/utils/avatar.vue
@@ -1,42 +1,51 @@
 <style lang="sass">
-  @import '../../styleguide/colors';
-
-  .avatar {
-    border-radius: 50%;
-    flex: 0 0 40px;
-    height: 40px;
-    width: 40px;
-
-    &.avatar-small {
-      flex: 0 0 24px;
-      height: 24px;
-      width: 24px;
-    }
-
-    &.avatar-default {
-      align-items: center;
-      background-color: $md-grey-500;
-      color: $pure-white;
-      display: flex;
-      justify-content: center;
-    }
+  .kiln-avatar {
+    flex: 0 0 auto;
   }
 </style>
 
 <template>
-  <img v-if="url" class="avatar" :class="'avatar-' + size" :src="url" />
-  <div v-else class="avatar avatar-default" :class="'avatar-' + size">
-    <ui-icon icon="person"></ui-icon>
-  </div>
+  <avatar class="kiln-avatar" :username="username" :src="imageURL" :size="pixelSize" :rounded="true"></avatar>
 </template>
 
 <script>
-  import UiIcon from 'keen/UiIcon';
+  import _ from 'lodash';
+  import Avatar from 'vue-avatar';
 
   export default {
-    props: ['url', 'size'],
+    props: ['url', 'size', 'name'],
+    computed: {
+      username() {
+        if (_.includes(this.name, ' ')) {
+          // if a name has spaces, it'll generate a nice avatar
+          return this.name;
+        } else if (_.includes(this.name, '@')) {
+          // probably an email
+          const beforeAt = this.name.match(/(.*?)@/)[1];
+
+          return beforeAt.split(/\W/).join(' '); // split everything before the @ by anything that's not a letter/digit/underscore
+        } else if (!_.isEmpty(this.name)) {
+          // some other kind of username, just use the first letter
+          return this.name[0];
+        } else {
+          return 'Walter Plinge'; // https://www.wikiwand.com/en/Walter_Plinge
+        }
+      },
+      imageURL() {
+        // only display the image if it's not the default google avatar
+        if (this.url && this.url.length && this.url !== 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg?sz=50') {
+          return this.url;
+        }
+      },
+      pixelSize() {
+        switch (this.size) {
+          case 'small': return 24;
+          default: return 40;
+        }
+      }
+    },
     components: {
-      UiIcon
+      Avatar
     }
   };
 </script>

--- a/lib/utils/person.vue
+++ b/lib/utils/person.vue
@@ -62,7 +62,7 @@
 
 <template>
   <div class="person-item" :class="{ 'has-primary-action': hasPrimaryAction }">
-    <avatar class="person-image" :url="image" @click.stop="onClick"></avatar>
+    <avatar class="person-image" :url="image" :name="name || subtitle" @click.stop="onClick"></avatar>
     <div class="person-text" @click.stop="onClick">
       <span v-if="name" class="person-name">{{ name }}</span>
       <span v-if="subtitle" class="person-subtitle">{{ subtitle }}</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15279,6 +15279,12 @@
       "integrity": "sha512-k04X7FsyAu+Tmc40KDUFT22LRZNfgHqpsuCWNUnU2FubeyBlVFLuJkxEdvRZEPVOEWIQuazFzYR1N/whfVkqvQ==",
       "dev": true
     },
+    "vue-avatar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vue-avatar/-/vue-avatar-2.1.1.tgz",
+      "integrity": "sha512-jsswVhcW3q6lxE6Yt0wOzhUtq+fyXd+/QGxanuwkTa1wOEPOOY9a7ifE18G8HVanv5/N9oDuHpda7nG6eMrCNw==",
+      "dev": true
+    },
     "vue-hot-reload-api": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "velocity-animate": "^1.5.0",
     "vue": "^2.5.9",
     "vue-async-computed": "^3.3.1",
+    "vue-avatar": "^2.1.1",
     "vue-loader": "^13.5.0",
     "vue-nprogress": "^0.1.5",
     "vue-style-loader": "^3.0.3",


### PR DESCRIPTION
Instead of the bland, grey user icon (or google's default avatar), use colorful circles with the user's initials if they don't have an avatar image

![screen shot 2017-11-29 at 4 58 31 pm](https://user-images.githubusercontent.com/447522/33401296-c795c868-d526-11e7-935a-d1bb7b664a35.png)

![screen shot 2017-11-29 at 3 05 56 pm](https://user-images.githubusercontent.com/447522/33401311-d07fd388-d526-11e7-9c54-bac1b2d561d3.png)

![screen shot 2017-11-29 at 5 00 39 pm](https://user-images.githubusercontent.com/447522/33401322-dea4dc60-d526-11e7-9b5f-a5d8e3e9de43.png)
