### PR TITLE
standardized validation helpers

### DIFF
--- a/docs/manipulating-components.md
+++ b/docs/manipulating-components.md
@@ -34,15 +34,30 @@ Basic lists also allow placeholders, which will display (and prompt users to add
 
 ```yaml
 myList:
+  _placeholder:
+    height: 600px
   _componentList:
-    _placeholder:
-      height: 600px
     include:
       - some-component
       - some-other-component
 ```
 
 ![](images/list_placeholder.png)
+
+#### Validation
+
+Similarly to [editable fields](https://claycms.gitbooks.io/kiln/editing-components.html#standard-input-arguments), component lists may contain validation for `min` and `max` lengths.
+
+```yaml
+myList:
+  _componentList:
+    include:
+      - some-component
+      - some-other-component
+    validate:
+      min: 1
+      max: 10
+```
 
 ### Head Lists
 

--- a/karma.local.conf.js
+++ b/karma.local.conf.js
@@ -1,5 +1,4 @@
 var settings = require('./karma.conf.js').settings,
-  WatchIgnorePlugin = require('webpack').WatchIgnorePlugin,
   _ = require('lodash');
 
 // generating code coverage reports for local tests
@@ -10,19 +9,17 @@ settings.coverageReporter.reporters = [
 
 module.exports = function (karma) {
   let localSettings = _.assign(settings, {
-    singleRun: false,
-    autoWatch: true,
-    autoWatchBatchDelay: 2000,
+    singleRun: true,
+    // autoWatch: false,
+    // autoWatchBatchDelay: 2000,
     browsers: ['Chrome']
   });
 
   _.set(localSettings, 'webpack.watch', true);
-  _.set(localSettings, 'webpack.plugins', [
-    new WatchIgnorePlugin([
-      /node_modules\//ig,
-      /coverage\//ig,
-      /dist\//ig
-    ])
-  ]);
+  _.set(localSettings, 'webpack.watchOptions', {
+    aggregateTimeout: 300,
+    ignored: /(node_modules|coverage|dist|docs|media|styleguide|.git|.github)/,
+    poll: 1000
+  });
   karma.set(localSettings);
 };

--- a/karma.local.conf.js
+++ b/karma.local.conf.js
@@ -1,4 +1,5 @@
 var settings = require('./karma.conf.js').settings,
+  WatchIgnorePlugin = require('webpack').WatchIgnorePlugin,
   _ = require('lodash');
 
 // generating code coverage reports for local tests
@@ -9,13 +10,20 @@ settings.coverageReporter.reporters = [
 
 module.exports = function (karma) {
   let localSettings = _.assign(settings, {
-    singleRun: true,
-    // autoWatch: false,
-    // autoWatchBatchDelay: 2000,
+    singleRun: false,
+    autoWatch: true,
+    autoWatchBatchDelay: 2000,
     browsers: ['Chrome']
   });
 
   _.set(localSettings, 'webpack.watch', true);
+  _.set(localSettings, 'webpack.plugins', [
+    new WatchIgnorePlugin([
+      /node_modules\//ig,
+      /coverage\//ig,
+      /dist\//ig
+    ])
+  ]);
   _.set(localSettings, 'webpack.watchOptions', {
     aggregateTimeout: 300,
     ignored: /(node_modules|coverage|dist|docs|media|styleguide|.git|.github)/,

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -167,10 +167,10 @@ export function saveComponent(store, {uri, data, eventID, snapshot, prevData}) {
  */
 export function removeComponent(store, el) {
   const componentEl = getComponentEl(el),
-    uri = componentEl.getAttribute(refAttr),
+    uri = componentEl && componentEl.getAttribute(refAttr),
     parentEl = getParentComponent(componentEl),
-    parentURI = parentEl.getAttribute(layoutAttr) || parentEl.getAttribute(refAttr),
-    path = componentEl.parentNode.getAttribute(editAttr),
+    parentURI = parentEl && parentEl.getAttribute(layoutAttr) || parentEl.getAttribute(refAttr),
+    path = componentEl && componentEl.parentNode && componentEl.parentNode.getAttribute(editAttr),
     list = getData(parentURI, path),
     prevURI = getPrevComponent(componentEl) && getPrevComponent(componentEl).getAttribute(refAttr);
 

--- a/lib/drawers/publish.vue
+++ b/lib/drawers/publish.vue
@@ -256,8 +256,10 @@
           return `Published ${distanceInWordsToNow(this.publishedDate, { addSuffix: true })}`;
         } else if (this.isArchived) {
           return 'Archived';
-        } else {
+        } else if (this.createdDate) {
           return `Draft Created ${distanceInWordsToNow(this.createdDate, { addSuffix: true })}`;
+        } else {
+          return 'Draft Created some time ago';
         }
       },
       time() {
@@ -267,8 +269,10 @@
           return dateFormat(this.publishedDate, 'MMMM Do [at] h:mm A');
         } else if (this.isArchived) {
           return dateFormat(this.lastUpdated, 'MMMM Do [at] h:mm A');
-        } else {
+        } else if (this.createdDate) {
           return dateFormat(this.createdDate, 'MMMM Do [at] h:mm A');
+        } else {
+          return 'Some time ago';
         }
       },
       showSchedule() {

--- a/lib/validators/built-in/beyonce.js
+++ b/lib/validators/built-in/beyonce.js
@@ -17,7 +17,7 @@ export function validate(state) {
 
       errors.push({
         uri,
-        field: field.name,
+        field: _.head(field.path.split('.')), // todo: deep complex-list paths in the ui
         location: labelComponent(uri),
         preview: getPreviewText(text, index, 7)
       });

--- a/lib/validators/built-in/beyonce.js
+++ b/lib/validators/built-in/beyonce.js
@@ -1,31 +1,28 @@
 import _ from 'lodash';
-import striptags from 'striptags';
-import { getComponentName } from '../../utils/references';
-import labelComponent from '../../utils/label';
-import { getPreviewText } from '../helpers';
+import { forEachComponent, forEachField, getPlaintextValue, getPreviewText, labelComponent } from '../helpers';
 
 export const label = 'Beyoncé',
   description = 'Beyoncé should always be spelled with an accent mark',
   type = 'warning';
 
 export function validate(state) {
-  return _.reduce(state.components, (result, component, uri) => {
-    _.forOwn(component, (val, key) => {
-      // note: only check for beyonce in text outside of tags,
-      // so things like urls work
-      if (_.isString(val) && _.includes(striptags(val).toLowerCase(), 'beyonce')) {
-        const text = striptags(val),
-          index = text.toLowerCase().indexOf('beyonce');
+  let errors = [];
 
-        result.push({
-          uri,
-          field: key,
-          location: labelComponent(getComponentName(uri)),
-          preview: getPreviewText(text, index, 7)
-        });
-      }
-    });
+  forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
+    // note: only check for beyonce in text outside of tags,
+    // so things like urls work
+    if (_.isString(field.value) && _.includes(getPlaintextValue(field.value).toLowerCase(), 'beyonce')) {
+      const text = getPlaintextValue(field.value),
+        index = text.toLowerCase().indexOf('beyonce');
 
-    return result;
-  }, []);
+      errors.push({
+        uri,
+        field: field.name,
+        location: labelComponent(uri),
+        preview: getPreviewText(text, index, 7)
+      });
+    }
+  }));
+
+  return errors;
 }

--- a/lib/validators/built-in/beyonce.js
+++ b/lib/validators/built-in/beyonce.js
@@ -11,7 +11,7 @@ export function validate(state) {
   forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
     // note: only check for beyonce in text outside of tags,
     // so things like urls work
-    if (_.isString(field.value) && _.includes(getPlaintextValue(field.value).toLowerCase(), 'beyonce')) {
+    if (field.type === 'editable-field' && _.isString(field.value) && _.includes(getPlaintextValue(field.value).toLowerCase(), 'beyonce')) {
       const text = getPlaintextValue(field.value),
         index = text.toLowerCase().indexOf('beyonce');
 

--- a/lib/validators/built-in/conditional-required.js
+++ b/lib/validators/built-in/conditional-required.js
@@ -11,7 +11,7 @@ export function validate(state) {
 
   forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
     // note: explicitly check that this isn't a regular required field
-    if (_.isObject(_.get(field, 'validate.required')) && !isValid(field, componentData)) {
+    if (!isValid(field, componentData, 'conditional-required')) {
       const compareField = _.get(field, 'validate.required.field'),
         compareSchema = _.get(getSchema(state, uri), compareField);
 

--- a/lib/validators/built-in/conditional-required.js
+++ b/lib/validators/built-in/conditional-required.js
@@ -1,60 +1,28 @@
 import _ from 'lodash';
-import { getComponentName } from '../../utils/references';
 import labelUtil from '../../utils/label';
-import { isEmpty, compare } from '../../utils/comparators';
-import { getValidation, hasValidation, getListProps } from '../helpers';
+import { forEachComponent, forEachField, labelComponent, isValid, getSchema } from '../helpers';
 
 export const label = 'Conditionally Required',
   description = 'Some fields are required for publication, based on other fields',
   type = 'error';
 
-function hasEmptyRequiredListItems(val, fieldSchema) {
-  const props = getListProps(fieldSchema);
-
-  // look through the complex-list props for anything that's required,
-  // then look through the field's data seeing if that prop is empty
-  return !!_.find(props, (propConfig) => hasValidation('conditional-required', propConfig) && !!_.find(val, (item) => isEmpty(item[propConfig.prop])));
-}
-
 export function validate(state) {
-  return _.reduce(state.components, (result, component, uri) => {
-    _.forOwn(component, (val, key) => {
-      const name = getComponentName(uri),
-        schema = _.get(state, `schemas[${name}][${key}]`);
+  let errors = [];
 
-      if (isEmpty(val) || hasEmptyRequiredListItems(val, schema)) {
-        // first, check empty values. if it's empty, then we should
-        // look in the schema to see if it was required
-        const conditionalRequired = getValidation('conditional-required', schema),
-          compareField = conditionalRequired && _.get(conditionalRequired, 'validate.required.field');
+  forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
+    // note: explicitly check that this isn't a regular required field
+    if (_.isObject(_.get(field, 'validate.required')) && !isValid(field, componentData)) {
+      const compareField = _.get(field, 'validate.required.field'),
+        compareSchema = _.get(getSchema(state, uri), compareField);
 
-        let compareSchema, emptyItemIndex, compareData, shouldBeRequired;
+      errors.push({
+        uri,
+        field: _.head(field.path.split('.')), // todo: deep complex-list paths in the ui
+        location: `${labelComponent(uri)} » ${labelUtil(field.name, field.schema)}`,
+        preview: `(based on ${labelUtil(compareField, compareSchema)})`
+      });
+    }
+  }));
 
-        if (conditionalRequired && conditionalRequired._path) {
-          // check the list item OR field it's based on, to see if it's required
-          compareSchema = _.find(_.get(getValidation('complex-list', schema), 'props'), (prop) => prop.prop === compareField);
-          emptyItemIndex = _.findIndex(val, (item) => isEmpty(item[conditionalRequired._path]));
-          compareData = _.get(val, `${emptyItemIndex}.${compareField}`);
-        }
-
-        if (conditionalRequired) {
-          // check the field it's based on, to see if it's actually required here
-          compareSchema = compareSchema || _.get(state, `schemas[${name}][${compareField}]`);
-          compareData = compareData || _.get(component, compareField);
-          shouldBeRequired = compare({ data: compareData, operator: _.get(conditionalRequired, 'validate.required.operator'), value: _.get(conditionalRequired, 'validate.required.value') });
-
-          if (shouldBeRequired) {
-            result.push({
-              uri,
-              field: key,
-              location: `${labelUtil(name)} » ${labelUtil(key, schema)}`,
-              preview: `(based on ${labelUtil(compareField, compareSchema)})`
-            });
-          }
-        }
-      }
-    });
-
-    return result;
-  }, []);
+  return errors;
 }

--- a/lib/validators/built-in/edit-links.js
+++ b/lib/validators/built-in/edit-links.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { forEachComponent, forEachField, labelComponent, getPlaintextValue } from '../helpers';
+import { forEachComponent, forEachField, labelComponent, getPlaintextValue, getPreviewText } from '../helpers';
 
 export const label = 'Edit Mode Links',
   description = 'There are internal links to Clay pages in edit mode',

--- a/lib/validators/built-in/edit-links.js
+++ b/lib/validators/built-in/edit-links.js
@@ -1,30 +1,29 @@
 import _ from 'lodash';
-import striptags from 'striptags';
-import { getComponentName } from '../../utils/references';
-import labelComponent from '../../utils/label';
-import { getPreviewText } from '../helpers';
+import { forEachComponent, forEachField, labelComponent, getPlaintextValue } from '../helpers';
 
 export const label = 'Edit Mode Links',
   description = 'There are internal links to Clay pages in edit mode',
   type = 'error';
 
 export function validate(state) {
-  return _.reduce(state.components, (result, component, uri) => {
-    _.forOwn(component, (val, key) => {
-      if (_.isString(val) && val.match(/href=".*?[\?\&]edit=true"/)) {
-        const linkText = val.match(/href=".*?[\?\&]edit=true".*?>(.*?)/)[1],
-          text = striptags(val),
-          index = text.indexOf(linkText);
+  let errors = [];
 
-        result.push({
-          uri,
-          field: key,
-          location: labelComponent(getComponentName(uri)),
-          preview: getPreviewText(text, index, 7)
-        });
-      }
-    });
+  forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
+    const val = field.value;
 
-    return result;
-  }, []);
+    if (_.isString(val) && val.match(/href=".*?[\?\&]edit=true"/)) {
+      const linkText = val.match(/href=".*?[\?\&]edit=true".*?>(.*?)/)[1],
+        text = getPlaintextValue(val),
+        index = text.indexOf(linkText);
+
+      errors.push({
+        uri,
+        field: _.head(field.path.split('.')), // todo: deep complex-list paths in the ui
+        location: labelComponent(uri),
+        preview: getPreviewText(text, index, 7)
+      });
+    }
+  }));
+
+  return errors;
 }

--- a/lib/validators/built-in/max.js
+++ b/lib/validators/built-in/max.js
@@ -10,7 +10,12 @@ export function validate(state) {
   let errors = [];
 
   forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
-    if (!isValid(field, componentData, 'max')) {
+    if (!isValid(field, componentData, 'max') && field.type === 'component-list') {
+      errors.push({
+        uri,
+        location: `${labelComponent(uri)} » ${labelUtil(field.name)}`
+      });
+    } else if (!isValid(field, componentData, 'max')) {
       errors.push({
         uri,
         field: _.head(field.path.split('.')), // todo: deep complex-list paths in the ui

--- a/lib/validators/built-in/max.test.js
+++ b/lib/validators/built-in/max.test.js
@@ -1,6 +1,6 @@
-import * as lib from './soft-maxlength';
+import * as lib from './max';
 
-describe('validators: soft-maxlength', () => {
+describe('validators: max', () => {
   it('has a label', () => expect(lib.label).to.not.equal(null));
   it('has a description', () => expect(lib.description).to.not.equal(null));
   it('returns errors', () => expect(lib.type).to.equal('error'));
@@ -89,6 +89,25 @@ describe('validators: soft-maxlength', () => {
       })).to.eql([]);
     });
 
+    it('passes if component list has fewer components than length', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: [{ _ref: 'domain.com/components/foo' }, { _ref: 'domain.com/components/bar' }] }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _componentList: {
+                validate: {
+                  max: 3
+                }
+              }
+            }
+          }
+        }
+      })).to.eql([]);
+    });
+
     it('fails if text field has more characters than length', () => {
       expect(fn({
         components: {
@@ -111,6 +130,28 @@ describe('validators: soft-maxlength', () => {
         field: 'a',
         location: 'Foo » A',
         preview: '…llo'
+      }]);
+    });
+
+    it('fails if component list has more components than length', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: [{ _ref: 'domain.com/components/foo' }, { _ref: 'domain.com/components/bar' }] }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _componentList: {
+                validate: {
+                  max: 1
+                }
+              }
+            }
+          }
+        }
+      })).to.eql([{
+        uri,
+        location: 'Foo » A'
       }]);
     });
   });

