### PR TITLE
do breadth-first traversal to fix #1095

### DIFF
--- a/lib/component-data/pubsub.js
+++ b/lib/component-data/pubsub.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import cuid from 'cuid';
-import { find } from '@nymag/dom';
-import { pubProp, subProp, componentRoute, getComponentName, refAttr } from '../utils/references';
+import { pubProp, subProp, componentRoute, getComponentName, refProp } from '../utils/references';
 import { ADD_SCHEMA } from './mutationTypes';
 import { PRELOAD_SUCCESS } from '../preloader/mutationTypes';
 import { props } from '../utils/promises';
@@ -177,14 +176,61 @@ function setPayload(prop, payload, value, eventID, uri) { // eslint-disable-line
 }
 
 /**
+ * breadth-first search, grabbing data from the store as we go
+ * @param  {object} data  in the parent component
+ * @param  {string} uri   (child) uri to search for
+ * @param  {object} store
+ * @return {boolean}
+ */
+function recursiveFind(data, uri, store) {
+  const uriInData = _.find(data, (val) => {
+    if (_.isArray(val)) {
+      // array, possibly a component list
+      return _.find(val, (item) => _.isObject(item) && item[refProp] === uri);
+    } else if (_.isObject(val)) {
+      // object, possibly a component prop
+      return val[refProp] === uri;
+    } else {
+      return false;
+    }
+  });
+
+  if (uriInData) {
+    // hey, we found it!
+    return true;
+  } else {
+    // lol nope, look through the children, ~ ~ ~ r e c u r s i v e l y ~ ~ ~
+    const children = _.reduce(data, (childList, val) => {
+      if (_.isArray(val) && _.isObject(_.head(val)) && _.has(_.head(val), refProp)) {
+        // component list, add all child uris
+        return childList.concat(_.map(val, (childRef) => childRef[refProp]));
+      } else if (_.isObject(val) && _.has(val, refProp)) {
+        // component prop, add single child uri
+        return childList.concat([val[refProp]]);
+      } else {
+        return childList;
+      }
+    }, []);
+
+    return _.find(children, (childURI) => {
+      const childData = _.get(store, `state.components["${childURI}"]`);
+
+      return recursiveFind(childData, uri, store);
+    });
+  }
+}
+
+/**
  * quickly determine if a component contains another component
  * by looking at the dom
  * @param  {string}  parent uri
  * @param  {string}  child  uri
+ * @param {object} parentData
+ * @param {object} store
  * @return {Boolean}
  */
