### PR TITLE
client-side layout re-rendering

### DIFF
--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -445,6 +445,7 @@ export function openAddComponent(store, { currentURI, parentURI, path, pos }) {
       path: path,
       components: [{ name: _.head(available) }]
     }).then((newEl) => {
+      // select component if it isn't a layout or head component
       if (newEl) {
         store.dispatch('select', newEl);
       }

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -43,13 +43,12 @@ function logSaveError(uri, e, data, eventID, snapshot, store) { // eslint-disabl
  * re-render (reverting) a component and stop the saving promise chain
  * @param  {string} uri
  * @param  {object} data
- * @param {string} html
  * @param  {boolean} [snapshot]
  * @param  {array} paths
  * @return {Promise}
  */
-function revertReject({ uri, data, html, snapshot, paths }) {
-  return store.dispatch('render', { uri, data, html, snapshot, paths })
+function revertReject({ uri, data, snapshot, paths }) {
+  return store.dispatch('render', { uri, data, snapshot, paths })
     .then(() => Promise.reject(new Error(`Save failed, reverting ${uri}`))); // don't continue saving
 }
 
@@ -436,7 +435,11 @@ export function openAddComponent(store, { currentURI, parentURI, path, pos }) {
       parentURI,
       path: path,
       components: [{ name: _.head(available) }]
-    }).then((newEl) => store.dispatch('select', newEl)));
+    }).then((newEl) => {
+      if (newEl) {
+        store.dispatch('select', newEl);
+      }
+    }));
   } else {
     // open the add components modal
     return store.dispatch('unfocus').then(() => store.commit(OPEN_ADD_COMPONENT, {

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -45,9 +45,10 @@ function logSaveError(uri, e, data, eventID, snapshot, store) { // eslint-disabl
  * @param  {object} data
  * @param  {boolean} [snapshot]
  * @param  {array} paths
+ * @param {object} store
  * @return {Promise}
  */
-function revertReject({ uri, data, snapshot, paths }) {
+function revertReject({ uri, data, snapshot, paths, store }) {
   return store.dispatch('render', { uri, data, snapshot, paths })
     .then(() => Promise.reject(new Error(`Save failed, reverting ${uri}`))); // don't continue saving
 }
@@ -74,7 +75,7 @@ function clientSave(uri, data, oldData, store, {eventID, snapshot, paths}) { // 
         .catch((e) => {
           logSaveError(uri, e, data, eventID, snapshot, store);
           store.commit(REVERT_COMPONENT, {uri, oldData});
-          return revertReject({ uri, data: oldData, snapshot, paths });
+          return revertReject({ uri, data: oldData, snapshot, paths, store });
         });
 
       return savedData;
@@ -92,7 +93,7 @@ function clientSave(uri, data, oldData, store, {eventID, snapshot, paths}) { // 
       // if there are any errors saving, publishing, or re-rendering component,
       // show the end user an error and revert it!
       logSaveError(uri, e, data, eventID, snapshot, store);
-      return revertReject({ uri, data: oldData, snapshot, paths });
+      return revertReject({ uri, data: oldData, snapshot, paths, store });
     });
 }
 
@@ -333,10 +334,18 @@ function addComponentsToPageArea(store, {currentURI, path, replace, components, 
     .then((newComponents) => {
       // note: we have to explicitly save these (rather than relying on the cascading PUT of the parent),
       // because they exist in page data
-      return Promise.all(_.map(newComponents, (component) => store.dispatch('saveComponent', { uri: component[refProp], data: component })))
-        .then(() => {
-          const uris = _.map(newComponents, (component) => component[refProp]);
+      return Promise.all(_.map(newComponents, (component) => {
+        const uri = component[refProp];
 
+        delete component[refProp]; // remove uri from actual data, since we're not doing a cascading PUT
+        return modelSave(uri, component)
+          .then((savedData) => addToQueue(save, [uri, savedData, false], 'save'))
+          .then((savedData) => publish(uri, savedData, null, false, store))
+          .then((savedData) => modelRender(uri, savedData))
+          .then((savedData) => store.commit(UPDATE_COMPONENT, {uri, data: savedData}))
+          .then(() => uri);
+      }))
+        .then((uris) => {
           // todo: add actual element to the dom, so we don't have to do a page reload
           if (replace) {
             // replace current uri when creating new list

--- a/lib/component-data/add-component.vue
+++ b/lib/component-data/add-component.vue
@@ -240,7 +240,11 @@
               path,
               components: [{ name: id }]
             })
-              .then((newEl) => self.$store.dispatch('select', newEl))
+              .then((newEl) => {
+                if (newEl) {
+                  self.$store.dispatch('select', newEl);
+                }
+              })
               .then(() => self.$nextTick(() => self.close()));
           });
       }

--- a/lib/component-data/reactive-render.js
+++ b/lib/component-data/reactive-render.js
@@ -127,6 +127,7 @@ function updateLayout(uri, newEl, paths) {
 export function updateDOM(uri, newEl, paths) {
   const isElement = newEl.nodeType === newEl.ELEMENT_NODE,
     isFragment = newEl.nodeType === newEl.DOCUMENT_FRAGMENT_NODE,
+    isDocument = newEl.nodeType === newEl.DOCUMENT_NODE,
     firstChild = isFragment && newEl.firstElementChild,
     isFullPageFragment = firstChild && firstChild.tagName === 'META' && firstChild.getAttribute('charset') === 'utf-8';
 
@@ -139,9 +140,24 @@ export function updateDOM(uri, newEl, paths) {
   } else if (isFragment) {
     // re-rendering a head component
     updateHeadComponent(uri, newEl);
+  } else if (isDocument) {
+    // re-rendering a component list in the page
+    updateLayout(uri, newEl, paths);
   } else {
     log.error(`Unknown node type (${newEl.nodeType}) for "${uri}"`, { action: 'updateDOM' });
   }
+}
+
+/**
+ * replace and decorate a page that was rendered server-side
+ * note: in kiln v4.x and above, components (including layouts) will ALWAYS be rendered client-side. only pages will pass in server-side html
+ * @param  {string} uri
+ * @param  {Element} html
+ * @param {array} paths that have changed
+ * @returns {Promise}
+ */
+function renderServerHTML(uri, html, paths) {
+  return Promise.resolve(updateDOM(uri, html, paths));
 }
 
 /**
@@ -152,7 +168,12 @@ export function updateDOM(uri, newEl, paths) {
  * @returns {Promise}
  */
 function renderClientData(uri, data, paths) {
-  return renderTemplate(uri, data).then((html) => updateDOM(uri, html, paths));
+  return renderTemplate(uri, data)
+    .then((html) => updateDOM(uri, html, paths))
+    .catch((e) => {
+      log.error(`Error rendering ${getComponentName(uri)}: ${e.message}`, { action: 'render' });
+      return Promise.reject(e);
+    });
 }
 
 /**
@@ -161,43 +182,49 @@ function renderClientData(uri, data, paths) {
  * @param  {object} store
  * @param {string} uri
  * @param {object} [data]
+ * @param {Element} [html] for page re-rendering
  * @param {string} snapshot
  * @param {array} paths
  * @returns {Promise}
  */
-export function render(store, {uri, data, snapshot, paths}) {
-  return renderClientData(uri, data, paths)
-    .catch((e) => {
-      log.error(`Error rendering ${getComponentName(uri)}: ${e.message}`, { action: 'render' });
-      return Promise.reject(e);
-    })
-    .then(() => {
-      const currentSelected = _.get(store, 'state.ui.currentSelection.uri'),
-        newEl = currentSelected && getComponentEl(currentSelected);
+export function render(store, {uri, data, html, snapshot, paths}) {
+  let promise;
 
-      let selectionPromise;
+  if (html) {
+    // server-rendered html, because we're updating page data
+    promise = renderServerHTML(uri, html, paths);
+  } else {
+    // component, layout, etc client-rendered stuff
+    promise = renderClientData(uri, data, paths);
+  }
 
-      // re-select the currently-selected component with a new element,
-      // just in case the currently-selected component was re-rendered
-      if (newEl) {
-        selectionPromise = store.dispatch('select', newEl);
-      } else {
-        // if there's nothing selected, OR if the selected component was destroyed when
-        // re-rendering, make sure we trigger unselect
-        selectionPromise = store.dispatch('unselect');
-      }
+  return promise.then(() => {
+    const currentSelected = _.get(store, 'state.ui.currentSelection.uri'),
+      newEl = currentSelected && getComponentEl(currentSelected);
 
-      return selectionPromise
-        .catch((e) => {
-          log.error(`Error selecting rendered component (${getComponentName(uri)}): ${e.message}`, { action: 'render' });
-          return Promise.reject(e);
-        })
-        .then(() => {
-          if (isComponent(uri)) {
-            store.commit(RENDER_COMPONENT, { uri, data, snapshot, paths });
-          } else {
-            store.commit(RENDER_PAGE, { uri, data, snapshot, paths });
-          }
-        });
-    });
+    let selectionPromise;
+
+    // re-select the currently-selected component with a new element,
+    // just in case the currently-selected component was re-rendered
+    if (newEl) {
+      selectionPromise = store.dispatch('select', newEl);
+    } else {
+      // if there's nothing selected, OR if the selected component was destroyed when
+      // re-rendering, make sure we trigger unselect
+      selectionPromise = store.dispatch('unselect');
+    }
+
+    return selectionPromise
+      .catch((e) => {
+        log.error(`Error selecting rendered component (${getComponentName(uri)}): ${e.message}`, { action: 'render' });
+        return Promise.reject(e);
+      })
+      .then(() => {
+        if (isComponent(uri)) {
+          store.commit(RENDER_COMPONENT, { uri, data, snapshot, paths });
+        } else {
+          store.commit(RENDER_PAGE, { uri, data, snapshot, paths });
+        }
+      });
+  });
 }

--- a/lib/component-data/reactive-render.js
+++ b/lib/component-data/reactive-render.js
@@ -117,6 +117,26 @@ function updateLayout(uri, newEl, paths) {
   });
 }
 
+function hasComment(el) {
+  const child = el.firstChild;
+
+  if (child) {
+    return child.nodeType === child.COMMENT_NODE;
+  } else {
+    return false;
+  }
+}
+
+function hasURIComment(el) {
+  const child = el.firstChild;
+
+  if (child) {
+    return child.data ? !!child.data.match(/data-uri=".*?"/) : false;
+  } else {
+    return false;
+  }
+}
+
 /**
  * update the dom with the newly-rendered component elements
  * note: this uses intelligent dom diffing, so only changes will update
@@ -128,8 +148,11 @@ export function updateDOM(uri, newEl, paths) {
   const isElement = newEl.nodeType === newEl.ELEMENT_NODE,
     isFragment = newEl.nodeType === newEl.DOCUMENT_FRAGMENT_NODE,
     isDocument = newEl.nodeType === newEl.DOCUMENT_NODE,
-    firstChild = isFragment && newEl.firstElementChild,
-    isFullPageFragment = firstChild && firstChild.tagName === 'META' && firstChild.getAttribute('charset') === 'utf-8';
+    // a full-page fragment happens when re-rendering the layout. we need to explicitly check that
+    // a) the first node is not a comment, or
+    // b) the first node isn't <!-- data-uri -->
+    // because that would indicate we're re-rendering a single head component
+    isFullPageFragment = isFragment && (!hasComment(newEl) || !hasURIComment(newEl));
 
   if (isElement) {
     // regular component in the body

--- a/lib/component-data/reactive-render.js
+++ b/lib/component-data/reactive-render.js
@@ -5,12 +5,13 @@ import { RENDER_COMPONENT } from './mutationTypes';
 import { RENDER_PAGE } from '../page-data/mutationTypes';
 import { render as renderTemplate } from './template';
 import { decorate } from '../decorators';
-import { refAttr, editAttr, isComponent } from '../utils/references';
+import { refAttr, editAttr, isComponent, getComponentName } from '../utils/references';
 import { destroySelector } from '../decorators/select';
 import { destroyPlaceholders } from '../decorators/placeholders';
 import addPlaceholder from '../decorators/placeholders';
 import addComponentList from '../decorators/component-list';
 import { getComponentFragment, getComponentListFragment, replaceHeadComponent, replaceHeadList } from '../utils/head-components';
+import { getComponentEl } from '../utils/component-elements';
 import logger from '../utils/log';
 
 const log = logger(__filename);
@@ -96,14 +97,12 @@ function updateBodyList(uri, oldList, newList) {
 
 /**
  * intelligently update the <html> element
- * triggered when the page or layout is saved
- * note: this will really just replace the component list that have been updated,
- * by calling updateHeadComponent() or updateBodyComponent()
+ * triggered when the layout is saved
  * @param {string} uri
  * @param {Document} newEl
  * @param {array} paths
  */
-function updateRootDOM(uri, newEl, paths) {
+function updateLayout(uri, newEl, paths) {
   _.each(paths, (path) => {
     const newList = find(newEl, `[${editAttr}="${path}"]`),
       oldList = find(`[${editAttr}="${path}"]`);
@@ -128,32 +127,21 @@ function updateRootDOM(uri, newEl, paths) {
 export function updateDOM(uri, newEl, paths) {
   const isElement = newEl.nodeType === newEl.ELEMENT_NODE,
     isFragment = newEl.nodeType === newEl.DOCUMENT_FRAGMENT_NODE,
-    isDocument = newEl.nodeType === newEl.DOCUMENT_NODE;
+    firstChild = isFragment && newEl.firstElementChild,
+    isFullPageFragment = firstChild && firstChild.tagName === 'META' && firstChild.getAttribute('charset') === 'utf-8';
 
   if (isElement) {
-    // regular old component
+    // regular component in the body
     updateBodyComponent(uri, newEl);
+  } else if (isFullPageFragment) {
+    // re-rendering a component list in the layout
+    updateLayout(uri, newEl, paths);
   } else if (isFragment) {
-    // head component
-    updateHeadComponent(uri, newEl);
-  } else if (isDocument) {
-    // page or layout. we'll have to find the invidividual component list and diff it with the old one
-    updateRootDOM(uri, newEl, paths);
+    // re-rendering a component list in the page
+    // updateRootDOM(uri, newEl, paths);
   } else {
     log.error(`Unknown node type (${newEl.nodeType}) for "${uri}"`, { action: 'updateDOM' });
   }
-}
-
-/**
- * replace and decorate a page that was rendered server-side
- * note: as of kiln v4.x, components will ALWAYS be rendered client-side. only pages will pass in server-side html
- * @param  {string} uri
- * @param  {Element} html
- * @param {array} paths that have changed
- * @returns {Promise}
- */
-function renderServerHTML(uri, html, paths) {
-  return Promise.resolve(updateDOM(uri, html, paths));
 }
 
 /**
@@ -173,44 +161,43 @@ function renderClientData(uri, data, paths) {
  * @param  {object} store
  * @param {string} uri
  * @param {object} [data]
- * @param {Element} [html]
  * @param {string} snapshot
  * @param {array} paths
  * @returns {Promise}
  */
-export function render(store, {uri, data, html, snapshot, paths}) {
-  let promise;
+export function render(store, {uri, data, snapshot, paths}) {
+  return renderClientData(uri, data, paths)
+    .catch((e) => {
+      log.error(`Error rendering ${getComponentName(uri)}: ${e.message}`, { action: 'render' });
+      return Promise.reject(e);
+    })
+    .then(() => {
+      const currentSelected = _.get(store, 'state.ui.currentSelection.uri'),
+        newEl = currentSelected && getComponentEl(currentSelected);
 
-  if (html) {
-    // server-side legacy html (or new layout html)
-    promise = renderServerHTML(uri, html, paths);
-  } else {
-    // client-side html, passing through handlebars template
-    promise = renderClientData(uri, data, paths);
-  }
+      let selectionPromise;
 
-  return promise.then(() => {
-    const currentSelected = _.get(store, 'state.ui.currentSelection.uri'),
-      newEl = currentSelected && find(`[${refAttr}="${currentSelected}"]`);
-
-    let selectionPromise;
-
-    // re-select the currently-selected component with a new element,
-    // just in case the currently-selected component was re-rendered
-    if (newEl) {
-      selectionPromise = store.dispatch('select', newEl);
-    } else {
-      // if there's nothing selected, OR if the selected component was destroyed when
-      // re-rendering, make sure we trigger unselect
-      selectionPromise = store.dispatch('unselect');
-    }
-
-    return selectionPromise.then(() => {
-      if (isComponent(uri)) {
-        store.commit(RENDER_COMPONENT, { uri, data, html, snapshot, paths });
+      // re-select the currently-selected component with a new element,
+      // just in case the currently-selected component was re-rendered
+      if (newEl) {
+        selectionPromise = store.dispatch('select', newEl);
       } else {
-        store.commit(RENDER_PAGE, { uri, data, html, snapshot, paths });
+        // if there's nothing selected, OR if the selected component was destroyed when
+        // re-rendering, make sure we trigger unselect
+        selectionPromise = store.dispatch('unselect');
       }
+
+      return selectionPromise
+        .catch((e) => {
+          log.error(`Error selecting rendered component (${getComponentName(uri)}): ${e.message}`, { action: 'render' });
+          return Promise.reject(e);
+        })
+        .then(() => {
+          if (isComponent(uri)) {
+            store.commit(RENDER_COMPONENT, { uri, data, snapshot, paths });
+          } else {
+            store.commit(RENDER_PAGE, { uri, data, snapshot, paths });
+          }
+        });
     });
-  });
 }

--- a/lib/component-data/reactive-render.js
+++ b/lib/component-data/reactive-render.js
@@ -137,8 +137,8 @@ export function updateDOM(uri, newEl, paths) {
     // re-rendering a component list in the layout
     updateLayout(uri, newEl, paths);
   } else if (isFragment) {
-    // re-rendering a component list in the page
-    // updateRootDOM(uri, newEl, paths);
+    // re-rendering a head component
+    updateHeadComponent(uri, newEl);
   } else {
     log.error(`Unknown node type (${newEl.nodeType}) for "${uri}"`, { action: 'updateDOM' });
   }

--- a/lib/component-data/template.js
+++ b/lib/component-data/template.js
@@ -3,6 +3,9 @@ import { create } from '@nymag/dom';
 import { getTemplate, getLocals, getData } from '../core-data/components';
 import { attempt } from '../utils/promises';
 import { refProp, getComponentName } from '../utils/references';
+import logger from '../utils/log';
+
+const log = logger(__filename);
 
 /**
  * list deep objects in another object, used for composing deep components
@@ -70,5 +73,8 @@ export function render(uri, data) {
   }
 
   // always compose data before rendering client-side
-  return attempt(() => tpl(compose(uri, renderableData))).then((html) => create(html));
+  return attempt(() => tpl(compose(uri, renderableData))).catch((e) => {
+    log.error(`Unable to render template for ${getComponentName(uri)}`, { action: 'render' });
+    return Promise.reject(e);
+  }).then((html) => create(html));
 }

--- a/lib/core-data/api.js
+++ b/lib/core-data/api.js
@@ -263,7 +263,7 @@ export function getHead(uri) {
  * @param {string} [queries] used by clay-space
  * @returns {Promise}
  */
-export function getHTML(uri, queries) {
+export function getHTML(uri, queries = '') {
   assertUri(uri);
 
   /* todo: Currently the second argument is ONLY used for the Space component because

--- a/lib/drawers/drawer.vue
+++ b/lib/drawers/drawer.vue
@@ -92,6 +92,7 @@
       component: 'head-components',
       selected: false,
       args: {
+        isPage: _.get(schema, `${list.path}.${componentListProp}.page`),
         path: list.path,
         schema: schema[list.path]
       }

--- a/lib/page-data/actions.js
+++ b/lib/page-data/actions.js
@@ -41,7 +41,7 @@ function logSaveError(uri, e, data, snapshot, store) { // eslint-disable-line
 }
 
 function queuePageSave(uri, data, oldData, store, {snapshot, paths}) { // eslint-disable-line
-  addToQueue(save, [uri, data], 'save')
+  return addToQueue(save, [uri, data, true], 'save')
     .then(() => getHTML(uri))
     .then((html) => {
       // note: we don't care about the data we got back from the api

--- a/lib/page-data/actions.js
+++ b/lib/page-data/actions.js
@@ -30,7 +30,7 @@ function shouldRender(paths) {
   return !!_.find(paths, (path) => !_.includes(internalPageProps, path));
 }
 
-function logSaveError(uri, e, data, snapshot) {
+function logSaveError(uri, e, data, snapshot, store) { // eslint-disable-line
   log.error(`Error saving page: ${e.message}`, { action: 'savePage', uri });
   store.dispatch('showSnackbar', { type: 'error', message: 'Changes made to current page were not saved!' });
   store.dispatch('showSnackbar', {
@@ -52,7 +52,7 @@ function queuePageSave(uri, data, oldData, store, {snapshot, paths}) { // eslint
     })
     .catch((e) => {
       store.commit(REVERT_PAGE, oldData);
-      logSaveError(uri, e, data, snapshot);
+      logSaveError(uri, e, data, snapshot, store);
       if (shouldRender(paths)) {
         return store.dispatch('render', { uri, html: document, snapshot, paths });
       }

--- a/lib/utils/head-components.js
+++ b/lib/utils/head-components.js
@@ -34,7 +34,8 @@ export function getComponentListPath(node) {
  */
 export function getComponentListStart(path, doc) {
   const root = doc || document,
-    walker = document.createTreeWalker(root.head, NodeFilter.SHOW_COMMENT);
+    head = root.head || doc, // re-rendered layouts won't have a <head> in their fragment. it's weird
+    walker = document.createTreeWalker(head, NodeFilter.SHOW_COMMENT);
 
   let node;
 


### PR DESCRIPTION
fixes #958

* intelligently re-render head components
* intelligently re-render head component lists in the layout
* intelligently re-render body component lists in the layout
* re-render head component lists in the page (from the server)
* re-render body component lists in the page (from the server)