--- a/lib/validators/built-in/min.js
+++ b/lib/validators/built-in/min.js
@@ -1,0 +1,29 @@
+import _ from 'lodash';
+import labelUtil from '../../utils/label';
+import { forEachComponent, forEachField, labelComponent, isValid, getPlaintextValue } from '../helpers';
+
+export const label = 'Min Length',
+  description = 'Some fields must be more than a certain length for consistent formatting across all syndications',
+  type = 'error';
+
+export function validate(state) {
+  let errors = [];
+
+  forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
+    if (!isValid(field, componentData, 'min') && field.type === 'component-list') {
+      errors.push({
+        uri,
+        location: `${labelComponent(uri)} » ${labelUtil(field.name)}`
+      });
+    } else if (!isValid(field, componentData, 'min')) {
+      errors.push({
+        uri,
+        field: _.head(field.path.split('.')), // todo: deep complex-list paths in the ui
+        location: `${labelComponent(uri)} » ${labelUtil(field.name, field.schema)}`,
+        preview: getPlaintextValue(field.value)
+      });
+    }
+  }));
+
+  return errors;
+}

--- a/lib/validators/built-in/min.test.js
+++ b/lib/validators/built-in/min.test.js
@@ -1,6 +1,6 @@
-import * as lib from './max';
+import * as lib from './min';
 
