### PR TITLE
component property editing

### DIFF
--- a/docs/manipulating-components.md
+++ b/docs/manipulating-components.md
@@ -150,3 +150,21 @@ Additionally, all types of component lists may be set to _fuzzy_. The default `i
 You may make any component list _fuzzy_ by adding that property in the config. This will add a _View All Components_ button into the header of the Add Components modal, which will list _all components available in your Clay installation_.
 
 ![](images/fuzzy_list.png)
+
+## Component Properties
+
+In addition to component lists, you can use _component properties_ if you want a single child component instead of an array of children.
+
+```yaml
+tags:
+  _component:
+    include:
+      - normal-tags
+      - fancy-tags
+```
+
+This allows you to swap out different components in a specific place, for example if you have two different tagging components with different styles and functionality. As with component lists, you may include a `_placeholder`. If your component property is editable, the child component's selector will allow you to remove it (and the placeholder that displays will allow you to add it).
+
+> #### info::Note
+>
+> Component properties are not allowed in the layout or page data, only in normal components. Because of this, they are also not allowed in the `<head>` of the page.

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -180,7 +180,7 @@ export function removeComponent(store, el) {
     newList = _.without(list, currentData);
     promise = saveComponent(store, { uri: parentURI, data: { [path]: newList } });
   } else if (_.isObject(list)) {
-    log.error('Removing components from props (without replacing them) is not currently supported!', { action: 'removeComponent', uri });
+    promise = saveComponent(store, { uri: parentURI, data: { [path]: {} }});
   } else if (_.isString(list)) {
     // list in a page
     newList = _.without(list, uri); // we only need the uri, not a full object

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -300,7 +300,7 @@ function addComponentsToComponentList(store, data, {currentURI, parentURI, path,
  * @returns {Promise}
  */
 function addComponentsToComponentProp(store, data, {parentURI, path, components, clone}) {
-  const oldURI = data[path][refProp];
+  const oldURI = _.get(data, `${path}.${refProp}`);
 
   if (components.length > 1) {
     log.warn(`Attempting to add multiple components to a component prop: ${getComponentName(parentURI)} » ${path}. Only the first component (${_.head(components).name}) will be added!`, { action: 'addComponentsToComponentProp' });
@@ -309,7 +309,9 @@ function addComponentsToComponentProp(store, data, {parentURI, path, components,
   // only create the first one
   return create([_.head(components)], clone).then((newComponents) => {
     return store.dispatch('saveComponent', { uri: parentURI, data: { [path]: _.head(newComponents) } }).then(() => {
-      store.commit(REMOVE_COMPONENT, { uri: oldURI });
+      if (oldURI) {
+        store.commit(REMOVE_COMPONENT, { uri: oldURI });
+      }
       // return the LAST element added
       return find(`[${refAttr}="${_.head(newComponents)[refProp]}"]`);
     });

--- a/lib/decorators/selector.vue
+++ b/lib/decorators/selector.vue
@@ -199,7 +199,6 @@
         <ui-icon-button v-show="hasDuplicateComponent" type="secondary" color="primary" class="quick-bar-button quick-bar-dupe" icon="add_circle_outline" :tooltip="`Add ${componentLabel}`" @click.stop="duplicateComponent"></ui-icon-button>
         <ui-icon-button v-show="hasDuplicateComponentWithData" type="secondary" color="primary" class="quick-bar-button quick-bar-dupe" icon="add_circle" :tooltip="`Duplicate ${componentLabel}`" @click.stop="duplicateComponentWithData"></ui-icon-button>
         <ui-icon-button v-once v-show="hasAddComponent" type="secondary" color="primary" class="quick-bar-button quick-bar-add" icon="add" :tooltip="addComponentText" @click.stop="openAddComponentPane"></ui-icon-button>
-        <ui-icon-button v-once v-show="hasReplaceComponent" type="secondary" color="primary" class="quick-bar-button quick-bar-replace" icon="swap_vert" :tooltip="`Replace ${componentLabel}`"></ui-icon-button>
       </div>
     </aside>
   </transition>
@@ -248,10 +247,8 @@
         componentLabel: label(getComponentName(this.$options.uri)),
         parentField: this.$options.parentField,
         parentURI: this.$options.parentURI,
-        // note: only for components in LISTS! components in properties can be replaced but not removed (for now)
-        hasRemove: this.$options.parentField && this.$options.parentField.type === 'list' && this.$options.parentField.isEditable,
-        hasAddComponent: this.$options.parentField && this.$options.parentField.type === 'list' && this.$options.parentField.isEditable,
-        hasReplaceComponent: this.$options.parentField && this.$options.parentField.type === 'prop' && this.$options.parentField.isEditable
+        hasRemove: this.$options.parentField && this.$options.parentField.isEditable,
+        hasAddComponent: this.$options.parentField && this.$options.parentField.type === 'list' && this.$options.parentField.isEditable
       };
     },
     computed: {

--- a/lib/forms/overlay.vue
+++ b/lib/forms/overlay.vue
@@ -114,7 +114,6 @@
           <ui-icon-button v-if="hasDuplicateComponent" type="secondary" color="black" icon="add_circle_outline" :tooltip="`Add ${componentLabel}`" @click.stop="duplicateComponent"></ui-icon-button>
           <ui-icon-button v-if="hasDuplicateComponentWithData" type="secondary" color="black" icon="add_circle" :tooltip="`Duplicate ${componentLabel}`" @click.stop="duplicateComponentWithData"></ui-icon-button>
           <ui-icon-button v-if="hasAddComponent" type="secondary" color="black" icon="add" :tooltip="addComponentText" @click.stop="openAddComponentPane"></ui-icon-button>
-          <ui-icon-button v-if="hasReplaceComponent" type="secondary" color="black" icon="swap_vert" :tooltip="`Replace ${componentLabel}`"></ui-icon-button>
           <div class="form-close-divider"></div>
           <ui-icon-button color="black" type="secondary" icon="check" ariaLabel="Save Form" tooltip="Save (ESC)" @click.stop="save"></ui-icon-button>
         </div>
@@ -229,8 +228,7 @@
       },
       isCurrentlySelected: (state) => _.get(state, 'ui.currentForm.uri') === _.get(state, 'ui.currentSelection.uri'),
       hasRemove(state) {
-        // note: this only shows up if the component that contains this form is selected
-        return this.isCurrentlySelected && _.get(state, 'ui.currentSelection.parentField.type') === 'list' && _.get(state, 'ui.currentSelection.parentField.isEditable');
+        return this.isCurrentlySelected && _.get(state, 'ui.currentSelection.parentField.isEditable');
       },
       hasDuplicateComponent(state) {
         return this.isCurrentlySelected && _.get(state, 'ui.currentSelection.parentField.type') === 'list' && _.get(state, 'ui.currentSelection.parentField.isEditable') && !_.get(state, 'ui.metaKey');
@@ -239,12 +237,7 @@
         return this.isCurrentlySelected && _.get(state, 'ui.currentSelection.parentField.type') === 'list' && _.get(state, 'ui.currentSelection.parentField.isEditable') && _.get(state, 'ui.metaKey');
       },
       hasAddComponent(state) {
-        // note: this only shows up if the component that contains this form is selected
         return this.isCurrentlySelected && _.get(state, 'ui.currentSelection.parentField.type') === 'list' && _.get(state, 'ui.currentSelection.parentField.isEditable');
-      },
-      hasReplaceComponent(state) {
-        // note: this only shows up if the component that contains this form is selected
-        return this.isCurrentlySelected && _.get(state, 'ui.currentSelection.parentField.type') === 'prop' && _.get(state, 'ui.currentSelection.parentField.isEditable');
       },
       addComponentText(state) {
         if (this.hasAddComponent) {


### PR DESCRIPTION
* fixes #751
* allows removal of editable component properties
* allows placeholder for empty component properties
* allows adding components to empty component properties
* removes (unused) code for "replacing" components in properties (just remove, then add)

Note: As of kiln 5, the "replace" code wasn't actually connected to anything. It presented a completely different affordance from other ways of manipulating components, so I decided to scrap the whole idea. This is a lot cleaner now.