### PR TITLE
Scoped PubSub

### DIFF
--- a/docs/editing-components.md
+++ b/docs/editing-components.md
@@ -353,6 +353,21 @@ plaintextTitle:
     help: Plaintext page title, set by seoHeadline, shortHeadline, or primaryHeadline.
 ```
 
+#### Scoped Publishing
+
+There are some situations where a component wants to limit the data they're sending to a certain subset of components on the page, rather than all components that listen to a property. For example, a slideshow that sets the width of its children shouldn't _also_ set the width of any other slideshow's children on the same page. To limit which components are affected by a property, you may use scoped publishing.
+
+There are currently three scopes you may publish to: `global` (default), `children`, and `parents`.
+
+```yaml
+slideshowWidth:
+  _publish:
+    name: width
+    scope: children
+  _has:
+    help: Width should propagate only to children
+```
+
 ### Subscribing
 
 Components that want to subscribe to properties should have `_subscribe` on the field(s) they want to update, with the name of the property it should subscribe to. Subscribed properties will trigger a component to save, thus allowing the subscribed component's `model.save()` method to do logic on the incoming data before it's sent to the server.
@@ -377,6 +392,22 @@ title:
   _subscribe:
     - pageTitle
     - overrideTitle
+```
+
+#### Scoped Many-To-Many Communication
+
+Scoped publishing may be used in many-to-many communication, and you may intersperse scoped and unscoped properties as needed.
+
+```yaml
+title:
+  _has: text
+  _publish:
+    - ogTitle
+    - twitterTitle
+    - name: socialTitle
+      scope: children
+    - name: articleTitle
+      scope: parents
 ```
 
 ### PubSub Tips

--- a/lib/component-data/pubsub.js
+++ b/lib/component-data/pubsub.js
@@ -20,6 +20,21 @@ let callStacks = {},
   // this allows us to determine which component(s) should update when properties are published
 
 /**
+ * convert publishable props to objects (or arrays of objects)
+ * @param  {string|object|array} prop
+ * @return {object|array}
+ */
+function convertPubObjects(prop) {
+  if (_.isArray(prop)) {
+    return _.map(prop, (part) => _.isString(part) ? { name: part } : part);
+  } else if (_.isString(prop)) {
+    return { name: prop }; // convert to object
+  } else {
+    return prop; // already an object
+  }
+}
+
+/**
  * register publishers and subscribers for a component
  * note: exported for testing
  * @param  {string} name   of component
@@ -29,10 +44,10 @@ export function register(name, schema) {
   _.forOwn(schema, (field, fieldName) => {
     // register publisher, if it exists
     if (_.isObject(field) && field[pubProp]) {
-      const prop = field[pubProp];
+      const pub = field[pubProp];
 
       publisherRegistery[name] = publisherRegistery[name] || {};
-      publisherRegistery[name][fieldName] = prop; // may be array or string
+      publisherRegistery[name][fieldName] = convertPubObjects(pub); // may be array or object
     }
 
     // register subscriber, if it exists
@@ -133,6 +148,28 @@ function shouldSubscribe(name, eventID) {
 }
 
 /**
+ * set payload values for property to publish
+ * @param {object} prop
+ * @param {object} payload  to modify
+ * @param {*} value    to publish
+ * @param {string} eventID
+ */
+function setPayload(prop, payload, value, eventID) {
+  const propName = prop.name;
+
+  if (hasSubscribers(propName)) {
+    // there are subscribers to this property!
+    // see if they should subscribe (e.g. they haven't already published) and construct
+    // a payload of the data that needs to be sent to these components
+    _.forOwn(subscriberRegistery[propName], (subscribedFields, subscriberName) => {
+      if (shouldSubscribe(subscriberName, eventID)) {
+        payload[subscriberName] = _.reduce(Array.from(subscribedFields), (subData, subscribedField) => _.assign(subData, { [subscribedField]: value }), payload[subscriberName] || {});
+      }
+    });
+  }
+}
+
+/**
  * update all instances of a component
  * @param  {string} eventID
  * @param  {boolean} [snapshot]
@@ -200,28 +237,10 @@ export function publish(uri, data, eventID, snapshot, store) { // eslint-disable
 
     if (_.isArray(prop)) {
       _.each(prop, (p) => {
-        if (hasSubscribers(p)) {
-          // there are subscribers to this property!
-          // see if they should subscribe (e.g. they haven't already published) and construct
-          // a payload of the data that needs to be sent to these components
-          _.forOwn(subscriberRegistery[p], (subscribedFields, subscriberName) => {
-            if (shouldSubscribe(subscriberName, eventID)) {
-              payload[subscriberName] = _.reduce(Array.from(subscribedFields), (subData, subscribedField) => _.assign(subData, { [subscribedField]: value }), payload[subscriberName] || {});
-            }
-          });
-        }
+        setPayload(p, payload, value, eventID);
       });
     } else {
-      if (hasSubscribers(prop)) {
-        // there are subscribers to this property!
-        // see if they should subscribe (e.g. they haven't already published) and construct
-        // a payload of the data that needs to be sent to these components
-        _.forOwn(subscriberRegistery[prop], (subscribedFields, subscriberName) => {
-          if (shouldSubscribe(subscriberName, eventID)) {
-            payload[subscriberName] = _.reduce(Array.from(subscribedFields), (subData, subscribedField) => _.assign(subData, { [subscribedField]: value }), payload[subscriberName] || {});
-          }
-        });
-      }
+      setPayload(prop, payload, value, eventID);
     }
   });
 

--- a/lib/component-data/pubsub.js
+++ b/lib/component-data/pubsub.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import cuid from 'cuid';
-import { pubProp, subProp, componentRoute, getComponentName } from '../utils/references';
+import { find } from '@nymag/dom';
+import { pubProp, subProp, componentRoute, getComponentName, refAttr } from '../utils/references';
 import { ADD_SCHEMA } from './mutationTypes';
 import { PRELOAD_SUCCESS } from '../preloader/mutationTypes';
 import { props } from '../utils/promises';
@@ -153,9 +154,11 @@ function shouldSubscribe(name, eventID) {
  * @param {object} payload  to modify
  * @param {*} value    to publish
  * @param {string} eventID
+ * @param {string} uri
  */