-describe('validators: max', () => {
+describe('validators: min', () => {
   it('has a label', () => expect(lib.label).to.not.equal(null));
   it('has a description', () => expect(lib.description).to.not.equal(null));
   it('returns errors', () => expect(lib.type).to.equal('error'));
@@ -14,7 +14,7 @@ describe('validators: max', () => {
       expect(fn({})).to.eql([]);
     });
 
-    it('passes if no fields with max', () => {
+    it('passes if no fields with min', () => {
       expect(fn({
         components: {
           [uri]: { a: null }
@@ -29,7 +29,7 @@ describe('validators: max', () => {
       })).to.eql([]);
     });
 
-    it('passes if text field has fewer characters than length', () => {
+    it('passes if text field has more characters than length', () => {
       expect(fn({
         components: {
           [uri]: { a: 'hello' }
@@ -40,7 +40,7 @@ describe('validators: max', () => {
               _has: {
                 input: 'text',
                 validate: {
-                  max: 6
+                  min: 2
                 }
               }
             }
@@ -60,7 +60,7 @@ describe('validators: max', () => {
               _has: {
                 input: 'text',
                 validate: {
-                  max: 5
+                  min: 5
                 }
               }
             }
@@ -69,7 +69,7 @@ describe('validators: max', () => {
       })).to.eql([]);
     });
 
-    it('passes if cleaned html has fewer characters than length', () => {
+    it('passes if cleaned html has more characters than length', () => {
       expect(fn({
         components: {
           [uri]: { a: '<span>h<strong>ell</strong>o</span>' }
@@ -80,7 +80,7 @@ describe('validators: max', () => {
               _has: {
                 input: 'text',
                 validate: {
-                  max: 6
+                  min: 4
                 }
               }
             }
@@ -89,7 +89,7 @@ describe('validators: max', () => {
       })).to.eql([]);
     });
 
-    it('passes if component list has fewer components than length', () => {
+    it('passes if component list has more components than length', () => {
       expect(fn({
         components: {
           [uri]: { a: [{ _ref: 'domain.com/components/foo' }, { _ref: 'domain.com/components/bar' }] }
@@ -99,7 +99,7 @@ describe('validators: max', () => {
             a: {
               _componentList: {
                 validate: {
-                  max: 3
+                  min: 1
                 }
               }
             }
@@ -108,7 +108,7 @@ describe('validators: max', () => {
       })).to.eql([]);
     });
 
-    it('fails if text field has more characters than length', () => {
+    it('fails if text field has fewer characters than length', () => {
       expect(fn({
         components: {
           [uri]: { a: 'hello' }
@@ -119,7 +119,7 @@ describe('validators: max', () => {
               _has: {
                 input: 'text',
                 validate: {
-                  max: 2
+                  min: 10
                 }
               }
             }
@@ -129,11 +129,11 @@ describe('validators: max', () => {
         uri,
         field: 'a',
         location: 'Foo » A',
-        preview: '…llo'
+        preview: 'hello'
       }]);
     });
 
-    it('fails if component list has more components than length', () => {
+    it('fails if component list has fewer components than length', () => {
       expect(fn({
         components: {
           [uri]: { a: [{ _ref: 'domain.com/components/foo' }, { _ref: 'domain.com/components/bar' }] }
@@ -143,7 +143,7 @@ describe('validators: max', () => {
             a: {
               _componentList: {
                 validate: {
-                  max: 1
+                  min: 3
                 }
               }
             }

--- a/lib/validators/built-in/pattern.js
+++ b/lib/validators/built-in/pattern.js
@@ -1,0 +1,24 @@
+import _ from 'lodash';
+import labelUtil from '../../utils/label';
+import { forEachComponent, forEachField, labelComponent, isValid } from '../helpers';
+
+export const label = 'Pattern',
+  description = 'Some fields require a specific pattern',
+  type = 'error';
+
+export function validate(state) {
+  let errors = [];
+
+  forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
+    if (!isValid(field, componentData, 'pattern')) {
+      errors.push({
+        uri,
+        field: _.head(field.path.split('.')), // todo: deep complex-list paths in the ui
+        location: `${labelComponent(uri)} » ${labelUtil(field.name, field.schema)}`,
+        preview: _.get(field, 'validate.patternMessage')
+      });
+    }
+  }));
+
+  return errors;
+}

--- a/lib/validators/built-in/pattern.js
+++ b/lib/validators/built-in/pattern.js
@@ -3,7 +3,7 @@ import labelUtil from '../../utils/label';
 import { forEachComponent, forEachField, labelComponent, isValid } from '../helpers';
 
 export const label = 'Pattern',
-  description = 'Some fields require a specific pattern',
+  description = 'Some fields must be formatted in a specific way',
   type = 'error';
 
 export function validate(state) {

--- a/lib/validators/built-in/pattern.test.js
+++ b/lib/validators/built-in/pattern.test.js
@@ -62,7 +62,7 @@ describe('validators: pattern', () => {
       })).to.eql([]);
     });
 
-    it('fails if pattern field with empty string', () => {
+    it('passes if pattern field with empty string', () => {
       expect(fn({
         components: {
           [uri]: { a: '' }
@@ -77,15 +77,10 @@ describe('validators: pattern', () => {
             }
           }
         }
-      })).to.eql([{
-        uri,
-        field: 'a',
-        location: 'Foo » A',
-        preview: 'Please write 5 letters'
-      }]);
+      })).to.eql([]);
     });
 
-    it('fails if pattern field with null value', () => {
+    it('passes if pattern field with null value', () => {
       expect(fn({
         components: {
           [uri]: { a: null }
@@ -100,15 +95,10 @@ describe('validators: pattern', () => {
             }
           }
         }
-      })).to.eql([{
-        uri,
-        field: 'a',
-        location: 'Foo » A',
-        preview: 'Please write 5 letters'
-      }]);
+      })).to.eql([]);
     });
 
-    it('fails if required field with undefined value', () => {
+    it('passes if pattern field with undefined value', () => {
       expect(fn({
         components: {
           [uri]: { a: undefined }
@@ -123,20 +113,33 @@ describe('validators: pattern', () => {
             }
           }
         }
-      })).to.eql([{
-        uri,
-        field: 'a',
-        location: 'Foo » A',
-        preview: 'Please write 5 letters'
-      }]);
+      })).to.eql([]);
     });
 
-    it('fails if required field not defined in the data', () => {
+    it('passes if pattern field not defined in the data', () => {
       expect(fn({
         components: {
           [uri]: {
             b: true // some other field needs to exist (otherwise we assume the component was deleted)
           }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: {
+                input: 'text',
+                validate: { pattern: '\\w{5}', patternMessage: 'Please write 5 letters' }
+              }
+            }
+          }
+        }
+      })).to.eql([]);
+    });
+
+    it('fails if pattern field that does not match', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: 'foo' }
         },
         schemas: {
           [name]: {
@@ -160,7 +163,7 @@ describe('validators: pattern', () => {
       expect(fn({
         components: {
           [uri]: {
-            b: true // some other field needs to exist (otherwise we assume the component was deleted)
+            a: 'foo'
           }
         },
         schemas: {

--- a/lib/validators/built-in/pattern.test.js
+++ b/lib/validators/built-in/pattern.test.js
@@ -1,0 +1,184 @@
+import * as lib from './pattern';
+
+describe('validators: pattern', () => {
+  it('has a label', () => expect(lib.label).to.not.equal(null));
+  it('has a description', () => expect(lib.description).to.not.equal(null));
+  it('returns errors', () => expect(lib.type).to.equal('error'));
+
+  describe('validate', () => {
+    const fn = lib.validate,
+      uri = 'domain.com/components/foo/instances/bar',
+      name = 'foo';
+
+    it('passes if no components', () => {
+      expect(fn({})).to.eql([]);
+    });
+
+    it('passes if deleted component', () => {
+      expect(fn({
+        components: {
+          [uri]: {}
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: 'text'
+            }
+          }
+        }
+      })).to.eql([]);
+    });
+
+    it('passes if no pattern fields', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: null }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: 'text'
+            }
+          }
+        }
+      })).to.eql([]);
+    });
+
+    it('passes if pattern field that matches', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: 'hello' }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: {
+                input: 'text',
+                validate: { pattern: '\\w{5}' }
+              }
+            }
+          }
+        }
+      })).to.eql([]);
+    });
+
+    it('fails if pattern field with empty string', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: '' }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: {
+                input: 'text',
+                validate: { pattern: '\\w{5}', patternMessage: 'Please write 5 letters' }
+              }
+            }
+          }
+        }
+      })).to.eql([{
+        uri,
+        field: 'a',
+        location: 'Foo » A',
+        preview: 'Please write 5 letters'
+      }]);
+    });
+
+    it('fails if pattern field with null value', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: null }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: {
+                input: 'text',
+                validate: { pattern: '\\w{5}', patternMessage: 'Please write 5 letters' }
+              }
+            }
+          }
+        }
+      })).to.eql([{
+        uri,
+        field: 'a',
+        location: 'Foo » A',
+        preview: 'Please write 5 letters'
+      }]);
+    });
+
+    it('fails if required field with undefined value', () => {
+      expect(fn({
+        components: {
+          [uri]: { a: undefined }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: {
+                input: 'text',
+                validate: { pattern: '\\w{5}', patternMessage: 'Please write 5 letters' }
+              }
+            }
+          }
+        }
+      })).to.eql([{
+        uri,
+        field: 'a',
+        location: 'Foo » A',
+        preview: 'Please write 5 letters'
+      }]);
+    });
+
+    it('fails if required field not defined in the data', () => {
+      expect(fn({
+        components: {
+          [uri]: {
+            b: true // some other field needs to exist (otherwise we assume the component was deleted)
+          }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: {
+                input: 'text',
+                validate: { pattern: '\\w{5}', patternMessage: 'Please write 5 letters' }
+              }
+            }
+          }
+        }
+      })).to.eql([{
+        uri,
+        field: 'a',
+        location: 'Foo » A',
+        preview: 'Please write 5 letters'
+      }]);
+    });
+
+    it('does not set preview text if patternMessage not found', () => {
+      expect(fn({
+        components: {
+          [uri]: {
+            b: true // some other field needs to exist (otherwise we assume the component was deleted)
+          }
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: {
+                input: 'text',
+                validate: { pattern: '\\w{5}' }
+              }
+            }
+          }
+        }
+      })).to.eql([{
+        uri,
+        field: 'a',
+        location: 'Foo » A',
+        preview: undefined
+      }]);
+    });
+  });
+});

--- a/lib/validators/built-in/required.js
+++ b/lib/validators/built-in/required.js
@@ -11,7 +11,7 @@ export function validate(state) {
 
   forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
     // note: explicitly check that this isn't a conditional-required field
-    if (_.get(field, 'validate.required') === true && !isValid(field, componentData)) {
+    if (_.get(field, 'validate.required') === true && !isValid(field, componentData, 'required')) {
       errors.push({
         uri,
         field: _.head(field.path.split('.')), // todo: deep complex-list paths in the ui

--- a/lib/validators/built-in/required.js
+++ b/lib/validators/built-in/required.js
@@ -1,49 +1,24 @@
 import _ from 'lodash';
-import { getComponentName } from '../../utils/references';
 import labelUtil from '../../utils/label';
-import { isEmpty } from '../../utils/comparators';
-import { getValidation, getListProps } from '../helpers';
+import { forEachComponent, forEachField, labelComponent, isValid } from '../helpers';
 
 export const label = 'Required',
   description = 'Some fields are required for publication',
   type = 'error';
 
-function hasEmptyRequiredListItems(val, fieldSchema) {
-  const props = getListProps(fieldSchema);
-
-  // look through the complex-list props for anything that's required,
-  // then look through the field's data seeing if that prop is empty
-  return !!_.find(props, (propConfig) => getValidation('required', propConfig) === true && !!_.find(val, (item) => isEmpty(item[propConfig.prop])));
-}
-
 export function validate(state) {
-  return _.reduce(state.components, (result, component, uri) => {
-    if (!_.isEmpty(component)) {
-      // if a component has been deleted, the representation in the store will be an empty object.
-      // this allows decorators and such to not fail, but we need to be aware of it
-      // when validating the component's data
-      // (because we want to validate against fields that are missing from the data)
-      const name = getComponentName(uri),
-        schema = _.get(state, `schemas[${name}]`);
+  let errors = [];
 
-      _.forOwn(schema, (fieldSchema, fieldName) => {
-        const requiredInput = getValidation('required', fieldSchema);
-
-        if (_.get(requiredInput, 'validate.required') === true) {
-          const val = component[fieldName];
-
-          // this field is required! check the component data
-          if (isEmpty(val) || hasEmptyRequiredListItems(val, fieldSchema)) {
-            result.push({
-              uri,
-              field: fieldName,
-              location: `${labelUtil(name)} » ${labelUtil(fieldName, schema)}`
-            });
-          }
-        }
+  forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
+    // note: explicitly check that this isn't a conditional-required field
+    if (_.get(field, 'validate.required') === true && !isValid(field, componentData)) {
+      errors.push({
+        uri,
+        field: _.head(field.path.split('.')), // todo: deep complex-list paths in the ui
+        location: `${labelComponent(uri)} » ${labelUtil(field.name, field.schema)}`
       });
     }
+  }));
 
-    return result;
-  }, []);
+  return errors;
 }

--- a/lib/validators/built-in/soft-maxlength.js
+++ b/lib/validators/built-in/soft-maxlength.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import labelUtil from '../../utils/label';
-import { forEachComponent, forEachField, labelComponent, isValid } from '../helpers';
+import { forEachComponent, forEachField, labelComponent, isValid, getPlaintextValue } from '../helpers';
 
 export const label = 'Max Length',
   description = 'Some fields must be less than a certain length for consistent formatting across all syndications',

--- a/lib/validators/built-in/soft-maxlength.js
+++ b/lib/validators/built-in/soft-maxlength.js
@@ -1,48 +1,27 @@
 import _ from 'lodash';
-import { decode } from 'he';
-import striptags from 'striptags';
-import { getComponentName } from '../../utils/references';
 import labelUtil from '../../utils/label';
-import { getValidation } from '../helpers';
+import { forEachComponent, forEachField, labelComponent, isValid } from '../helpers';
 
 export const label = 'Max Length',
   description = 'Some fields must be less than a certain length for consistent formatting across all syndications',
   type = 'error';
 
-/**
- * decode and strip html tags from text,
- * so we can get an accurate length measurement
- * @param  {string} value
- * @return {string}
- */
-function cleanValue(value) {
-  return decode(striptags(value));
-}
-
 export function validate(state) {
-  return _.reduce(state.components, (result, component, uri) => {
-    _.forOwn(component, (val, key) => {
-      const name = getComponentName(uri),
-        schema = _.get(state, `schemas[${name}][${key}]`),
-        softMaxlength = getValidation('max', schema);
+  let errors = [];
 
-      if (_.isString(val) && softMaxlength) {
-        const cleanVal = cleanValue(val);
+  forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
+    if (_.get(field, 'validate.max') && !isValid(field, componentData)) {
+      errors.push({
+        uri,
+        field: _.head(field.path.split('.')), // todo: deep complex-list paths in the ui
+        location: `${labelComponent(uri)} » ${labelUtil(field.name, field.schema)}`,
+        preview: _.truncate(`…${getPlaintextValue(field.value).substr(_.get(field, 'validate.max'))}`, {
+          length: 40,
+          omission: '…'
+        })
+      });
+    }
+  }));
 
-        if (cleanVal.length > _.get(softMaxlength, 'validate.max')) {
-          result.push({
-            uri,
-            field: key,
-            location: `${labelUtil(name)} » ${labelUtil(key, schema)}`,
-            preview: _.truncate(`…${cleanVal.substr(_.get(softMaxlength, 'validate.max'))}`, {
-              length: 40,
-              omission: '…'
-            })
-          });
-        }
-      }
-    });
-
-    return result;
-  }, []);
+  return errors;
 }

--- a/lib/validators/built-in/soft-maxlength.js
+++ b/lib/validators/built-in/soft-maxlength.js
@@ -10,7 +10,7 @@ export function validate(state) {
   let errors = [];
 
   forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
-    if (_.get(field, 'validate.max') && !isValid(field, componentData)) {
+    if (!isValid(field, componentData, 'max')) {
       errors.push({
         uri,
         field: _.head(field.path.split('.')), // todo: deep complex-list paths in the ui

--- a/lib/validators/built-in/tk.js
+++ b/lib/validators/built-in/tk.js
@@ -1,34 +1,28 @@
 import _ from 'lodash';
-import striptags from 'striptags';
-import { getComponentName, refProp } from '../../utils/references';
-import labelComponent from '../../utils/label';
-import { getPreviewText } from '../helpers';
+import { forEachComponent, forEachField, getPlaintextValue, getPreviewText, labelComponent } from '../helpers';
 
 export const label = 'TKs',
   description = 'There are TKs in your article. Make sure they\'re intentional',
   type = 'warning';
 
-function isUri(str) {
-  return !!/^[^\s]+[\/.][^\s]+$/.exec(str);
-}
-
 export function validate(state) {
-  return _.reduce(state.components, (result, component, uri) => {
-    _.forOwn(component, (val, key) => {
-      const text = _.isString(val) && !isUri(val) && striptags(val);
+  let errors = [];
 
-      if (key !== refProp && text && _.includes(text.toLowerCase(), 'tk')) {
-        const index = text.toLowerCase().indexOf('tk');
+  forEachComponent(state, (componentData, uri) => forEachField(state, componentData, uri, (field) => {
+    // note: only check for tk in text outside of tags,
+    // so things like urls work (also only check editable fields, not refs)
+    if (field.type === 'editable-field' && _.isString(field.value) && _.includes(getPlaintextValue(field.value).toLowerCase(), 'tk')) {
+      const text = getPlaintextValue(field.value),
+        index = text.toLowerCase().indexOf('tk');
 
-        result.push({
-          uri,
-          field: key,
-          location: labelComponent(getComponentName(uri)),
-          preview: getPreviewText(text, index, 2)
-        });
-      }
-    });
+      errors.push({
+        uri,
+        field: _.head(field.path.split('.')), // todo: deep complex-list paths in the ui
+        location: labelComponent(uri),
+        preview: getPreviewText(text, index, 2)
+      });
+    }
+  }));
 
-    return result;
-  }, []);
+  return errors;
 }

--- a/lib/validators/built-in/tk.test.js
+++ b/lib/validators/built-in/tk.test.js
@@ -1,6 +1,6 @@
 import * as lib from './tk';
 
-describe('validators: beyonce', () => {
+describe('validators: tk', () => {
   it('has a label', () => expect(lib.label).to.not.equal(null));
   it('has a description', () => expect(lib.description).to.not.equal(null));
   it('returns warnings', () => expect(lib.type).to.equal('warning'));
@@ -37,7 +37,7 @@ describe('validators: beyonce', () => {
         schemas: {
           [name]: {
             a: {
-              _has: ['text']
+              _has: 'text'
             }
           }
         }
@@ -53,7 +53,7 @@ describe('validators: beyonce', () => {
         schemas: {
           [name]: {
             a: {
-              _has: ['text']
+              _has: 'text'
             }
           }
         }
@@ -86,7 +86,7 @@ describe('validators: beyonce', () => {
         schemas: {
           [name]: {
             a: {
-              _has: ['text']
+              _has: 'text'
             }
           }
         }
@@ -99,6 +99,13 @@ describe('validators: beyonce', () => {
       expect(fn({
         components: {
           [uri]: { a: 'end of sentence tk. Start of sentence'}
+        },
+        schemas: {
+          [name]: {
+            a: {
+              _has: 'text'
+            }
+          }
         }
       }).length, 'fails tk at the end of a sentence').to.equal(1);
     });

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -290,7 +290,7 @@ export function isValid(field, componentData, type) { // eslint-disable-line
     switch (type) {
       case 'required': return !(validate.required === true && isFieldEmpty);
       case 'conditional-required': return !(_.isObject(validate.required) && shouldBeRequired(field, componentData) && isFieldEmpty);
-      case 'pattern': return !(!strValue || validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')));
+      case 'pattern': return !(!isFieldEmpty && validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')));
       case 'min': return !(validate.min && (length || fieldValue) < validate.min);
       case 'max': return !(validate.max && (length || fieldValue) > validate.max);
       default: throw new Error(`Unsupported validation type: ${type}`);
@@ -299,7 +299,7 @@ export function isValid(field, componentData, type) { // eslint-disable-line
     // validate required fields first, then the rest of the built-in validation rules
     return !(validate.required === true && isFieldEmpty || // regular required
       _.isObject(validate.required) && shouldBeRequired(field, componentData) && isFieldEmpty || // conditional-required
-      validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')) || // pattern validation
+      !isFieldEmpty && validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')) || // pattern validation
       validate.min && (length || fieldValue) < validate.min || // minimum length / value
       validate.max && (length || fieldValue) > validate.max); // maximum length / value
   }

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -286,7 +286,9 @@ export function isValid(field, componentData, type) { // eslint-disable-line
     length = (strValue || fieldValue).length;
   }
 
+  // you can run isValid() against a specific type, or simply against all options specified in the `validate` object
   if (type) {
+    // run against a specific kind of validation
     switch (type) {
       case 'required': return !(validate.required === true && isFieldEmpty);
       case 'conditional-required': return !(_.isObject(validate.required) && shouldBeRequired(field, componentData) && isFieldEmpty);
@@ -296,6 +298,7 @@ export function isValid(field, componentData, type) { // eslint-disable-line
       default: throw new Error(`Unsupported validation type: ${type}`);
     }
   } else {
+    // run against all options specified in the `validate` object
     // validate required fields first, then the rest of the built-in validation rules
     return !(validate.required === true && isFieldEmpty || // regular required
       _.isObject(validate.required) && shouldBeRequired(field, componentData) && isFieldEmpty || // conditional-required

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -1,8 +1,182 @@
 // some little helpers to make writing validators easier.
 // these are exported through the api for use in custom validators
 import _ from 'lodash';
+import striptags from 'striptags';
+import { decode } from 'he';
 import { rawExpand } from '../forms/inputs';
-import { fieldProp, inputProp } from '../utils/references';
+import { isComponent, getComponentName, refProp, fieldProp, inputProp, componentListProp, componentProp } from '../utils/references';
+import { isEmpty, compare } from '../utils/comparators';
+
+/**
+ * iterate through components, calling a function on all non-empty components
+ * optionally: only call the function on specific types of components
+ * @param  {object}   state
+ * @param  {Function} fn called with componentData, uri
+ * @param  {string|array}   [nameFilter]
+ */
+export function forEachComponent(state, fn, nameFilter) {
+  _.forOwn(_.get(state, 'components', {}), (componentData, uri) => {
+    if (_.isEmpty(componentData)) {
+      return; // component has been removed from the store, so it's an empty object
+    }
+
+    if (_.isArray(nameFilter)) {
+      // if the component matches any of the names, run the function
+      _.each(nameFilter, (name) => {
+        if (uri.match(new RegExp(`components\/${name}(?:\/|$)`))) {
+          fn(componentData, uri);
+        }
+      });
+    } else if (_.isString(nameFilter) && uri.match(new RegExp(`components\/${nameFilter}(?:\/|$)`))) {
+      // if the component matches the (single) type passed in, run the function
+      fn(componentData, uri);
+    } else if (!nameFilter) {
+      // if no filter was passed in, run the funtion
+      fn(componentData, uri);
+    }
+  });
+}
+
+/**
+ * get schema from state
+ * @param  {object} state
+ * @param  {string} name or uri
+ * @return {object}
+ */
+export function getSchema(state, name) {
+  // if it's actually a full uri, get the name
+  if (isComponent(name)) {
+    name = getComponentName(name);
+  }
+
+  return _.get(state, `schemas[${name}]`, {});
+}
+
+/**
+ * call field fn with field object,
+ * recursively calling itself for complex-list items
+ * @param  {object}   schema
+ * @param  {*}   data
+ * @param  {string}   name
+ * @param  {string}   path (in complex-lists, this will have the item's index)
+ * @param  {Function} fn
+ */
+function recursivelyCallField({ schema, data, name, path, fn }) {
+  let fieldObj = {
+    name,
+    path,
+    schema
+  };
+
+  if (_.has(schema, fieldProp) && _.get(schema, `${fieldProp}.${inputProp}`) === 'complex-list') {
+    // complex-list, so recursively look at fields inside it
+    fieldObj.type = 'complex-list';
+    fieldObj.value = data || [];
+    // complex list items, or empty array
+    // note: complex lists that don't have default data (and were never set) get normalized to `[]` here
+    fn(fieldObj);
+    // once the complex-list itself is called, iterate through any items it may contain
+    _.each(fieldObj.value, (item, index) => {
+      _.each(_.get(schema, `${fieldProp}.props`, []), (listProp) => {
+        const prop = listProp.prop;
+
+        recursivelyCallField({
+          schema: listProp,
+          data: _.get(item, prop, null),
+          name: prop,
+          path: `${path}.${index}.${prop}`,
+          fn
+        });
+      });
+    });
+  } else if (_.has(schema, fieldProp) && (_.has(schema, `${fieldProp}.${inputProp}`) || _.isString(schema[fieldProp]))) {
+    // regular editable field
+    fieldObj.type = 'editable-field';
+    fieldObj.value = data;
+    // field data, or null
+    // note: fields that don't have default data (and were never set) get normalized to `null` here
+    fn(fieldObj);
+  } else {
+    // non-editable field (no `input` set)
+    // note: these may be set by model.js, pubsub, or other means. they can still be validated against
+    fieldObj.type = 'non-editable-field';
+    fieldObj.value = data;
+    // field data, or null
+    // note: non-editable fields might have weird-looking data (e.g. component lists, props, etc that weren't specced out in the schema correctly)
+    // note: fields that don't have default data (and were never set) get normalized to `null` here
+    fn(fieldObj);
+  }
+}
+
+/**
+ * iterate through fields, calling a function on each field
+ * note: fields inside complex-lists will be called AFTER the complex-list field
+ * note: fields inside complex-lists will have indices in their paths
+ * @param {object} state
+ * @param  {object}   componentData
+ * @param  {string}   uri
+ * @param  {Function} fn called with field object { type, name, schema, path, value }
+ * note: field.type is 'complex-list', 'editable-field', 'component-list', 'component-prop', or 'non-editable-field'
+ */
+export function forEachField(state, componentData, uri, fn) {
+  const schema = getSchema(state, uri);
+
+  if (_.isEmpty(componentData) || _.isEmpty(schema)) {
+    // don't run validation against empty components or components without fields
+    return;
+  }
+
+  _.forOwn(schema, (fieldSchema, fieldName) => {
+    let fieldObj = {
+      name: fieldName,
+      schema: fieldSchema
+    };
+
+    if (_.includes(['_version', '_description', '_devDescription'], fieldName)) {
+      // don't run field validation if the field is a reserved field (version, description, etc)
+      return;
+    }
+
+    // set the field type
+    if (_.has(fieldSchema, componentListProp)) {
+      const val = _.get(componentData, fieldName, []);
+
+      // component list
+      fieldObj.type = 'component-list';
+      fieldObj.path = fieldName;
+      fieldObj.value = _.isArray(val) ? val.map((child) => child[refProp]) : val;
+      // array of refs, string alias for a page area, or empty array
+      fn(fieldObj);
+    } else if (_.has(fieldSchema, componentProp)) {
+      // component prop
+      fieldObj.type = 'component-prop';
+      fieldObj.path = fieldName;
+      fieldObj.value = _.get(componentData, fieldName, {})[refProp] || null;
+      // child ref, or null
+      fn(fieldObj);
+    } else {
+      // possibly-recursive field
+      recursivelyCallField({
+        schema: fieldSchema,
+        data: _.get(componentData, fieldName, null),
+        name: fieldName,
+        path: fieldName,
+        fn
+      });
+    }
+  });
+}
+
+/**
+ * get the plaintext value of a string
+ * @param  {string} val
+ * @return {string}
+ */
+export function getPlaintextValue(val) {
+  let str = new String(val);
+
+  return decode(striptags(str));
+}
 
 /**
  * get the text to preview
@@ -29,6 +203,82 @@ export function getPreviewText(text, index, length) {
 
   return previewText;
 }
+
+/**
+ * detrmine whether a conditional-required field should be required
+ * note: exported for testing
+ * @param  {object} field         { type, name, path, schema, value }
+ * @param  {object} componentData
+ * @return {boolean}
+ */
+export function shouldBeRequired(field, componentData) {
+  const compareField = _.get(field, 'schema.validate.required.field'),
+    compareOperator = _.get(field, 'schema.validate.required.operator'),
+    compareValue = _.get(field, 'schema.validate.required.value'),
+    path = _.get(field, 'path'),
+    pathArray = path.split('.');
+
+  let comparePath;
+
+  if (pathArray.length > 1) {
+    // iterate up through the path, checking to see if the parent item (for complex lists)
+    // has the field in question
+    _.findLast(pathArray, (pathPart, pathIndex) => {
+      if (pathPart.match(/\d+/)) {
+        const subPath = pathArray.slice(0, pathIndex + 1).join('.');
+
+        if (_.has(componentData, `${subPath}.${compareField}`)) {
+          comparePath = `${subPath}.${compareField}`;
+          return true;
+        } else {
+          return false;
+        };
+      } else {
+        return false;
+      }
+    });
+  } else {
+    comparePath = compareField;
+  }
+
+  return compare({ data: _.get(componentData, comparePath), operator: compareOperator, value: compareValue });
+}
+
+/**
+ * determine if a field passes built-in validation
+ * @param  {object}  field         { type, name, path, schema, value }
+ * @param  {object}  componentData
+ * @return {Boolean}
+ */
+export function isValid(field, componentData) { // eslint-disable-line
+  const validate = _.get(field, 'schema.validate'),
+    fieldValue = _.get(field, 'value'),
+    isFieldEmpty = isEmpty(fieldValue),
+    strValue = _.isString(fieldValue) && getPlaintextValue(fieldValue);
+
+  let length;
+
+  if (!_.isObject(validate)) {
+    return true; // if no built-in validation rules, return true
+  }
+
+  // if we're dealing with strings or arrays, we'll want to check min/max against the length
+  // (if it's numbers, dates, or other things, we want to check min/max against the value directly)
+  if (strValue || _.isArray(fieldValue)) {
+    length = (strValue || fieldValue).length;
+  }
+
+  // validate required fields first, then the rest of the built-in validation rules
+  return !(isFieldEmpty && validate.required === true ||
+    isFieldEmpty && _.isObject(validate.required) && shouldBeRequired(field, componentData) || // conditional-required
+    !isFieldEmpty && validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')) || // pattern validation
+    !isFieldEmpty && validate.min && length < validate.min || // minimum string/array length
+    !isFieldEmpty && validate.min && fieldValue < validate.min || // minimum number/date value
+    !isFieldEmpty && validate.max && length > validate.max || // maximum string/array length
+    !isFieldEmpty && validate.max && fieldValue > validate.max); // maximum number/date value
+}
+
+// DEPRECATED HELPERS - will be removed in kiln 6.x
 
 /**
  * get a input config from a field's schema, if it contains that specific input

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -151,6 +151,7 @@ export function forEachField(state, componentData, uri, fn) {
       fieldObj.type = 'component-list';
       fieldObj.path = fieldName;
       fieldObj.value = _.isArray(val) ? val.map((child) => child[refProp]) : val;
+      fieldObj.validate = _.get(fieldSchema, `${componentListProp}.validate`);
       // array of refs, string alias for a page area, or empty array
       fn(fieldObj);
     } else if (_.has(fieldSchema, componentProp)) {
@@ -158,6 +159,7 @@ export function forEachField(state, componentData, uri, fn) {
       fieldObj.type = 'component-prop';
       fieldObj.path = fieldName;
       fieldObj.value = _.get(componentData, fieldName, {})[refProp] || null;
+      fieldObj.validate = _.get(fieldSchema, `${componentProp}.validate`);
       // child ref, or null
       fn(fieldObj);
     } else {

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -66,7 +66,8 @@ function recursivelyCallField({ schema, data, name, path, fn }) {
   let fieldObj = {
     name,
     path,
-    schema
+    schema,
+    validate: _.get(schema, `${fieldProp}.validate`)
   };
 
   if (_.has(schema, fieldProp) && _.get(schema, `${fieldProp}.${inputProp}`) === 'complex-list') {
@@ -133,7 +134,7 @@ export function forEachField(state, componentData, uri, fn) {
       schema: fieldSchema
     };
 
-    if (_.includes(['_version', '_description', '_devDescription'], fieldName)) {
+    if (_.includes(['_version', '_description', '_devDescription', '_groups'], fieldName)) {
       // don't run field validation if the field is a reserved field (version, description, etc)
       return;
     }
@@ -222,9 +223,9 @@ export function getPreviewText(text, index, length) {
  * @return {boolean}
  */
 export function shouldBeRequired(field, componentData) {
-  const compareField = _.get(field, 'schema.validate.required.field'),
-    compareOperator = _.get(field, 'schema.validate.required.operator'),
-    compareValue = _.get(field, 'schema.validate.required.value'),
+  const compareField = _.get(field, 'validate.required.field'),
+    compareOperator = _.get(field, 'validate.required.operator'),
+    compareValue = _.get(field, 'validate.required.value'),
     path = _.get(field, 'path'),
     pathArray = path.split('.');
 
@@ -261,7 +262,7 @@ export function shouldBeRequired(field, componentData) {
  * @return {Boolean}
  */
 export function isValid(field, componentData) { // eslint-disable-line
-  const validate = _.get(field, 'schema.validate'),
+  const validate = _.get(field, 'validate'),
     fieldValue = _.get(field, 'value'),
     isFieldEmpty = isEmpty(fieldValue),
     strValue = _.isString(fieldValue) && getPlaintextValue(fieldValue);

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import striptags from 'striptags';
 import { decode } from 'he';
 import { rawExpand } from '../forms/inputs';
+import label from '../utils/label';
 import { isComponent, getComponentName, refProp, fieldProp, inputProp, componentListProp, componentProp } from '../utils/references';
 import { isEmpty, compare } from '../utils/comparators';
 
@@ -176,6 +177,15 @@ export function getPlaintextValue(val) {
   let str = new String(val);
 
   return decode(striptags(str));
+}
+
+/**
+ * generate a component label from a uri
+ * @param  {string} uri
+ * @return {string}
+ */
+export function labelComponent(uri) {
+  return label(getComponentName(uri));
 }
 
 /**

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -263,9 +263,10 @@ export function shouldBeRequired(field, componentData) {
  * determine if a field passes built-in validation
  * @param  {object}  field         { type, name, path, schema, value }
  * @param  {object}  componentData
+ * @param {string} [type] if you only want to validate against a specific thing
  * @return {Boolean}
  */
-export function isValid(field, componentData) { // eslint-disable-line
+export function isValid(field, componentData, type) { // eslint-disable-line
   const validate = _.get(field, 'validate'),
     fieldValue = _.get(field, 'value'),
     isFieldEmpty = isEmpty(fieldValue),
@@ -283,14 +284,23 @@ export function isValid(field, componentData) { // eslint-disable-line
     length = (strValue || fieldValue).length;
   }
 
-  // validate required fields first, then the rest of the built-in validation rules
-  return !(isFieldEmpty && validate.required === true ||
-    isFieldEmpty && _.isObject(validate.required) && shouldBeRequired(field, componentData) || // conditional-required
-    !isFieldEmpty && validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')) || // pattern validation
-    !isFieldEmpty && validate.min && length < validate.min || // minimum string/array length
-    !isFieldEmpty && validate.min && fieldValue < validate.min || // minimum number/date value
-    !isFieldEmpty && validate.max && length > validate.max || // maximum string/array length
-    !isFieldEmpty && validate.max && fieldValue > validate.max); // maximum number/date value
+  if (type) {
+    switch (type) {
+      case 'required': return !(validate.required === true && isFieldEmpty);
+      case 'conditional-required': return !(_.isObject(validate.required) && shouldBeRequired(field, componentData) && isFieldEmpty);
+      case 'pattern': return !(validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')));
+      case 'min': return !(validate.min && (length || fieldValue) < validate.min);
+      case 'max': return !(validate.max && (length || fieldValue) > validate.max);
+      default: return true;
+    }
+  } else {
+    // validate required fields first, then the rest of the built-in validation rules
+    return !(validate.required === true && isFieldEmpty || // regular required
+      _.isObject(validate.required) && shouldBeRequired(field, componentData) && isFieldEmpty || // conditional-required
+      validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')) || // pattern validation
+      validate.min && (length || fieldValue) < validate.min || // minimum length / value
+      validate.max && (length || fieldValue) > validate.max); // maximum length / value
+  }
 }
 
 // DEPRECATED HELPERS - will be removed in kiln 6.x

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -290,7 +290,7 @@ export function isValid(field, componentData, type) { // eslint-disable-line
     switch (type) {
       case 'required': return !(validate.required === true && isFieldEmpty);
       case 'conditional-required': return !(_.isObject(validate.required) && shouldBeRequired(field, componentData) && isFieldEmpty);
-      case 'pattern': return !(validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')));
+      case 'pattern': return !(!strValue || validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')));
       case 'min': return !(validate.min && (length || fieldValue) < validate.min);
       case 'max': return !(validate.max && (length || fieldValue) > validate.max);
       default: throw new Error(`Unsupported validation type: ${type}`);

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -291,7 +291,7 @@ export function isValid(field, componentData, type) { // eslint-disable-line
       case 'pattern': return !(validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')));
       case 'min': return !(validate.min && (length || fieldValue) < validate.min);
       case 'max': return !(validate.max && (length || fieldValue) > validate.max);
-      default: return true;
+      default: throw new Error(`Unsupported validation type: ${type}`);
     }
   } else {
     // validate required fields first, then the rest of the built-in validation rules

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -222,7 +222,7 @@ export function getPreviewText(text, index, length) {
 }
 
 /**
- * detrmine whether a conditional-required field should be required
+ * determine whether a conditional-required field should be required
  * note: exported for testing
  * @param  {object} field         { type, name, path, schema, value }
  * @param  {object} componentData

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -45,6 +45,10 @@ export function forEachComponent(state, fn, nameFilter) {
  * @return {object}
  */
 export function getSchema(state, name) {
+  if (_.isString(state)) {
+    throw new Error('You must pass in state to getSchema() as the first argument!');
+  }
+
   // if it's actually a full uri, get the name
   if (isComponent(name)) {
     name = getComponentName(name);

--- a/lib/validators/helpers.test.js
+++ b/lib/validators/helpers.test.js
@@ -257,7 +257,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: null,
-        schema: {}
+        schema: {},
+        validate: undefined
       });
     });
 
@@ -275,7 +276,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: null,
-        schema: { _has: { help: 'hi' }}
+        schema: { _has: { help: 'hi' }},
+        validate: undefined
       });
     });
 
@@ -293,7 +295,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: null,
-        schema: { _has: { help: 'hi' }}
+        schema: { _has: { help: 'hi' }},
+        validate: undefined
       });
     });
 
@@ -312,7 +315,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: 'b',
-        schema: { _has: { help: 'hi' }}
+        schema: { _has: { help: 'hi' }},
+        validate: undefined
       });
     });
 
@@ -330,7 +334,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: null,
-        schema: { _has: 'text' }
+        schema: { _has: 'text' },
+        validate: undefined
       });
     });
 
@@ -348,7 +353,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: null,
-        schema: { _has: { input: 'text' }  }
+        schema: { _has: { input: 'text' }  },
+        validate: undefined
       });
     });
 
@@ -366,7 +372,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: false,
-        schema: { _has: 'checkbox' }
+        schema: { _has: 'checkbox' },
+        validate: undefined
       });
     });
 
@@ -384,7 +391,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: false,
-        schema: { _has: { input: 'checkbox' }  }
+        schema: { _has: { input: 'checkbox' }  },
+        validate: undefined
       });
     });
 
@@ -402,7 +410,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: '',
-        schema: { _has: { input: 'text' }  }
+        schema: { _has: { input: 'text' }  },
+        validate: undefined
       });
     });
 
@@ -420,7 +429,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: 0,
-        schema: { _has: { input: 'text', type: 'number' }  }
+        schema: { _has: { input: 'text', type: 'number' }  },
+        validate: undefined
       });
     });
 
