### PR TITLE
only render complex-list items when they're near the viewport

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -18,6 +18,7 @@ import { getEventPath } from './lib/utils/events';
 import { standardCurve } from './lib/utils/references';
 import 'keen-ui/src/bootstrap'; // import this once, for KeenUI components
 import 'velocity-animate/velocity.ui.min.js'; // import this once, for velocity ui stuff
+import VueObserveVisibility from 'vue-observe-visibility';
 
 // set animation defaults
 velocity.defaults.easing = standardCurve;
@@ -53,6 +54,9 @@ Vue.use(NProgress, {
   router: false,
   http: false
 });
+
+// add visibility observer directive
+Vue.use(VueObserveVisibility);
 
 // Register keys to make key events easy to call
 Vue.config.keyCodes.comma = 188;

--- a/inputs/complex-list-item.vue
+++ b/inputs/complex-list-item.vue
@@ -5,8 +5,6 @@
   @import '../styleguide/typography';
 
   .complex-list-item {
-    @include form();
-
     border: 1px solid $divider-color;
     border-radius: 2px;
     box-shadow: $shadow-2dp;
@@ -20,6 +18,10 @@
     &.is-expanded {
       box-shadow: $shadow-8dp;
     }
+  }
+
+  .complex-list-item-inner {
+    @include form();
   }
 
   .complex-list-item + .complex-list-item {
@@ -55,20 +57,23 @@
 </style>
 
 <template>
-  <div class="complex-list-item" :class="{ 'is-expanded': isCurrentItem }" :ref="name" @click.stop="onClick">
-    <field v-for="(field, fieldIndex) in fieldNames" :key="fieldIndex" :class="{ 'first-field': fieldIndex === 0 }" :name="name + '.' + field" :data="fields[field]" :schema="fieldSchemas[field]"></field>
-    <div v-if="hasRequiredFields" class="required-footer">* Required fields</div>
-    <transition name="complex-list-item-actions" appear mode="out-in" :css="false" @enter="enter" @leave="leave">
-      <div v-if="isCurrentItem" class="complex-list-item-actions">
-        <div class="complex-list-item-actions-inner ui-button-group">
-          <span class="complex-list-item-actions-left">Item {{ index + 1 }}/{{ total }}</span>
-          <div class="complex-list-item-actions-right ui-button-group">
-            <ui-button buttonType="button" type="secondary" color="red" icon="delete" @click.stop.prevent="removeItem(index)">Remove</ui-button>
-            <ui-button buttonType="button" type="secondary" color="accent" icon="add" @click.stop.prevent="addItemAndUnselect(index)">Add Another</ui-button>
+  <div class="complex-list-item" :class="{ 'is-expanded': isCurrentItem }" :ref="name" v-observe-visibility="visibilityChanged" @click.stop="onClick">
+    <div v-if="isVisible" class="complex-list-item-inner">
+      <field v-for="(field, fieldIndex) in fieldNames" :key="fieldIndex" :class="{ 'first-field': fieldIndex === 0 }" :name="name + '.' + field" :data="fields[field]" :schema="fieldSchemas[field]"></field>
+      <div v-if="hasRequiredFields" class="required-footer">* Required fields</div>
+      <transition name="complex-list-item-actions" appear mode="out-in" :css="false" @enter="enter" @leave="leave">
+        <div v-if="isCurrentItem" class="complex-list-item-actions">
+          <div class="complex-list-item-actions-inner ui-button-group">
+            <span class="complex-list-item-actions-left">Item {{ index + 1 }}/{{ total }}</span>
+            <div class="complex-list-item-actions-right ui-button-group">
+              <ui-button buttonType="button" type="secondary" color="red" icon="delete" @click.stop.prevent="removeItem(index)">Remove</ui-button>
+              <ui-button buttonType="button" type="secondary" color="accent" icon="add" @click.stop.prevent="addItemAndUnselect(index)">Add Another</ui-button>
+            </div>
           </div>
         </div>
-      </div>
-    </transition>
+      </transition>
+    </div>
+    <div v-else class="complex-list-item-hidden" :style="{ height: initialHeight }"></div>
   </div>
 </template>
 
@@ -91,7 +96,11 @@
       'currentItem'
     ],
     data() {
-      return {};
+      return {
+        isVisible: false,
+        initialHeight: '100px',
+        isInitialHeightChanged: false
+      };
     },
     computed: {
       isCurrentItem() {
@@ -134,6 +143,21 @@
       },
       onClick() {
         this.$emit('current', this.index);
+      },
+      visibilityChanged(isInViewport, entry) {
+        const BUFFER = 500;
+
+        if (isInViewport || entry.boundingClientRect.top < entry.rootBounds.bottom + BUFFER || entry.boundingClientRect.bottom < entry.rootBounds.top + BUFFER) {
+          this.isVisible = true;
+        } else {
+          this.isVisible = false;
+        }
+
+        if (isInViewport && !this.isInitialHeightChanged) {
+          // if the height was never set based on the item height, do it the first time it's visible
+          // this.initialHeight = `${this.$el.clientHeight}px`;
+          this.isInitialHeightChanged = true;
+        }
       }
     },
     components: {

--- a/inputs/complex-list-item.vue
+++ b/inputs/complex-list-item.vue
@@ -20,6 +20,10 @@
     }
   }
 
