### PR TITLE
Revert "Amazon-style hover effects on selectors"

### DIFF
--- a/lib/decorators/select.js
+++ b/lib/decorators/select.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import _ from 'lodash';
 import delegate from 'delegate';
-import { find } from '@nymag/dom';
 import store from '../core-data/store';
 import { prependChild, closest } from '@nymag/dom';
 import { refAttr, layoutAttr, editAttr, refProp, componentListProp, componentProp, getComponentName, isComponent } from '../utils/references';
@@ -75,30 +74,6 @@ export function getParentField(child, parent) {
   }
 }
 
-function isHoveringTowardsSelector(e, lastPos) {
-  const pos = { x: e.clientX, y: e.clientY },
-    selectedURI = _.get(store, 'state.ui.currentSelection.uri');
-
-  let selector;
-
-  if (!selectedURI) {
-    // nothing selected, don't set the lastPos
-    return false;
-  }
-
-  // otherwise, set the selector and see if we're moving towards it
-  selector = find(`[data-uri="${selectedURI}"] .quick-bar`);
-
-  // note: only do this when the selector is to the left
-  if (selector && selector.classList.contains('selector-left')) {
-    const rect = selector.getBoundingClientRect(),
-      xTowards = pos.x > rect.left && pos.x <= lastPos.x,
-      yTowards = pos.y > rect.top && pos.y < rect.bottom;
-
-    return xTowards && yTowards;
-  }
-}
-
 /**
  * add selector to element
  * @param {string} uri
@@ -126,34 +101,23 @@ export function addSelector(uri, el) {
 
   // add global mouseover handler if it hasn't been added yet
   if (!delegated.bodyMouseover) {
-    let lastMousePos = { x: null, y: null };
-
     delegated.bodyMouseover = true;
     document.body.addEventListener('mouseover', _.debounce((e) => {
       const closestComponent = closest(e.target, `[${refAttr}]`);
 
-      if (lastMousePos.x === null) {
-        // set the position
-        lastMousePos = { x: e.clientX, y: e.clientY };
-      }
-
-      if (isHoveringTowardsSelector(e, lastMousePos)) {
-        return;
-      } else if (closestComponent &&
+      if (closestComponent &&
           isComponent(closestComponent.getAttribute(refAttr)) && // if hovering over a component
           getComponentName(closestComponent.getAttribute(refAttr)) !== 'clay-kiln' && // and that component isn't kiln
           !_.get(store, 'state.ui.currentForm') && // and there are no forms open
           !closestComponent.classList.contains('selected')) { // and the hovered component isn't selected
-        lastMousePos = { x: e.clientX, y: e.clientY };
         store.dispatch('select', closestComponent); // ...select it!
       } else if (closestComponent &&
           !isComponent(closestComponent.getAttribute(refAttr)) && // if hovering over something that isn't a component
           !_.get(store, 'state.ui.currentForm')) { // and there are no forms open
         // unselect if mousing back over the page
-        lastMousePos = { x: null, y: null };
         store.dispatch('unselect');
       }
-    }, 50));
+    }, 100));
   }
 
   // add selector to the component el, BEHIND the component's children


### PR DESCRIPTION
Reverts clay/clay-kiln#1079

This had some weird edge cases, and while it solved the issue that prompted it, there was a lot of negative feedback about the UX in enough situations that we decided to remove it.