-function isComponentInside(parent, child) {
-  return !!find(`[${refAttr}="${parent}"] [${refAttr}="${child}"]`);
+function isComponentInside(parent, child, parentData, store) {
+  return recursiveFind(parentData, child, store);
 }
 
 /**
@@ -193,18 +239,25 @@ function isComponentInside(parent, child) {
  * @param  {string} scope
  * @param  {string} publisherURI
  * @param  {string} subscriberURI
+ * @param {object} pubData (latest data from pubbing component, not in the store yet)
+ * @param {object} store
  * @return {boolean}
  */
-function subscriberInScope(scope, publisherURI, subscriberURI) {
+function subscriberInScope({ scope, publisherURI, subscriberURI, pubData, store }) {
   if (scope === 'global') {
     // 'global' scope is the default
     return true;
   } else if (_.includes(['children', 'child'], scope)) {
     // 'children' only publish to components inside the publisher
-    return isComponentInside(publisherURI, subscriberURI);
+    // note: we send the latest data from the publishing component because it's not in the store yet
+    // (and subscribing components might have just been added in the current save)
+    return isComponentInside(publisherURI, subscriberURI, pubData, store);
   } else if (_.includes(['parents', 'parent'], scope)) {
+    // note: if the component is publishing to parents, their data will already contain the uri of the publishing component
+    const subData = _.get(store, `state.components['${subscriberURI}']`);
+
     // 'parents' only publish to components that contain the publisher
-    return isComponentInside(subscriberURI, publisherURI);
+    return isComponentInside(subscriberURI, publisherURI, subData, store);
   } else {
     throw new Error(`Unable to determine scope for "${scope}" in ${getComponentName(publisherURI)}`);
   }
@@ -214,10 +267,11 @@ function subscriberInScope(scope, publisherURI, subscriberURI) {
  * update all instances of a component
  * @param  {string} eventID
  * @param  {boolean} [snapshot]
+ * @param {object} pubData
  * @param  {object} store
  * @return {function}
  */
-function updateComponentInstances(eventID, snapshot, store) {
+function updateComponentInstances({ eventID, snapshot, pubData, store }) {
   return (payload, name) => {
     const { data, scope, publisherURI } = payload;
 
@@ -232,7 +286,7 @@ function updateComponentInstances(eventID, snapshot, store) {
       const instances = _.filter(Object.keys(store.state.components), (uri) => _.includes(uri, `${componentRoute}${name}/`));
 
       return Promise.all(_.compact(_.map(instances, (uri) => {
-        if (scope && subscriberInScope(scope, publisherURI, uri)) {
+        if (scope && subscriberInScope({ scope, publisherURI, subscriberURI: uri, pubData, store })) {
           // subscriber is in scope!
           return store.dispatch('saveComponent', { uri, data, eventID, snapshot });
         } else if (scope) {
@@ -252,11 +306,12 @@ function updateComponentInstances(eventID, snapshot, store) {
  * @param  {object} payload
  * @param  {string} eventID
  * @param  {boolean} [snapshot]
+ * @param {object} pubData from publishing component
  * @param {object} store
  * @return {Promise}
  */
-function updateSubscribers(payload, eventID, snapshot, store) {
-  return props(_.mapValues(payload, updateComponentInstances(eventID, snapshot, store)));
+function updateSubscribers({ payload, eventID, snapshot, pubData, store }) {
+  return props(_.mapValues(payload, updateComponentInstances({ eventID, snapshot, pubData, store })));
 }
 
 /**
@@ -301,5 +356,5 @@ export function publish(uri, data, eventID, snapshot, store) { // eslint-disable
   });
 
   // update all the subscribed components, then return the original component's data
-  return updateSubscribers(payload, eventID, snapshot, store).then(() => data);
+  return updateSubscribers({ payload, eventID, snapshot, pubData: data, store }).then(() => data);
 }

--- a/lib/component-data/pubsub.test.js
+++ b/lib/component-data/pubsub.test.js
@@ -1,7 +1,15 @@
+import _ from 'lodash';
 import * as lib from './pubsub';
-import { refAttr } from '../utils/references';
+import { refProp } from '../utils/references';
 
 const data = { foo: 'harder', bar: 'better', baz: 'faster', qux: 'stronger' },
+  componentPrefix = 'domain.com/components/',
+  aInstance = `${componentPrefix}A/instances/1`,
+  bInstance = `${componentPrefix}B/instances/1`,
+  cInstance = `${componentPrefix}C/instances/1`,
+  dInstance = `${componentPrefix}D/instances/1`,
+  aData = _.assign({}, data, { content: [{ [refProp]: bInstance }]}),
+  bData = _.assign({}, data, { content: [{ [refProp]: cInstance }]}),
   eventID = 'abcdef',
   schemas = {
     noPub: { foo: {} },
@@ -84,36 +92,25 @@ const data = { foo: 'harder', bar: 'better', baz: 'faster', qux: 'stronger' },
       foo: { _publish: '1' },
       baz: { _subscribe: '3' }
     }
-  },
-  componentPrefix = 'domain.com/components/';
+  };
 
 describe('pubsub', () => {
   let sandbox, store;
 
   beforeEach(() => {
-    const grandParentEl = document.createElement('div'),
-      parentEl = document.createElement('div'),
-      childEl = document.createElement('div');
-
     sandbox = sinon.sandbox.create();
     lib.unregisterAll(); // unregister all components from pubsub
     store = {
       dispatch: sandbox.spy((action, {uri, eventID, snapshot}) => lib.publish(uri, store.state.components[uri], eventID, snapshot, store)),
       state: {
         components: {
-          [`${componentPrefix}A/instances/1`]: data,
-          [`${componentPrefix}B/instances/1`]: data,
-          [`${componentPrefix}C/instances/1`]: data,
-          [`${componentPrefix}D/instances/1`]: data
+          [aInstance]: aData,
+          [bInstance]: bData,
+          [cInstance]: data,
+          [dInstance]: data
         }
       }
     };
-    grandParentEl.setAttribute(refAttr, `${componentPrefix}A/instances/1`);
-    parentEl.setAttribute(refAttr, `${componentPrefix}B/instances/1`);
-    childEl.setAttribute(refAttr, `${componentPrefix}C/instances/1`);
-    parentEl.appendChild(childEl);
-    grandParentEl.appendChild(parentEl);
-    document.body.appendChild(grandParentEl);
   });
 
   afterEach(() => {
@@ -122,7 +119,7 @@ describe('pubsub', () => {
 
   function expectAwith1() {
     expect(store.dispatch).to.have.been.calledWith('saveComponent', {
-      uri: `${componentPrefix}A/instances/1`,
+      uri: aInstance,
       data: { foo: 'harder' },
       eventID,
       snapshot: null
@@ -131,7 +128,7 @@ describe('pubsub', () => {
 
   function expectBwith1() {
     expect(store.dispatch).to.have.been.calledWith('saveComponent', {
-      uri: `${componentPrefix}B/instances/1`,
+      uri: bInstance,
       data: { foo: 'harder' },
       eventID,
       snapshot: null
@@ -140,7 +137,7 @@ describe('pubsub', () => {
 
   function expectCwith1() {
     expect(store.dispatch).to.have.been.calledWith('saveComponent', {
-      uri: `${componentPrefix}C/instances/1`,
+      uri: cInstance,
       data: { foo: 'harder' },
       eventID,
       snapshot: null
@@ -149,7 +146,7 @@ describe('pubsub', () => {
 
   function expectCwith2() {
     expect(store.dispatch).to.have.been.calledWith('saveComponent', {
-      uri: `${componentPrefix}C/instances/1`,
+      uri: cInstance,
       data: { bar: 'better' },
       eventID,
       snapshot: null
@@ -158,7 +155,7 @@ describe('pubsub', () => {
 
   function expectCwith3() {
     expect(store.dispatch).to.have.been.calledWith('saveComponent', {
-      uri: `${componentPrefix}C/instances/1`,
+      uri: cInstance,
       data: { baz: 'faster' },
       eventID,
       snapshot: null
@@ -167,7 +164,7 @@ describe('pubsub', () => {
 
   function expectDwith2() {
     expect(store.dispatch).to.have.been.calledWith('saveComponent', {
-      uri: `${componentPrefix}D/instances/1`,
+      uri: dInstance,
       data: { bar: 'better' },
       eventID,
       snapshot: null
@@ -176,7 +173,7 @@ describe('pubsub', () => {
 
   function expectDwith2foo() {
     expect(store.dispatch).to.have.been.calledWith('saveComponent', {
-      uri: `${componentPrefix}D/instances/1`,
+      uri: dInstance,
       data: { foo: 'harder' },
       eventID,
       snapshot: null
@@ -185,7 +182,7 @@ describe('pubsub', () => {
 
   function expectBwith12() {
     expect(store.dispatch).to.have.been.calledWith('saveComponent', {
-      uri: `${componentPrefix}B/instances/1`,
+      uri: bInstance,
       data: { foo: 'harder', bar: 'better' },
       eventID,
       snapshot: null
@@ -383,7 +380,7 @@ describe('pubsub', () => {
     it('throws error if unknown scope', () => {
       lib.register('A', schemas.pubFetch);
       lib.register('B', schemas.sub1);
-      expect(() => fn(`${componentPrefix}A/instances/1`, data, eventID, null, store)).to.throw('Unable to determine scope for "fetch" in A');
+      expect(() => fn(aInstance, aData, eventID, null, store)).to.throw('Unable to determine scope for "fetch" in A');
     });
 
     it('propagates B → 1 → C (children)', () => {
@@ -391,7 +388,7 @@ describe('pubsub', () => {
       lib.register('C', schemas.sub1);
       lib.register('D', schemas.sub1); // not a child, should not be updated
       // note: to test, you must pass in a full uri, as that's registered on the element
-      return fn(`${componentPrefix}B/instances/1`, data, eventID, null, store).then(() => {
+      return fn(bInstance, bData, eventID, null, store).then(() => {
         expect(store.dispatch.callCount).to.equal(1); // C saves once
         expectCwith1();
       });
@@ -402,7 +399,7 @@ describe('pubsub', () => {
       lib.register('C', schemas.sub1);
       lib.register('D', schemas.sub1); // not a child, should not be updated
       // note: to test, you must pass in a full uri, as that's registered on the element
-      return fn(`${componentPrefix}A/instances/1`, data, eventID, null, store).then(() => {
+      return fn(aInstance, aData, eventID, null, store).then(() => {
         expect(store.dispatch.callCount).to.equal(1); // C saves once
         expectCwith1();
       });
@@ -413,7 +410,7 @@ describe('pubsub', () => {
       lib.register('A', schemas.sub1);
       lib.register('C', schemas.sub1); // not a parent, should not be updated
       // note: to test, you must pass in a full uri, as that's registered on the element
-      return fn(`${componentPrefix}B/instances/1`, data, eventID, null, store).then(() => {
+      return fn(bInstance, bData, eventID, null, store).then(() => {
         expect(store.dispatch.callCount).to.equal(1); // A saves once
         expectAwith1();
       });
@@ -424,7 +421,7 @@ describe('pubsub', () => {
       lib.register('A', schemas.sub1);
       lib.register('B', schemas.sub1); // actually a parent, so should update as well
       // note: to test, you must pass in a full uri, as that's registered on the element
-      return fn(`${componentPrefix}C/instances/1`, data, eventID, null, store).then(() => {
+      return fn(cInstance, data, eventID, null, store).then(() => {
         expect(store.dispatch.callCount).to.equal(2); // A saves once, B saves once
         expectAwith1();
         expectBwith1();
@@ -435,7 +432,7 @@ describe('pubsub', () => {
       lib.register('A', schemas.pubGlobal);
       lib.register('B', schemas.sub1);
       // 'global' publishing doesn't look in the dom, so the uri doesn't matter
-      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+      return fn(`${componentPrefix}A`, aData, eventID, null, store).then(() => {
         expect(store.dispatch.callCount).to.equal(1); // B saves once
         expectBwith1();
       });
@@ -446,7 +443,7 @@ describe('pubsub', () => {
       lib.register('B', schemas.sub1);
       lib.register('D', schemas.sub2foo); // second prop in array is global
       // note: to test, you must pass in a full uri, as that's registered on the element
-      return fn(`${componentPrefix}A/instances/1`, data, eventID, null, store).then(() => {
+      return fn(aInstance, aData, eventID, null, store).then(() => {
         expect(store.dispatch.callCount).to.equal(2); // B saves once, D saves once
         expectBwith1();
         expectDwith2foo();

--- a/package-lock.json
+++ b/package-lock.json
@@ -7815,6 +7815,12 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+      "dev": true
+    },
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
@@ -17135,6 +17141,32 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
       "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==",
       "dev": true
+    },
+    "vue-unit": {
+      "version": "github:tom-kitchin/vue-unit#ec9673cbddf8318f72d87c10bbe030822770b5f4",
+      "dev": true,
+      "requires": {
+        "lodash.kebabcase": "4.1.1",
+        "sinon": "2.4.1"
+      },
+      "dependencies": {
+        "sinon": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+          "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+          "dev": true,
+          "requires": {
+            "diff": "3.3.1",
+            "formatio": "1.2.0",
+            "lolex": "1.6.0",
+            "native-promise-only": "0.8.1",
+            "path-to-regexp": "1.7.0",
+            "samsam": "1.3.0",
+            "text-encoding": "0.6.4",
+            "type-detect": "4.0.3"
+          }
+        }
+      }
     },
     "vuex": {
       "version": "3.0.1",


### PR DESCRIPTION
This fixes the issue when adding a child that subscribes to a scoped (children) pubsub from the parent, becase it's not in the DOM at the time of adding.

The pubsub system will do a breadth-first traversal to find it in the store, instead.