### PR TITLE
Add Page History drawer

### DIFF
--- a/lib/drawers/drawer.vue
+++ b/lib/drawers/drawer.vue
@@ -73,6 +73,7 @@
   import UiTab from 'keen/UiTab';
   // components used in tabs
   import contributors from './contributors.vue';
+  import pageHistory from './page-history.vue';
   import visibleComponents from './visible-components.vue';
   import headComponents from './head-components.vue';
   import invisibleComponents from './invisible-components.vue';
@@ -207,6 +208,7 @@
       UiTabs,
       UiTab,
       contributors,
+      'page-history': pageHistory,
       'visible-components': visibleComponents,
       'head-components': headComponents,
       'invisible-components': invisibleComponents,

--- a/lib/drawers/drawer.vue
+++ b/lib/drawers/drawer.vue
@@ -145,7 +145,7 @@
       tabs() {
         if (this.name === 'contributors') {
           return [{
-            title: 'Latest Editors',
+            title: 'Contributors',
             component: 'contributors',
             selected: true
           },{

--- a/lib/drawers/drawer.vue
+++ b/lib/drawers/drawer.vue
@@ -144,9 +144,12 @@
       tabs() {
         if (this.name === 'contributors') {
           return [{
-            title: 'Contributors',
+            title: 'Latest Editors',
             component: 'contributors',
             selected: true
+          },{
+            title: 'Page History',
+            component: 'page-history'
           }];
         } else if (this.name === 'components') {
           const state = _.get(this.$store, 'state'),

--- a/lib/drawers/page-history.vue
+++ b/lib/drawers/page-history.vue
@@ -88,7 +88,9 @@
   import isThisYear from 'date-fns/is_this_year';
   import person from '../utils/person.vue';
   import UiButton from 'keen/UiButton';
-
+  import store from '../core-data/store';
+  import { pageUri } from '@nymag/dom';
+      
   /**
    * format time for pages
    * @param  {Date} date
@@ -139,6 +141,9 @@
           return event;
         }).reverse();
       }
+    },
+    mounted: function (){
+      store.dispatch('getListData', { uri: pageUri() });
     },
     methods: {
     },

--- a/lib/drawers/page-history.vue
+++ b/lib/drawers/page-history.vue
@@ -33,7 +33,8 @@
 
         &-archived,
         &-unarchived,
-        &-unpublished {
+        &-unpublished,
+        &-unscheduled {
           color: $archived;
         }
       }

--- a/lib/drawers/page-history.vue
+++ b/lib/drawers/page-history.vue
@@ -1,0 +1,149 @@
+<style lang="sass">
+  @import '../../styleguide/colors';
+
+  .page-history-list {
+    padding: 0;
+
+    .person-item {
+      padding: 12px 16px;
+    }
+
+    .page-history-event {
+      font-family: $font-stack;
+      margin: 8px 13px 16px;
+
+      &-action,
+      &-time {
+        float: left;
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+
+      &-action {
+        color: $text-alt-color;
+        font-weight: bold;
+
+        &-published {
+          color: $published;
+        }
+
+        &-scheduled {
+          color: $scheduled;
+        }
+
+        &-archived,
+        &-unarchived,
+        &-unpublished {
+          color: $archived;
+        }
+      }
+
+      &-time {
+        margin-left: 5px;
+      }
+
+      &-users {
+        clear:both;
+        font-size: 11px;
+      }
+    }
+
+    .page-history-event-time {
+      color: $text-alt-color;
+    }
+    
+    .page-history-event-users {
+      color: $text-color;
+    }
+  }
+</style>
+
+<template>
+  <div class="page-history-list">
+    <div
+      class="page-history-event"
+      v-for="event of history"
+      :key="event.timestamp"
+    >
+      <div 
+        class="page-history-event-action"
+        :class="['page-history-event-action-'+event.formattedAction]"
+      >{{event.formattedAction}}</div>
+      <div class="page-history-event-time">{{event.formattedTime}}</div>
+      <div class="page-history-event-users">{{event.formattedUsers}}</div>
+
+    </div>
+  </div>
+</template>
+
+<script>
+  import _ from 'lodash';
+  import isValidDate from 'date-fns/is_valid';
+  import dateFormat from 'date-fns/format';
+  import isToday from 'date-fns/is_today';
+  import distanceInWordsToNow from 'date-fns/distance_in_words_to_now';
+  import isTomorrow from 'date-fns/is_tomorrow';
+  import isYesterday from 'date-fns/is_yesterday';
+  import isThisYear from 'date-fns/is_this_year';
+  import person from '../utils/person.vue';
+  import UiButton from 'keen/UiButton';
+
+  /**
+   * format time for pages
+   * @param  {Date} date
+   * @return {string}
+   */
+  function formatStatusTime(date) {
+    date = date ? new Date(date) : null;
+
+    if (!date || !isValidDate(date)) {
+      return null;
+    }
+
+    if (isToday(date)) {
+      return distanceInWordsToNow(date, { includeSeconds: false, addSuffix: true });
+    } else if (isTomorrow(date)) {
+      return 'Tomorrow';
+    } else if (isYesterday(date)) {
+      return 'Yesterday';
+    } else if (isThisYear(date)) {
+      return dateFormat(date, 'M/D');
+    } else {
+      return dateFormat(date, 'M/D/YY');
+    }
+  }
+
+  function addEd(word) {
+    if (!word.length){
+      return word;
+    }
+    else if (word[word.length-1] == "e"){
+      return word+"d"
+    }
+    else {
+      return word+"ed";
+    }
+  }
+
+  export default {
+    data() {
+      return {};
+    },
+    computed: {
+      history() {
+        return _.map(_.cloneDeep(_.get(this.$store, 'state.page.state.history', [])), (event) => {
+          event.formattedTime = formatStatusTime(event.timestamp);
+          event.formattedAction = addEd(event.action);
+          event.formattedUsers = 'By ' + event.users.map((user) => user.name || user.username).join(', ');
+          return event;
+        }).reverse();
+      }
+    },
+    methods: {
+    },
+    components: {
+      person,
+      UiButton
+    }
+  };
+</script>

--- a/lib/page-state/actions.js
+++ b/lib/page-state/actions.js
@@ -22,18 +22,30 @@ const postPageList = _.debounce((endpoint, data, store) => {
  * @return {object}
  */
 export function updateHistoryWithEditAction(state, currentUser) {
-  let history = state.history ? _.cloneDeep(state.history) : [];
+  let history = state.history ? _.cloneDeep(state.history) : [],
+    latest,
+    userIndex;
 
   // If history is empty or the latest item is not an edit event, add a new edit event
   if (history.length === 0 || history[history.length - 1].action !== 'edit') {
     history.push({
       action: 'edit',
       timestamp: new Date(),
-      users: [_.omit(currentUser, ['updateTime'])]
+      users: [currentUser]
     });
   // latest item is an edit event, and but it doesn't contain this user, add the user to the event
-  } else if (_.find(history[history.length - 1].users, (user) => user.username === currentUser.username) === undefined) {
-    history[history.length - 1].users.push(currentUser);
+  } else {
+    latest = history[history.length - 1];
+    userIndex = _.findIndex(latest.users, (user) => user.username === currentUser.username);
+
+    if (userIndex === -1) {
+      latest.users.push(currentUser);
+    } else if (userIndex > -1) {
+      // if the current user is in the list, but isn't at the end, we should move it to the end
+      latest.users.splice(userIndex, 1); // remove user from list
+      latest.users.push(currentUser); // and add it to the end
+    }
+    latest.timestamp = new Date();
   }
 
   return history;
@@ -79,7 +91,7 @@ export function updatePageList(store, data = {}) {
   // then add the new (cloned and updated) users array to the new state
   newState.users = users;
 
-  newState.history = updateHistoryWithEditAction(newState, currentUser);
+  newState.history = updateHistoryWithEditAction(newState, _.omit(currentUser, 'updateTime'));
 
   return postPageList(`${prefix}/_pagelist`, {
     url: uri,

--- a/lib/page-state/actions.test.js
+++ b/lib/page-state/actions.test.js
@@ -24,10 +24,10 @@ define('updating page history with edit event', () => {
     expect(state.history[state.history.length - 1].users).to.deep.equal([{username: 'c@d'}, {username: 'a@b'}]);
   });
 
-  it('will do nothing if the latest event is an edit event and the user is already included', () => {
+  it('will move the user to be the latest the user is already included', () => {
     let state = { history: [{action: 'edit', users: [{username: 'a@b' }, {username: 'c@d'}]}]};
 
     state.history = updateHistoryWithEditAction(state, currentUser);
-    expect(state.history[state.history.length - 1].users).to.deep.equal([{username: 'a@b'}, {username: 'c@d'}]);
+    expect(state.history[state.history.length - 1].users).to.deep.equal([{username: 'c@d'}, {username: 'a@b'}]);
   });
 });

--- a/styleguide/_colors.scss
+++ b/styleguide/_colors.scss
@@ -1,6 +1,7 @@
 @import '~keen-ui/src/styles/md-colors'; // material design color palette
 
 // states (used by progress bar, status message, publish button)
+$archived: $md-red;
 $scheduled: $md-orange;
 $published: $md-green;
 


### PR DESCRIPTION
Closes #1093 

<img width="1111" alt="screen shot 2018-02-05 at 4 45 06 pm" src="https://user-images.githubusercontent.com/2479295/35830361-f9eac500-0a93-11e8-9176-54309d9cc7b5.png">


Adds a panel to the Contributors drawer which will track page events included in a page's history.  