@@ -438,7 +448,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: true,
-        schema: { _has: { input: 'checkbox' }  }
+        schema: { _has: { input: 'checkbox' }  },
+        validate: undefined
       });
     });
 
@@ -456,7 +467,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: 'hi',
-        schema: { _has: { input: 'text' }  }
+        schema: { _has: { input: 'text' }  },
+        validate: undefined
       });
     });
 
@@ -474,7 +486,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: 5,
-        schema: { _has: { input: 'text', type: 'number' }  }
+        schema: { _has: { input: 'text', type: 'number' }  },
+        validate: undefined
       });
     });
 
@@ -494,7 +507,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: [],
-        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } },
+        validate: undefined
       });
     });
 
@@ -512,7 +526,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: [],
-        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } },
+        validate: undefined
       });
     });
 
@@ -530,14 +545,16 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: [{}],
-        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } },
+        validate: undefined
       });
       expect(_.get(spy, 'args.1.0')).to.eql({
         type: 'editable-field',
         name: 'b',
         path: 'a.0.b',
         value: null,
-        schema: { prop: 'b', _has: 'text' }
+        schema: { prop: 'b', _has: 'text' },
+        validate: undefined
       });
     });
 
@@ -555,21 +572,24 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: [{ b: 'c' }, { b: 'd' }],
-        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } },
+        validate: undefined
       });
       expect(_.get(spy, 'args.1.0')).to.eql({
         type: 'editable-field',
         name: 'b',
         path: 'a.0.b',
         value: 'c',
-        schema: { prop: 'b', _has: 'text' }
+        schema: { prop: 'b', _has: 'text' },
+        validate: undefined
       });
       expect(_.get(spy, 'args.2.0')).to.eql({
         type: 'editable-field',
         name: 'b',
         path: 'a.1.b',
         value: 'd',
-        schema: { prop: 'b', _has: 'text' }
+        schema: { prop: 'b', _has: 'text' },
+        validate: undefined
       });
     });
 
