### PR TITLE
fix 1026, deep links in view mode

### DIFF
--- a/lib/preloader/actions.js
+++ b/lib/preloader/actions.js
@@ -9,6 +9,7 @@ import { PRELOAD_PENDING, PRELOAD_SUCCESS, LOADING_SUCCESS } from './mutationTyp
 import defaultState from './default-state';
 import normalize from '../utils/normalize-component-data';
 import getSites from './sites';
+import parseUrl from './parse-url';
 import { hasAnyBehaviors, convertSchema } from '../core-data/behaviors2input';
 
 /**
@@ -98,41 +99,6 @@ function getPageStatus(state) {
     return 'published';
   } else {
     return 'draft';
-  }
-}
-
-/**
- * Turn the hash string on the location
- * into an object
- *
- * @return {Object}
- */
-function parseUrl() {
-  if (window.location.hash) {
-    const hashProps = window.location.hash.replace('#', '').split('~');
-
-    let propMapping;
-
-    if (hashProps[0] === 'kiln') {
-      // opening the clay menu
-      propMapping = {
-        tab: hashProps[1],
-        sites: hashProps[2],
-        status: hashProps[3],
-        query: hashProps[4] || ''
-      };
-    } else {
-      // opening a form
-      propMapping = {
-        component: hashProps[0],
-        instance: hashProps[1],
-        path: hashProps[2]
-      };
-    }
-
-    return propMapping;
-  } else {
-    return null;
   }
 }
 

--- a/lib/preloader/mutationTypes.js
+++ b/lib/preloader/mutationTypes.js
@@ -5,5 +5,7 @@ export const LOADING_SUCCESS = 'LOADING_SUCCESS'; // used by view + edit
 export const PRELOAD_SITE = 'PRELOAD_SITE'; // only used by view
 export const PRELOAD_ALL_SITES = 'PRELOAD_ALL_SITES'; // only used by view
 export const PRELOAD_USER = 'PRELOAD_USER'; // only used by view
+export const PRELOAD_URL = 'PRELOAD_URL'; // only used by view
+
 export const META_PRESS = 'META_PRESS'; // only used by edit
 export const META_UNPRESS = 'META_UNPRESS'; // only used by edit

--- a/lib/preloader/mutations.js
+++ b/lib/preloader/mutations.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { PRELOAD_PENDING, PRELOAD_SUCCESS, LOADING_SUCCESS, PRELOAD_SITE, PRELOAD_ALL_SITES, PRELOAD_USER, META_PRESS, META_UNPRESS } from './mutationTypes';
+import { PRELOAD_PENDING, PRELOAD_SUCCESS, LOADING_SUCCESS, PRELOAD_SITE, PRELOAD_ALL_SITES, PRELOAD_USER, PRELOAD_URL, META_PRESS, META_UNPRESS } from './mutationTypes';
 
 export default {
   [PRELOAD_PENDING]: (state) => state,
@@ -8,6 +8,7 @@ export default {
   [PRELOAD_SITE]: (state, site) => _.assign(state, { site }),
   [PRELOAD_ALL_SITES]: (state, sites) => _.assign(state, { allSites: sites }),
   [PRELOAD_USER]: (state, user) => _.assign(state, { user }),
+  [PRELOAD_URL]: (state, urlConfig) => _.assign(state, { url: urlConfig }),
   [META_PRESS]: (state) => {
     state.ui.metaKey = true;
     return state;

--- a/lib/preloader/parse-url.js
+++ b/lib/preloader/parse-url.js
@@ -1,0 +1,34 @@
+/**
+ * Turn the hash string on the location
+ * into an object
+ *
+ * @return {Object}
+ */
+export default function parseUrl() {
+  if (window.location.hash) {
+    const hashProps = window.location.hash.replace('#', '').split('~');
+
+    let propMapping;
+
+    if (hashProps[0] === 'kiln') {
+      // opening the clay menu
+      propMapping = {
+        tab: hashProps[1],
+        sites: hashProps[2],
+        status: hashProps[3],
+        query: hashProps[4] || ''
+      };
+    } else {
+      // opening a form
+      propMapping = {
+        component: hashProps[0],
+        instance: hashProps[1],
+        path: hashProps[2]
+      };
+    }
+
+    return propMapping;
+  } else {
+    return null;
+  }
+}

--- a/view.js
+++ b/view.js
@@ -7,7 +7,8 @@ import { addToolbarButton } from './lib/utils/custom-buttons'; // eslint-disable
 import store from './lib/core-data/store';
 import toolbar from './lib/toolbar/view-toolbar.vue';
 import getSites from './lib/preloader/sites';
-import { PRELOAD_PENDING, LOADING_SUCCESS, PRELOAD_SITE, PRELOAD_ALL_SITES, PRELOAD_USER } from './lib/preloader/mutationTypes';
+import parseUrl from './lib/preloader/parse-url';
+import { PRELOAD_PENDING, LOADING_SUCCESS, PRELOAD_SITE, PRELOAD_ALL_SITES, PRELOAD_USER, PRELOAD_URL } from './lib/preloader/mutationTypes';
 import { UPDATE_PAGE_STATE, UPDATE_PAGEURI } from './lib/page-state/mutationTypes';
 import { META_PRESS, META_UNPRESS } from './lib/preloader/mutationTypes';
 import { props } from './lib/utils/promises';
@@ -69,8 +70,9 @@ document.addEventListener('DOMContentLoaded', function () {
     store.commit(UPDATE_PAGEURI, pageUri());
     store.commit(PRELOAD_ALL_SITES, allSites);
     store.commit(PRELOAD_USER, window.kiln.preloadUser);
+    store.commit(PRELOAD_URL, parseUrl());
     store.commit(LOADING_SUCCESS);
-  });
+  }).then(() => store.dispatch('parseURLHash')); // check for deep-linked clay menu
 
   // when ESC bubbles up to the document, close the current form or pane / unselect components
   document.body.addEventListener('keydown', (e) => {


### PR DESCRIPTION
* moves `parseUrl` into a separate file, so `view.js` can call it directly
* addds the url parsing call to the view-mode preloading, enabling the direct linking of view-mode clay menu