+  .complex-list-item-hidden {
+    height: 100px;
+  }
+
   .complex-list-item-inner {
     @include form();
   }
@@ -73,7 +77,7 @@
         </div>
       </transition>
     </div>
-    <div v-else class="complex-list-item-hidden" :style="{ height: initialHeight }"></div>
+    <div v-else class="complex-list-item-hidden"></div>
   </div>
 </template>
 
@@ -97,9 +101,7 @@
     ],
     data() {
       return {
-        isVisible: false,
-        initialHeight: '100px',
-        isInitialHeightChanged: false
+        isVisible: false
       };
     },
     computed: {
@@ -151,12 +153,6 @@
           this.isVisible = true;
         } else {
           this.isVisible = false;
-        }
-
-        if (isInViewport && !this.isInitialHeightChanged) {
-          // if the height was never set based on the item height, do it the first time it's visible
-          // this.initialHeight = `${this.$el.clientHeight}px`;
-          this.isInitialHeightChanged = true;
         }
       }
     },

--- a/inputs/text.vue
+++ b/inputs/text.vue
@@ -22,6 +22,7 @@
 
 <template>
   <ui-textbox
+    :autosize="false"
     :value="data"
     :type="type"
     :multiLine="isMultiline"

--- a/lib/forms/field-helpers.js
+++ b/lib/forms/field-helpers.js
@@ -5,6 +5,9 @@ import striptags from 'striptags';
 import { closest, find } from '@nymag/dom';
 import { fieldClass, firstFieldClass } from '../utils/references';
 import { isEmpty, compare } from '../utils/comparators';
+import logger from '../utils/log';
+
+const log = logger(__filename);
 
 /**
  * find the field element a behavior is inside
@@ -41,9 +44,14 @@ export function setCaret(el, offset, data) {
   if (offset === -1) {
     // set caret at the end if it's negative
     // todo: maybe support arbitrary negative offsets?
-    set(inputEl, data.length - 1);
-  } else {
+    offset = data.length - 1;
+  }
+
+  // set the offset, but fail gracefully
+  try {
     set(inputEl, offset);
+  } catch (e) {
+    log.debug(`Cannot set caret in field: ${e.message}`, { action: 'setCaret', el });
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15375,6 +15375,12 @@
         "nprogress": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz"
       }
     },
+    "vue-observe-visibility": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.3.1.tgz",
+      "integrity": "sha512-hrTdlkTiPmjjH+00dIiCsr/bBPNjUljNc9rboeLXMnXUqeom8LKa4l3iLwb3exa9PUUhtp4RrOtsa2eH0NimsQ==",
+      "dev": true
+    },
     "vue-style-loader": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "vue-avatar": "^2.1.1",
     "vue-loader": "^13.5.0",
     "vue-nprogress": "^0.1.5",
+    "vue-observe-visibility": "^0.3.1",
     "vue-style-loader": "^3.0.3",
     "vue-template-compiler": "^2.5.9",
     "vue-unit": "github:tom-kitchin/vue-unit",


### PR DESCRIPTION
* uses visibility observer to only render complex-list items if they're within 500px of the viewport
* allows infinitely-long complex lists
* a 480-item list went from 43s form load time to 0s
* allows smooth scrolling in complex-lists
* disables auto-expand on textareas, as that code is a little buggy (users can simply drag them open if they want, like you do with native textareas)

<a href="http://up.keats.me/1T3M1T0b2n0s" target="_blank"><img src="https://d3vv6lp55qjaqc.cloudfront.net/items/2Y0V0F3n2S1i0L3l2k3c/Screen%20Recording%202017-12-06%20at%2010.25%20AM.gif" style="display: block;height: auto;width: 100%;"/></a>