@@ -602,21 +622,24 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: [{ b: [{ c: 'hi' }] }],
-        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: { input: 'complex-list', props: [{ prop: 'c', _has: 'text' }]} }] } }
+        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: { input: 'complex-list', props: [{ prop: 'c', _has: 'text' }]} }] } },
+        validate: undefined
       });
       expect(_.get(spy, 'args.1.0')).to.eql({
         type: 'complex-list',
         name: 'b',
         path: 'a.0.b',
         value: [{ c: 'hi' }],
-        schema: { prop: 'b', _has: { input: 'complex-list', props: [{ prop: 'c', _has: 'text' }]} }
+        schema: { prop: 'b', _has: { input: 'complex-list', props: [{ prop: 'c', _has: 'text' }]} },
+        validate: undefined
       });
       expect(_.get(spy, 'args.2.0')).to.eql({
         type: 'editable-field',
         name: 'c',
         path: 'a.0.b.0.c',
         value: 'hi',
-        schema: { prop: 'c', _has: 'text' }
+        schema: { prop: 'c', _has: 'text' },
+        validate: undefined
       });
     });
   });
@@ -655,12 +678,10 @@ describe('validation helpers', () => {
     it('compares root fields', () => {
       expect(fn({
         path: 'a',
-        schema: {
-          validate: {
-            required: {
-              field: 'b',
-              operator: 'empty'
-            }
+        validate: {
+          required: {
+            field: 'b',
+            operator: 'empty'
           }
         }}, { b: '' })).to.equal(true);
     });
@@ -668,12 +689,10 @@ describe('validation helpers', () => {
     it('compares complex-list field to root field', () => {
       expect(fn({
         path: 'a.0.b',
-        schema: {
-          validate: {
-            required: {
-              field: 'c',
-              operator: 'empty'
-            }
+        validate: {
+          required: {
+            field: 'c',
+            operator: 'empty'
           }
         }}, { a: [{ b: 'hi' }], c: '' })).to.equal(true);
     });
@@ -681,12 +700,10 @@ describe('validation helpers', () => {
     it('compares complex-list field to field in same list item', () => {
       expect(fn({
         path: 'a.0.b',
-        schema: {
-          validate: {
-            required: {
-              field: 'c',
-              operator: 'empty'
-            }
+        validate: {
+          required: {
+            field: 'c',
+            operator: 'empty'
           }
         }}, { a: [{ b: 'hi', c: '' }] })).to.equal(true);
     });
@@ -694,13 +711,11 @@ describe('validation helpers', () => {
     it('compares complex-list field to field in same list item BEFORE checking root field', () => {
       expect(fn({
         path: 'a.0.b',
-        schema: {
-          validate: {
-            required: {
-              field: 'c',
-              operator: '===',
-              value: 'one'
-            }
+        validate: {
+          required: {
+            field: 'c',
+            operator: '===',
+            value: 'one'
           }
         }}, { a: [{ b: 'hi', c: 'one' }], c: 'two' })).to.equal(true);
     });
@@ -708,13 +723,11 @@ describe('validation helpers', () => {
     it('compares nested complex-list field to field in same list item BEFORE checking higher-level list', () => {
       expect(fn({
         path: 'a.0.b.0.c',
-        schema: {
-          validate: {
-            required: {
-              field: 'd',
-              operator: '===',
-              value: 'one'
-            }
+        validate: {
+          required: {
+            field: 'd',
+            operator: '===',
+            value: 'one'
           }
         }}, { a: [{ b: [{ c: 'hi', d: 'one' }], d: 'two' }] })).to.equal(true);
     });
@@ -728,75 +741,75 @@ describe('validation helpers', () => {
     });
 
     it('returns true if non-empty and required', () => {
-      expect(fn({ schema: { validate: { required: true } }, value: 'hi' })).to.equal(true);
+      expect(fn({ validate: { required: true }, value: 'hi' })).to.equal(true);
     });
 
     it('returns false if empty and required', () => {
-      expect(fn({ schema: { validate: { required: true } }, value: '' })).to.equal(false);
+      expect(fn({ validate: { required: true }, value: '' })).to.equal(false);
     });
 
     it('returns true if non-empty and conditionally-required', () => {
-      expect(fn({ path: 'b', schema: { validate: { required: { field: 'a', operator: 'empty' } } }, value: 'hi' }, { a: '' })).to.equal(true);
+      expect(fn({ path: 'b', validate: { required: { field: 'a', operator: 'empty' } }, value: 'hi' }, { a: '' })).to.equal(true);
     });
 
     it('returns false if empty and conditionally-required', () => {
-      expect(fn({ path: 'b', schema: { validate: { required: { field: 'a', operator: 'empty' } } }, value: '' }, { a: '' })).to.equal(false);
+      expect(fn({ path: 'b', validate: { required: { field: 'a', operator: 'empty' } }, value: '' }, { a: '' })).to.equal(false);
     });
 
     it('returns true if pattern matches', () => {
-      expect(fn({ schema: { validate: { pattern: '^a' } }, value: 'abc' })).to.equal(true);
+      expect(fn({ validate: { pattern: '^a' }, value: 'abc' })).to.equal(true);
     });
 
     it('returns true if pattern does not match', () => {
-      expect(fn({ schema: { validate: { pattern: '^a' } }, value: 'bcd' })).to.equal(false);
+      expect(fn({ validate: { pattern: '^a' }, value: 'bcd' })).to.equal(false);
     });
 
     it('returns true if string length >= min', () => {
-      expect(fn({ schema: { validate: { min: 2 }}, value: 'hi' })).to.equal(true);
+      expect(fn({ validate: { min: 2 }, value: 'hi' })).to.equal(true);
     });
 
     it('returns false if string length !>= min', () => {
-      expect(fn({ schema: { validate: { min: 2 }}, value: 'a' })).to.equal(false);
+      expect(fn({ validate: { min: 2 }, value: 'a' })).to.equal(false);
     });
 
     it('returns true if array length >= min', () => {
-      expect(fn({ schema: { validate: { min: 1 }}, value: ['a'] })).to.equal(true);
+      expect(fn({ validate: { min: 1 }, value: ['a'] })).to.equal(true);
     });
 
     it('returns false if array length !>= min', () => {
-      expect(fn({ schema: { validate: { min: 2 }}, value: ['a'] })).to.equal(false);
+      expect(fn({ validate: { min: 2 }, value: ['a'] })).to.equal(false);
     });
 
     it('returns true if number value >= min', () => {
-      expect(fn({ schema: { validate: { min: 5 }}, value: 5 })).to.equal(true);
+      expect(fn({ validate: { min: 5 }, value: 5 })).to.equal(true);
     });
 
     it('returns false if number value !>= min', () => {
-      expect(fn({ schema: { validate: { min: 5 }}, value: 4 })).to.equal(false);
+      expect(fn({ validate: { min: 5 }, value: 4 })).to.equal(false);
     });
 
     it('returns true if string length <= max', () => {
-      expect(fn({ schema: { validate: { max: 2 }}, value: 'hi' })).to.equal(true);
+      expect(fn({ validate: { max: 2 }, value: 'hi' })).to.equal(true);
     });
 
     it('returns false if string length !<= max', () => {
-      expect(fn({ schema: { validate: { max: 2 }}, value: 'abc' })).to.equal(false);
+      expect(fn({ validate: { max: 2 }, value: 'abc' })).to.equal(false);
     });
 
     it('returns true if array length <= max', () => {
-      expect(fn({ schema: { validate: { max: 1 }}, value: ['a'] })).to.equal(true);
+      expect(fn({ validate: { max: 1 }, value: ['a'] })).to.equal(true);
     });
 
     it('returns false if array length !<= max', () => {
-      expect(fn({ schema: { validate: { max: '1' }}, value: ['a', 'b'] })).to.equal(false);
+      expect(fn({ validate: { max: '1' }, value: ['a', 'b'] })).to.equal(false);
     });
 
     it('returns true if number value <= max', () => {
-      expect(fn({ schema: { validate: { max: 5 }}, value: 5 })).to.equal(true);
+      expect(fn({ validate: { max: 5 }, value: 5 })).to.equal(true);
     });
 
     it('returns false if number value !<= max', () => {
-      expect(fn({ schema: { validate: { max: 5 }}, value: 6 })).to.equal(false);
+      expect(fn({ validate: { max: 5 }, value: 6 })).to.equal(false);
     });
   });
 

--- a/lib/validators/helpers.test.js
+++ b/lib/validators/helpers.test.js
@@ -147,7 +147,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: [],
-        schema: { _componentList: true }
+        schema: { _componentList: true },
+        validate: undefined
       });
     });
 
@@ -165,7 +166,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: [],
-        schema: { _componentList: true }
+        schema: { _componentList: true },
+        validate: undefined
       });
     });
 
@@ -183,7 +185,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: ['domain.com/components/bar'],
-        schema: { _componentList: true }
+        schema: { _componentList: true },
+        validate: undefined
       });
     });
 
@@ -201,7 +204,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: 'a',
-        schema: { _componentList: { page: true } }
+        schema: { _componentList: { page: true } },
+        validate: undefined
       });
     });
 
@@ -221,7 +225,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: null,
-        schema: { _component: true }
+        schema: { _component: true },
+        validate: undefined
       });
     });
 