-function setPayload(prop, payload, value, eventID) {
-  const propName = prop.name;
+function setPayload(prop, payload, value, eventID, uri) { // eslint-disable-line
+  const propName = prop.name,
+    propScope = prop.scope;
 
   if (hasSubscribers(propName)) {
     // there are subscribers to this property!
@@ -163,9 +166,47 @@ function setPayload(prop, payload, value, eventID) {
     // a payload of the data that needs to be sent to these components
     _.forOwn(subscriberRegistery[propName], (subscribedFields, subscriberName) => {
       if (shouldSubscribe(subscriberName, eventID)) {
-        payload[subscriberName] = _.reduce(Array.from(subscribedFields), (subData, subscribedField) => _.assign(subData, { [subscribedField]: value }), payload[subscriberName] || {});
+        payload[subscriberName] = {
+          data: _.reduce(Array.from(subscribedFields), (subData, subscribedField) => _.assign(subData, { [subscribedField]: value }), _.get(payload, `${subscriberName}.data`, {})),
+          scope: propScope,
+          publisherURI: uri
+        };
       }
     });
+  }
+}
+
+/**
+ * quickly determine if a component contains another component
+ * by looking at the dom
+ * @param  {string}  parent uri
+ * @param  {string}  child  uri
+ * @return {Boolean}
+ */
+function isComponentInside(parent, child) {
+  return !!find(`[${refAttr}="${parent}"] [${refAttr}="${child}"]`);
+}
+
+/**
+ * determine if a subscriber fits the publisher's scope
+ * note: allowed scopes are currently 'children', 'parent', and 'global'
+ * @param  {string} scope
+ * @param  {string} publisherURI
+ * @param  {string} subscriberURI
+ * @return {boolean}
+ */
+function subscriberInScope(scope, publisherURI, subscriberURI) {
+  if (scope === 'global') {
+    // 'global' scope is the default
+    return true;
+  } else if (_.includes(['children', 'child'], scope)) {
+    // 'children' only publish to components inside the publisher
+    return isComponentInside(publisherURI, subscriberURI);
+  } else if (_.includes(['parents', 'parent'], scope)) {
+    // 'parents' only publish to components that contain the publisher
+    return isComponentInside(subscriberURI, publisherURI);
+  } else {
+    throw new Error(`Unable to determine scope for "${scope}" in ${getComponentName(publisherURI)}`);
   }
 }
 
@@ -177,16 +218,31 @@ function setPayload(prop, payload, value, eventID) {
  * @return {function}
  */
 function updateComponentInstances(eventID, snapshot, store) {
-  return (data, name) => {
+  return (payload, name) => {
+    const { data, scope, publisherURI } = payload;
+
     if (name === 'kiln') {
       // we're updating the page list!
       return store.dispatch('updatePageList', data);
     } else {
       // we're updating other components on the page!
-      // get all their instances from the store, then update them
+      // get all their instances from the store,
+      // then see if there's any scoping to the published stuff
+      // then update them
       const instances = _.filter(Object.keys(store.state.components), (uri) => _.includes(uri, `${componentRoute}${name}/`));
 
-      return Promise.all(_.map(instances, (uri) => store.dispatch('saveComponent', { uri, data, eventID, snapshot })));
+      return Promise.all(_.compact(_.map(instances, (uri) => {
+        if (scope && subscriberInScope(scope, publisherURI, uri)) {
+          // subscriber is in scope!
+          return store.dispatch('saveComponent', { uri, data, eventID, snapshot });
+        } else if (scope) {
+          // not in scope!
+          return;
+        } else {
+          // no scope!
+          return store.dispatch('saveComponent', { uri, data, eventID, snapshot });
+        }
+      })));
     }
   };
 }
@@ -237,10 +293,10 @@ export function publish(uri, data, eventID, snapshot, store) { // eslint-disable
 
     if (_.isArray(prop)) {
       _.each(prop, (p) => {
-        setPayload(p, payload, value, eventID);
+        setPayload(p, payload, value, eventID, uri);
       });
     } else {
-      setPayload(prop, payload, value, eventID);
+      setPayload(prop, payload, value, eventID, uri);
     }
   });
 

--- a/lib/component-data/pubsub.test.js
+++ b/lib/component-data/pubsub.test.js
@@ -1,4 +1,5 @@
 import * as lib from './pubsub';
+import { refAttr } from '../utils/references';
 
 const data = { foo: 'harder', bar: 'better', baz: 'faster', qux: 'stronger' },
   eventID = 'abcdef',
@@ -16,6 +17,18 @@ const data = { foo: 'harder', bar: 'better', baz: 'faster', qux: 'stronger' },
     subArray: {
       foo: { _subscribe: ['1', '2'] }
     },
+    pubChildren: {
+      foo: { _publish: { name: '1', scope: 'children' }}
+    },
+    pubParents: {
+      foo: { _publish: { name: '1', scope: 'parents' }}
+    },
+    pubGlobal: {
+      foo: { _publish: { name: '1', scope: 'global' }}
+    },
+    pubArrayChildren: {
+      foo: { _publish: [{ name: '1', scope: 'children' }, '2']} // allow mixed scoped + unscoped
+    },
     pub1: {
       foo: { _publish: '1' }
     },
@@ -27,6 +40,9 @@ const data = { foo: 'harder', bar: 'better', baz: 'faster', qux: 'stronger' },
     },
     sub2: {
       bar: { _subscribe: '2' }
+    },
+    sub2foo: { // special case for testing pubArrayChildren
+      foo: { _subscribe: '2' }
     },
     pub12: {
       foo: { _publish: '1' },
@@ -71,6 +87,10 @@ describe('pubsub', () => {
   let sandbox, store;
 
   beforeEach(() => {
+    const grandParentEl = document.createElement('div'),
+      parentEl = document.createElement('div'),
+      childEl = document.createElement('div');
+
     sandbox = sinon.sandbox.create();
     lib.unregisterAll(); // unregister all components from pubsub
     store = {
@@ -84,11 +104,26 @@ describe('pubsub', () => {
         }
       }
     };
+    grandParentEl.setAttribute(refAttr, `${componentPrefix}A/instances/1`);
+    parentEl.setAttribute(refAttr, `${componentPrefix}B/instances/1`);
+    childEl.setAttribute(refAttr, `${componentPrefix}C/instances/1`);
+    parentEl.appendChild(childEl);
+    grandParentEl.appendChild(parentEl);
+    document.body.appendChild(grandParentEl);
   });
 
   afterEach(() => {
     sandbox.restore();
   });
+
+  function expectAwith1() {
+    expect(store.dispatch).to.have.been.calledWith('saveComponent', {
+      uri: `${componentPrefix}A/instances/1`,
+      data: { foo: 'harder' },
+      eventID,
+      snapshot: null
+    });
+  }
 
   function expectBwith1() {
     expect(store.dispatch).to.have.been.calledWith('saveComponent', {
@@ -130,6 +165,15 @@ describe('pubsub', () => {
     expect(store.dispatch).to.have.been.calledWith('saveComponent', {
       uri: `${componentPrefix}D/instances/1`,
       data: { bar: 'better' },
+      eventID,
+      snapshot: null
+    });
+  }
+
+  function expectDwith2foo() {
+    expect(store.dispatch).to.have.been.calledWith('saveComponent', {
+      uri: `${componentPrefix}D/instances/1`,
+      data: { foo: 'harder' },
       eventID,
       snapshot: null
     });
@@ -327,6 +371,75 @@ describe('pubsub', () => {
       return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
         expect(store.dispatch.callCount).to.equal(1); // B saves once
         expectBwith1();
+      });
+    });
+
+    // scoped pubsub
+
+    it('propagates B → 1 → C (children)', () => {
+      lib.register('B', schemas.pubChildren);
+      lib.register('C', schemas.sub1);
+      lib.register('D', schemas.sub1); // not a child, should not be updated
+      // note: to test, you must pass in a full uri, as that's registered on the element
+      return fn(`${componentPrefix}B/instances/1`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(1); // C saves once
+        expectCwith1();
+      });
+    });
+
+    it('propagates A → 1 → C (children)', () => {
+      lib.register('A', schemas.pubChildren);
+      lib.register('C', schemas.sub1);
+      lib.register('D', schemas.sub1); // not a child, should not be updated
+      // note: to test, you must pass in a full uri, as that's registered on the element
+      return fn(`${componentPrefix}A/instances/1`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(1); // C saves once
+        expectCwith1();
+      });
+    });
+
+    it('propagates B → 1 → A (parents)', () => {
+      lib.register('B', schemas.pubParents);
+      lib.register('A', schemas.sub1);
+      lib.register('C', schemas.sub1); // not a parent, should not be updated
+      // note: to test, you must pass in a full uri, as that's registered on the element
+      return fn(`${componentPrefix}B/instances/1`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(1); // A saves once
+        expectAwith1();
+      });
+    });
+
+    it('propagates C → 1 → B, C → 1 → A (parents)', () => {
+      lib.register('C', schemas.pubParents);
+      lib.register('A', schemas.sub1);
+      lib.register('B', schemas.sub1); // actually a parent, so should update as well
+      // note: to test, you must pass in a full uri, as that's registered on the element
+      return fn(`${componentPrefix}C/instances/1`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(2); // A saves once, B saves once
+        expectAwith1();
+        expectBwith1();
+      });
+    });
+
+    it('propagates A → 1 → B (global)', () => {
+      lib.register('A', schemas.pubGlobal);
+      lib.register('B', schemas.sub1);
+      // 'global' publishing doesn't look in the dom, so the uri doesn't matter
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(1); // B saves once
+        expectBwith1();
+      });
+    });
+
+    it('propagates [A] → 1 → B (children), [A] → 2 → D', () => {
+      lib.register('A', schemas.pubArrayChildren);
+      lib.register('B', schemas.sub1);
+      lib.register('D', schemas.sub2foo); // second prop in array is global
+      // note: to test, you must pass in a full uri, as that's registered on the element
+      return fn(`${componentPrefix}A/instances/1`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(2); // B saves once, D saves once
+        expectBwith1();
+        expectDwith2foo();
       });
     });
   });

