### PR TITLE
add multi-property pubsub

### DIFF
--- a/docs/editing-components.md
+++ b/docs/editing-components.md
@@ -364,6 +364,21 @@ ogTitle:
   _has: text
 ```
 
+### Many-To-Many Communication
+
+Both `_publish` and `_subscribe` can receive a single property (as a string) _or an array of properties_. This extremely powerful tool allows you to create complicated many-to-many communication workflows in a safe and standardized way.
+
+```yaml
+title:
+  _has: text
+  _publish:
+    - ogTitle
+    - twitterTitle
+  _subscribe:
+    - pageTitle
+    - overrideTitle
+```
+
 ### PubSub Tips
 
 Kiln intelligently prevents a component from publishing more than once during pubsub, so you may safely create circular pubsub logic. For example, a `tags` component may update an `article`'s `primaryTag` field, and the `article` may also allow editing of that field (and propagating those changes back to `tags`).

--- a/lib/component-data/pubsub.js
+++ b/lib/component-data/pubsub.js
@@ -29,17 +29,27 @@ export function register(name, schema) {
   _.forOwn(schema, (field, fieldName) => {
     // register publisher, if it exists
     if (_.isObject(field) && field[pubProp]) {
+      const prop = field[pubProp];
+
       publisherRegistery[name] = publisherRegistery[name] || {};
-      publisherRegistery[name][fieldName] = field[pubProp];
+      publisherRegistery[name][fieldName] = prop; // may be array or string
     }
 
     // register subscriber, if it exists
     if (_.isObject(field) && field[subProp]) {
       const prop = field[subProp];
 
-      subscriberRegistery[prop] = subscriberRegistery[prop] || {};
-      subscriberRegistery[prop][name] = subscriberRegistery[prop][name] || new Set();
-      subscriberRegistery[prop][name].add(fieldName);
+      if (_.isArray(prop)) {
+        _.each(prop, (p) => {
+          subscriberRegistery[p] = subscriberRegistery[p] || {};
+          subscriberRegistery[p][name] = subscriberRegistery[p][name] || new Set();
+          subscriberRegistery[p][name].add(fieldName);
+        });
+      } else {
+        subscriberRegistery[prop] = subscriberRegistery[prop] || {};
+        subscriberRegistery[prop][name] = subscriberRegistery[prop][name] || new Set();
+        subscriberRegistery[prop][name].add(fieldName);
+      }
     }
   });
 }
@@ -188,15 +198,30 @@ export function publish(uri, data, eventID, snapshot, store) { // eslint-disable
   _.forOwn(publisherRegistery[name], (prop, field) => {
     const value = data[field];
 
-    if (hasSubscribers(prop)) {
-      // there are subscribers to this property!
-      // see if they should subscribe (e.g. they haven't already published) and construct
-      // a payload of the data that needs to be sent to these components
-      _.forOwn(subscriberRegistery[prop], (subscribedFields, subscriberName) => {
-        if (shouldSubscribe(subscriberName, eventID)) {
-          payload[subscriberName] = _.reduce(Array.from(subscribedFields), (subData, subscribedField) => _.assign(subData, { [subscribedField]: value }), payload[subscriberName] || {});
+    if (_.isArray(prop)) {
+      _.each(prop, (p) => {
+        if (hasSubscribers(p)) {
+          // there are subscribers to this property!
+          // see if they should subscribe (e.g. they haven't already published) and construct
+          // a payload of the data that needs to be sent to these components
+          _.forOwn(subscriberRegistery[p], (subscribedFields, subscriberName) => {
+            if (shouldSubscribe(subscriberName, eventID)) {
+              payload[subscriberName] = _.reduce(Array.from(subscribedFields), (subData, subscribedField) => _.assign(subData, { [subscribedField]: value }), payload[subscriberName] || {});
+            }
+          });
         }
       });
+    } else {
+      if (hasSubscribers(prop)) {
+        // there are subscribers to this property!
+        // see if they should subscribe (e.g. they haven't already published) and construct
+        // a payload of the data that needs to be sent to these components
+        _.forOwn(subscriberRegistery[prop], (subscribedFields, subscriberName) => {
+          if (shouldSubscribe(subscriberName, eventID)) {
+            payload[subscriberName] = _.reduce(Array.from(subscribedFields), (subData, subscribedField) => _.assign(subData, { [subscribedField]: value }), payload[subscriberName] || {});
+          }
+        });
+      }
     }
   });
 

--- a/lib/component-data/pubsub.test.js
+++ b/lib/component-data/pubsub.test.js
@@ -10,6 +10,12 @@ const data = { foo: 'harder', bar: 'better', baz: 'faster', qux: 'stronger' },
         _publish: '1'
       }
     },
+    pubArray: {
+      foo: { _publish: ['1', '2'] }
+    },
+    subArray: {
+      foo: { _subscribe: ['1', '2'] }
+    },
     pub1: {
       foo: { _publish: '1' }
     },
@@ -301,6 +307,26 @@ describe('pubsub', () => {
           title: 'harder',
           authors: 'better'
         });
+      });
+    });
+
+    // multi-property pubsub
+
+    it('propagates [A] → 1 → B', () => {
+      lib.register('A', schemas.pubArray);
+      lib.register('B', schemas.sub1);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(1); // B saves once
+        expectBwith1();
+      });
+    });
+
+    it('propagates A → 1 → [B]', () => {
+      lib.register('A', schemas.pub1);
+      lib.register('B', schemas.subArray);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(1); // B saves once
+        expectBwith1();
       });
     });
   });


### PR DESCRIPTION
* fixes #1032
* allows both `_publish` and `_subscribe` to be arrays of strings
* enables publishing / subscribing to multiple properties from a single field
* updates documentation with example of new functionality