@@ -239,7 +244,8 @@ describe('validation helpers', () => {
         name: 'a',
         path: 'a',
         value: 'domain.com/components/bar',
-        schema: { _component: true }
+        schema: { _component: true },
+        validate: undefined
       });
     });
 

--- a/lib/validators/helpers.test.js
+++ b/lib/validators/helpers.test.js
@@ -87,6 +87,10 @@ describe('validation helpers', () => {
   describe('getSchema', () => {
     const fn = lib.getSchema;
 
+    it('throws error if uri passed in as first argument', () => {
+      expect(() => getSchema('foo')).to.throw(Error);
+    });
+
     it('gets schema for component', () => {
       expect(fn({ schemas: { foo: { a: 'b' }}}, 'foo')).to.eql({ a: 'b' });
     });

--- a/lib/validators/helpers.test.js
+++ b/lib/validators/helpers.test.js
@@ -88,7 +88,7 @@ describe('validation helpers', () => {
     const fn = lib.getSchema;
 
     it('throws error if uri passed in as first argument', () => {
-      expect(() => getSchema('foo')).to.throw(Error);
+      expect(() => fn('foo')).to.throw(Error);
     });
 
     it('gets schema for component', () => {
@@ -814,6 +814,30 @@ describe('validation helpers', () => {
 
     it('returns false if number value !<= max', () => {
       expect(fn({ validate: { max: 5 }, value: 6 })).to.equal(false);
+    });
+
+    it('validates required directly', () => {
+      expect(fn({ validate: { required: true }, value: 'hi' }, { a: 'hi' }, 'required')).to.equal(true);
+    });
+
+    it('validates conditional-required directly', () => {
+      expect(fn({ path: 'b', validate: { required: { field: 'a', operator: 'empty' } }, value: 'hi' }, { a: '' }, 'conditional-required')).to.equal(true);
+    });
+
+    it('validates pattern directly', () => {
+      expect(fn({ validate: { pattern: '^a' }, value: 'abc' }, { a: 'abc' }, 'pattern')).to.equal(true);
+    });
+
+    it('validates min directly', () => {
+      expect(fn({ validate: { min: 5 }, value: 5 }, { a: 5 }, 'min')).to.equal(true);
+    });
+
+    it('validates max directly', () => {
+      expect(fn({ validate: { max: 5 }, value: 5 }, { a: 5 }, 'max')).to.equal(true);
+    });
+
+    it('throws error if validating an unsupported type', () => {
+      expect(() => fn({ validate: { cool: true } }, {}, 'cool')).to.throw(Error);
     });
   });
 

--- a/lib/validators/helpers.test.js
+++ b/lib/validators/helpers.test.js
@@ -1,6 +1,642 @@
+import _ from 'lodash';
 import * as lib from './helpers';
 
+function getFirstArg(spy) {
+  return _.get(spy, 'args.0.0');
+}
+
 describe('validation helpers', () => {
+  let sandbox, spy;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    spy = sandbox.spy();
+  });
+
+  afterEach(() => {
+    spy = null;
+    sandbox.restore();
+  });
+
+  describe('forEachComponent', () => {
+    const fn = lib.forEachComponent;
+
+    it('does not run function if no components', () => {
+      fn(null, spy);
+      expect(spy.callCount).to.equal(0);
+    });
+
+    it('does not run function on components that have been removed from the state', () => {
+      fn({
+        components: {
+          a: {},
+          b: { a: 'b' }
+        }
+      }, spy);
+      expect(spy.callCount).to.equal(1); // only called on b
+    });
+
+    it('calls function on each component', () => {
+      let aData = { a: 'b' },
+        bData = { b: 'c' };
+
+      fn({
+        components: {
+          a: aData,
+          b: bData
+        }
+      }, spy);
+      expect(spy.callCount).to.equal(2);
+      expect(spy.args[0]).to.eql([aData, 'a']);
+      expect(spy.args[1]).to.eql([bData, 'b']);
+    });
+
+    it('allows filtering by component', () => {
+      let aData = { a: 'b' },
+        bData = { b: 'c' };
+
+      fn({
+        components: {
+          'components/a/instances/foo': aData,
+          'components/b/instances/foo': bData,
+          'components/a': {} // empty data
+        }
+      }, spy, 'a');
+      expect(spy.callCount).to.equal(1);
+      expect(spy.args[0]).to.eql([aData, 'components/a/instances/foo']);
+    });
+
+    it('allows filtering by multiple components', () => {
+      let aData = { a: 'b' },
+        bData = { b: 'c' },
+        cData = { c: 'd' };
+
+      fn({
+        components: {
+          'components/a/instances/foo': aData,
+          'components/b/instances/foo': bData,
+          'components/c/instances/foo': cData
+        }
+      }, spy, ['a', 'b']);
+      expect(spy.callCount).to.equal(2);
+      expect(spy.args[0]).to.eql([aData, 'components/a/instances/foo']);
+      expect(spy.args[1]).to.eql([bData, 'components/b/instances/foo']);
+    });
+  });
+
+  describe('getSchema', () => {
+    const fn = lib.getSchema;
+
+    it('gets schema for component', () => {
+      expect(fn({ schemas: { foo: { a: 'b' }}}, 'foo')).to.eql({ a: 'b' });
+    });
+
+    it('gets schema for hyphenated-named component', () => {
+      expect(fn({ schemas: { 'foo-bar': { a: 'b' }}}, 'foo-bar')).to.eql({ a: 'b' });
+    });
+
+    it('gets schema for uri', () => {
+      expect(fn({ schemas: { foo: { a: 'b' }}}, 'domain.com/components/foo/instances/bar')).to.eql({ a: 'b' });
+    });
+  });
+
+  describe('forEachField', () => {
+    const fn = lib.forEachField;
+
+    it('does not call fn for empty component', () => {
+      fn({ schemas: { foo: { a: {} } } }, {}, 'foo', spy);
+      expect(spy.callCount).to.equal(0);
+    });
+
+    it('does not call fn for empty schema (no fields or metadata)', () => {
+      fn({ schemas: { foo: {} } }, { a: 'b' }, 'foo', spy);
+      expect(spy.callCount).to.equal(0);
+    });
+
+    it('does not call fn for metadata', () => {
+      // _version, _description, and _devDescription are component metadata
+      fn({
+        schemas: {
+          foo: {
+            _version: 1,
+            _description: 'some desc',
+            _devDescription: 'some desc'
+          }
+        }
+      }, { a: 'b' }, 'foo', spy);
+      expect(spy.callCount).to.equal(0);
+    });
+
+    // component lists
+
+    it('calls fn w/ empty data for component list', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _componentList: true }
+          }
+        }
+      }, { b: 'c' }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'component-list',
+        name: 'a',
+        path: 'a',
+        value: [],
+        schema: { _componentList: true }
+      });
+    });
+
+    it('calls fn w/ empty array for component list', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _componentList: true }
+          }
+        }
+      }, { a: [] }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'component-list',
+        name: 'a',
+        path: 'a',
+        value: [],
+        schema: { _componentList: true }
+      });
+    });
+
+    it('calls fn w/ data for component list', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _componentList: true }
+          }
+        }
+      }, { a: [{ _ref: 'domain.com/components/bar' }] }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'component-list',
+        name: 'a',
+        path: 'a',
+        value: ['domain.com/components/bar'],
+        schema: { _componentList: true }
+      });
+    });
+
+    it('calls fn w/ data for page area', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _componentList: { page: true } }
+          }
+        }
+      }, { a: 'a' }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'component-list',
+        name: 'a',
+        path: 'a',
+        value: 'a',
+        schema: { _componentList: { page: true } }
+      });
+    });
+
+    // component props
+
+    it('calls fn w/ null data for component prop', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _component: true }
+          }
+        }
+      }, { b: 'c' }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'component-prop',
+        name: 'a',
+        path: 'a',
+        value: null,
+        schema: { _component: true }
+      });
+    });
+
+    it('calls fn w/ data for component prop', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _component: true }
+          }
+        }
+      }, { a: { _ref: 'domain.com/components/bar' } }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'component-prop',
+        name: 'a',
+        path: 'a',
+        value: 'domain.com/components/bar',
+        schema: { _component: true }
+      });
+    });
+
+    // non-editable fields
+
+    it('calls fn w/ null data for field w/ empty object in schema', () => {
+      // note: these log warnings when they're initially added to the page,
+      // because we want developers to add descriptions to their fields
+      fn({
+        schemas: {
+          foo: {
+            a: {}
+          }
+        }
+      }, { b: 'c' }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'non-editable-field',
+        name: 'a',
+        path: 'a',
+        value: null,
+        schema: {}
+      });
+    });
+
+    it('calls fn w/ null data for non-editable fields', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { help: 'hi' }}
+          }
+        }
+      }, { b: 'c' }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'non-editable-field',
+        name: 'a',
+        path: 'a',
+        value: null,
+        schema: { _has: { help: 'hi' }}
+      });
+    });
+
+    it('calls fn w/ null data for non-editable fields w/ undefined data', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { help: 'hi' }}
+          }
+        }
+      }, { a: undefined }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'non-editable-field',
+        name: 'a',
+        path: 'a',
+        value: null,
+        schema: { _has: { help: 'hi' }}
+      });
+    });
+
+    it('calls fn w/ data for non-editable fields', () => {
+      // e.g. if data is generated by model.js or pubsub
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { help: 'hi' }}
+          }
+        }
+      }, { a: 'b' }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'non-editable-field',
+        name: 'a',
+        path: 'a',
+        value: 'b',
+        schema: { _has: { help: 'hi' }}
+      });
+    });
+
+    it('calls fn w/ null data for editable fields (shorthand syntax)', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: 'text'}
+          }
+        }
+      }, { b: 'c' }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'editable-field',
+        name: 'a',
+        path: 'a',
+        value: null,
+        schema: { _has: 'text' }
+      });
+    });
+
+    it('calls fn w/ null data for editable fields (longhand syntax)', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { input: 'text' } }
+          }
+        }
+      }, { b: 'c' }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'editable-field',
+        name: 'a',
+        path: 'a',
+        value: null,
+        schema: { _has: { input: 'text' }  }
+      });
+    });
+
+    it('calls fn w/ data for editable fields (shorthand syntax)', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: 'checkbox'}
+          }
+        }
+      }, { a: false }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'editable-field',
+        name: 'a',
+        path: 'a',
+        value: false,
+        schema: { _has: 'checkbox' }
+      });
+    });
+
+    it('calls fn w/ data for editable fields (longhand syntax)', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { input: 'checkbox' } }
+          }
+        }
+      }, { a: false }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'editable-field',
+        name: 'a',
+        path: 'a',
+        value: false,
+        schema: { _has: { input: 'checkbox' }  }
+      });
+    });
+
+    it('calls fn w/ data for editable fields (empty string)', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { input: 'text' } }
+          }
+        }
+      }, { a: '' }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'editable-field',
+        name: 'a',
+        path: 'a',
+        value: '',
+        schema: { _has: { input: 'text' }  }
+      });
+    });
+
+    it('calls fn w/ data for editable fields (zero)', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { input: 'text', type: 'number' } }
+          }
+        }
+      }, { a: 0 }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'editable-field',
+        name: 'a',
+        path: 'a',
+        value: 0,
+        schema: { _has: { input: 'text', type: 'number' }  }
+      });
+    });
+
+    it('calls fn w/ data for editable fields (boolean)', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { input: 'checkbox' } }
+          }
+        }
+      }, { a: true }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'editable-field',
+        name: 'a',
+        path: 'a',
+        value: true,
+        schema: { _has: { input: 'checkbox' }  }
+      });
+    });
+
+    it('calls fn w/ data for editable fields (string)', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { input: 'text' } }
+          }
+        }
+      }, { a: 'hi' }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'editable-field',
+        name: 'a',
+        path: 'a',
+        value: 'hi',
+        schema: { _has: { input: 'text' }  }
+      });
+    });
+
+    it('calls fn w/ data for editable fields (number)', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { input: 'text', type: 'number' } }
+          }
+        }
+      }, { a: 5 }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'editable-field',
+        name: 'a',
+        path: 'a',
+        value: 5,
+        schema: { _has: { input: 'text', type: 'number' }  }
+      });
+    });
+
+    // complex lists
+
+    it('calls fn w/ empty array for undefined complex-lists', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+          }
+        }
+      }, { b: 'c' }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'complex-list',
+        name: 'a',
+        path: 'a',
+        value: [],
+        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+      });
+    });
+
+    it('calls fn w/ empty array for empty complex-lists', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+          }
+        }
+      }, { a: [] }, 'foo', spy);
+      expect(spy.callCount).to.equal(1);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'complex-list',
+        name: 'a',
+        path: 'a',
+        value: [],
+        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+      });
+    });
+
+    it('recursively calls fn for complex-lists (null child)', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+          }
+        }
+      }, { a: [{}] }, 'foo', spy);
+      expect(spy.callCount).to.equal(2);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'complex-list',
+        name: 'a',
+        path: 'a',
+        value: [{}],
+        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+      });
+      expect(_.get(spy, 'args.1.0')).to.eql({
+        type: 'editable-field',
+        name: 'b',
+        path: 'a.0.b',
+        value: null,
+        schema: { prop: 'b', _has: 'text' }
+      });
+    });
+
+    it('recursively calls fn for complex-lists (children w/ data)', () => {
+      fn({
+        schemas: {
+          foo: {
+            a: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+          }
+        }
+      }, { a: [{ b: 'c' }, { b: 'd' }] }, 'foo', spy);
+      expect(spy.callCount).to.equal(3);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'complex-list',
+        name: 'a',
+        path: 'a',
+        value: [{ b: 'c' }, { b: 'd' }],
+        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: 'text' }] } }
+      });
+      expect(_.get(spy, 'args.1.0')).to.eql({
+        type: 'editable-field',
+        name: 'b',
+        path: 'a.0.b',
+        value: 'c',
+        schema: { prop: 'b', _has: 'text' }
+      });
+      expect(_.get(spy, 'args.2.0')).to.eql({
+        type: 'editable-field',
+        name: 'b',
+        path: 'a.1.b',
+        value: 'd',
+        schema: { prop: 'b', _has: 'text' }
+      });
+    });
+
+    it('recursively calls fn for complex-lists inside complex-list', () => {
+      // [ ಠ Ĺ̯ ಠೃ ] I say, steady on old chum!
+      fn({
+        schemas: {
+          foo: {
+            a: {
+              _has: {
+                input: 'complex-list',
+                props: [{
+                  prop: 'b',
+                  _has: {
+                    input: 'complex-list',
+                    props: [{
+                      prop: 'c',
+                      _has: 'text'
+                    }]
+                  }
+                }]
+              }
+            }
+          }
+        }
+      }, { a: [{ b: [{ c: 'hi' }] }] }, 'foo', spy);
+      expect(spy.callCount).to.equal(3);
+      expect(getFirstArg(spy)).to.eql({
+        type: 'complex-list',
+        name: 'a',
+        path: 'a',
+        value: [{ b: [{ c: 'hi' }] }],
+        schema: { _has: { input: 'complex-list', props: [{ prop: 'b', _has: { input: 'complex-list', props: [{ prop: 'c', _has: 'text' }]} }] } }
+      });
+      expect(_.get(spy, 'args.1.0')).to.eql({
+        type: 'complex-list',
+        name: 'b',
+        path: 'a.0.b',
+        value: [{ c: 'hi' }],
+        schema: { prop: 'b', _has: { input: 'complex-list', props: [{ prop: 'c', _has: 'text' }]} }
+      });
+      expect(_.get(spy, 'args.2.0')).to.eql({
+        type: 'editable-field',
+        name: 'c',
+        path: 'a.0.b.0.c',
+        value: 'hi',
+        schema: { prop: 'c', _has: 'text' }
+      });
+    });
+  });
+
+  describe('getPlaintextValue', () => {
+    const fn = lib.getPlaintextValue;
+
+    it('passes through strings without formatting', () => {
+      expect(fn('hi')).to.eql('hi');
+    });
+
+    it('removes formatting from strings', () => {
+      expect(fn('<strong>hi</strong>')).to.eql('hi');
+    });
+
+    it('decodes html entities', () => {
+      expect(fn('&hellip;')).to.eql('…');
+    });
+  });
+
   describe('getPreviewText', () => {
     const fn = lib.getPreviewText;
 
@@ -12,6 +648,159 @@ describe('validation helpers', () => {
       expect(fn('O brave new world, that has such people in\'t!', 21, 0)).to.equal('… brave new world, that has such people i…');
     });
   });