--- a/lib/component-data/pubsub.test.js
+++ b/lib/component-data/pubsub.test.js
@@ -17,6 +17,10 @@ const data = { foo: 'harder', bar: 'better', baz: 'faster', qux: 'stronger' },
     subArray: {
       foo: { _subscribe: ['1', '2'] }
     },
+    // testing unsupported scopes
+    pubFetch: {
+      foo: { _publish: { name: '1', scope: 'fetch' }}
+    },
     pubChildren: {
       foo: { _publish: { name: '1', scope: 'children' }}
     },
@@ -375,6 +379,12 @@ describe('pubsub', () => {
     });
 
     // scoped pubsub
+
+    it('throws error if unknown scope', () => {
+      lib.register('A', schemas.pubFetch);
+      lib.register('B', schemas.sub1);
+      expect(() => fn(`${componentPrefix}A/instances/1`, data, eventID, null, store)).to.throw('Unable to determine scope for "fetch" in A');
+    });
 
     it('propagates B → 1 → C (children)', () => {
       lib.register('B', schemas.pubChildren);


### PR DESCRIPTION
* fixes #1075
* allows limiting scope to parents or children
* allows scoped pubsub in arrays
* refactored pubsub for code clarity
* updated docs

Single property:

```yaml
slideshowWidth:
  _publish:
    name: width
    scope: children
  _has:
    help: Width should propagate only to children
```

Multiple properties:

```yaml
title:
  _has: text
  _publish:
    - ogTitle
    - twitterTitle
    - name: socialTitle
      scope: children
    - name: articleTitle
      scope: parents
```
  