### PR TITLE
fix PageListItem url generation

### DIFF
--- a/lib/nav/page-list-item.vue
+++ b/lib/nav/page-list-item.vue
@@ -244,6 +244,7 @@
       protocol: 'http:', // note: assumes http (until we have protocol in site configs)
       port: site.port.toString(),
       hostname: site.host,
+      host: site.host,
     }) + htmlExt;
   }
 


### PR DESCRIPTION
Right now, urls.addPort is returning the entire host as undefined because it's calling replace on location.host, which wasn't defined in the call to uriToUrl from PageListItem