+
+  describe('shouldBeRequired', () => {
+    const fn = lib.shouldBeRequired;
+
+    it('compares root fields', () => {
+      expect(fn({
+        path: 'a',
+        schema: {
+          validate: {
+            required: {
+              field: 'b',
+              operator: 'empty'
+            }
+          }
+        }}, { b: '' })).to.equal(true);
+    });
+
+    it('compares complex-list field to root field', () => {
+      expect(fn({
+        path: 'a.0.b',
+        schema: {
+          validate: {
+            required: {
+              field: 'c',
+              operator: 'empty'
+            }
+          }
+        }}, { a: [{ b: 'hi' }], c: '' })).to.equal(true);
+    });
+
+    it('compares complex-list field to field in same list item', () => {
+      expect(fn({
+        path: 'a.0.b',
+        schema: {
+          validate: {
+            required: {
+              field: 'c',
+              operator: 'empty'
+            }
+          }
+        }}, { a: [{ b: 'hi', c: '' }] })).to.equal(true);
+    });
+
+    it('compares complex-list field to field in same list item BEFORE checking root field', () => {
+      expect(fn({
+        path: 'a.0.b',
+        schema: {
+          validate: {
+            required: {
+              field: 'c',
+              operator: '===',
+              value: 'one'
+            }
+          }
+        }}, { a: [{ b: 'hi', c: 'one' }], c: 'two' })).to.equal(true);
+    });
+
+    it('compares nested complex-list field to field in same list item BEFORE checking higher-level list', () => {
+      expect(fn({
+        path: 'a.0.b.0.c',
+        schema: {
+          validate: {
+            required: {
+              field: 'd',
+              operator: '===',
+              value: 'one'
+            }
+          }
+        }}, { a: [{ b: [{ c: 'hi', d: 'one' }], d: 'two' }] })).to.equal(true);
+    });
+  });
+
+  describe('isValid', () => {
+    const fn = lib.isValid;
+
+    it('returns true if no validation rules', () => {
+      expect(fn({ schema: { _has: 'text' } })).to.equal(true);
+    });
+
+    it('returns true if non-empty and required', () => {
+      expect(fn({ schema: { validate: { required: true } }, value: 'hi' })).to.equal(true);
+    });
+
+    it('returns false if empty and required', () => {
+      expect(fn({ schema: { validate: { required: true } }, value: '' })).to.equal(false);
+    });
+
+    it('returns true if non-empty and conditionally-required', () => {
+      expect(fn({ path: 'b', schema: { validate: { required: { field: 'a', operator: 'empty' } } }, value: 'hi' }, { a: '' })).to.equal(true);
+    });
+
+    it('returns false if empty and conditionally-required', () => {
+      expect(fn({ path: 'b', schema: { validate: { required: { field: 'a', operator: 'empty' } } }, value: '' }, { a: '' })).to.equal(false);
+    });
+
+    it('returns true if pattern matches', () => {
+      expect(fn({ schema: { validate: { pattern: '^a' } }, value: 'abc' })).to.equal(true);
+    });
+
+    it('returns true if pattern does not match', () => {
+      expect(fn({ schema: { validate: { pattern: '^a' } }, value: 'bcd' })).to.equal(false);
+    });
+
+    it('returns true if string length >= min', () => {
+      expect(fn({ schema: { validate: { min: 2 }}, value: 'hi' })).to.equal(true);
+    });
+
+    it('returns false if string length !>= min', () => {
+      expect(fn({ schema: { validate: { min: 2 }}, value: 'a' })).to.equal(false);
+    });
+
+    it('returns true if array length >= min', () => {
+      expect(fn({ schema: { validate: { min: 1 }}, value: ['a'] })).to.equal(true);
+    });
+
+    it('returns false if array length !>= min', () => {
+      expect(fn({ schema: { validate: { min: 2 }}, value: ['a'] })).to.equal(false);
+    });
+
+    it('returns true if number value >= min', () => {
+      expect(fn({ schema: { validate: { min: 5 }}, value: 5 })).to.equal(true);
+    });
+
+    it('returns false if number value !>= min', () => {
+      expect(fn({ schema: { validate: { min: 5 }}, value: 4 })).to.equal(false);
+    });
+
+    it('returns true if string length <= max', () => {
+      expect(fn({ schema: { validate: { max: 2 }}, value: 'hi' })).to.equal(true);
+    });
+
+    it('returns false if string length !<= max', () => {
+      expect(fn({ schema: { validate: { max: 2 }}, value: 'abc' })).to.equal(false);
+    });
+
+    it('returns true if array length <= max', () => {
+      expect(fn({ schema: { validate: { max: 1 }}, value: ['a'] })).to.equal(true);
+    });
+
+    it('returns false if array length !<= max', () => {
+      expect(fn({ schema: { validate: { max: '1' }}, value: ['a', 'b'] })).to.equal(false);
+    });
+
+    it('returns true if number value <= max', () => {
+      expect(fn({ schema: { validate: { max: 5 }}, value: 5 })).to.equal(true);
+    });
+
+    it('returns false if number value !<= max', () => {
+      expect(fn({ schema: { validate: { max: 5 }}, value: 6 })).to.equal(false);
+    });
+  });
+
+  // DEPRECATED - will be removed in kiln 6.x
 
   describe('getInput', () => {
     const fn = lib.getInput;


### PR DESCRIPTION
* implements methods to standardize validation
* updates built-in validators with new methods
* all new methods have 100% test coverage
* adds deprecation warning to old methods
* code cleanup

New Stuff!

* adds `min` validation
* renames `soft-maxlength` to simply `max`
* allows `min` and `max` validation on component lists #1047 
* adds `pattern` validation

![screen shot 2017-12-12 at 2 41 39 pm](https://user-images.githubusercontent.com/447522/33904864-d675915a-df4a-11e7-848d-5c0d3bfbb731.png)

fixes #1015 #1061 #1047 #1062