### PR TITLE
minor changes and bugfixes re: publish drawer

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -144,7 +144,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // when clicks bubble up to the document, close the current form or pane / unselect components
   document.body.addEventListener('click', (e) => {
-    if (_.find(getEventPath(e), (el) => el.classList && el.classList.contains('ui-calendar'))) {
+    const ePath = getEventPath(e);
+
+    if (_.find(ePath, (el) => el.classList && (el.classList.contains('ui-calendar') || el.classList.contains('kiln-overlay-form')))) {
       return;
     }
 

--- a/inputs/wysiwyg-caret.js
+++ b/inputs/wysiwyg-caret.js
@@ -35,7 +35,7 @@ export function getLastOffsetWithNewlines(data) {
     plainText = striptags(text);
 
   let i = 0,
-    realOffset = plainText.length - 1;
+    realOffset = plainText.length;
 
   // go through each character (up to the end of the text),
   // increasing the real offset every time we hit a paragraph

--- a/inputs/wysiwyg-caret.test.js
+++ b/inputs/wysiwyg-caret.test.js
@@ -20,16 +20,16 @@ describe('wysiwyg caret', () => {
   describe('getLastOffsetWithNewlines', () => {
     const fn = lib.getLastOffsetWithNewlines;
 
-    it('gets offset for empty field', () => expect(fn(null)).to.equal(-1));
-    it('gets offset for plain text', () => expect(fn('hi')).to.equal(1));
-    it('gets offset for single line of html', () => expect(fn('<strong>hi</strong>')).to.equal(1));
-    it('gets offset for single paragraph of html', () => expect(fn('<p>hi</p>')).to.equal(1));
+    it('gets offset for empty field', () => expect(fn(null)).to.equal(0));
+    it('gets offset for plain text', () => expect(fn('hi')).to.equal(2));
+    it('gets offset for single line of html', () => expect(fn('<strong>hi</strong>')).to.equal(2));
+    it('gets offset for single paragraph of html', () => expect(fn('<p>hi</p>')).to.equal(2));
 
-    it('gets offset for the first of two paragraphs', () => expect(fn('<p>hello</p><p>world</p>')).to.equal(11));
+    it('gets offset for the first of two paragraphs', () => expect(fn('<p>hello</p><p>world</p>')).to.equal(12));
 
     // note: the caret will be at the beginning of the SECOND LINE, not the end of the first
-    it('gets offset for the second of two paragraphs', () => expect(fn('<p>hello</p><p>world</p>')).to.equal(11));
+    it('gets offset for the second of two paragraphs', () => expect(fn('<p>hello</p><p>world</p>')).to.equal(12));
 
-    it('gets offset for more than two paragraphs', () => expect(fn('<p>hello</p><p>world</p><p>bye</p>')).to.equal(16));
+    it('gets offset for more than two paragraphs', () => expect(fn('<p>hello</p><p>world</p><p>bye</p>')).to.equal(17));
   });
 });

--- a/lib/deep-linking/actions.js
+++ b/lib/deep-linking/actions.js
@@ -27,7 +27,7 @@ function openHashedForm(store, urlProps) {
 
   // If it's an inline wysiwyg we need to open the form on the
   // element with `data-editable`, not the component itself
-  if (_.get(group, 'schema.input') === 'inline') {
+  if (_.get(group, 'schema._has.input') === 'inline') {
     if (el.getAttribute(editAttr) === path) {
       groupEl = el;
     } else {

--- a/lib/drawers/publish.vue
+++ b/lib/drawers/publish.vue
@@ -162,7 +162,7 @@
       <span class="action-message">{{ actionMessage }} <ui-icon-button v-if="showSchedule" icon="close" buttonType="button" type="secondary" color="default" size="small" tooltip="Clear Date/Time" tooltipPosition="left middle" @click.stop="clearScheduleForm"></ui-icon-button></span>
       <form class="schedule-form" @submit.prevent="schedulePage">
         <ui-datepicker class="schedule-date" color="accent" v-model="dateValue" :minDate="today" :customFormatter="formatDate" label="Date" :disabled="hasErrors"></ui-datepicker>
-        <timepicker class="schedule-time" :value="timeValue" label="Time" :disabled="hasErrors" @update="updateTime"></timepicker>
+        <timepicker ref="timepicker" class="schedule-time" :value="timeValue" label="Time" :disabled="hasErrors" @update="updateTime"></timepicker>
       </form>
       <ui-button v-if="showSchedule" :disabled="disableSchedule || isArchived || hasErrors" class="action-button" buttonType="button" color="orange" @click.stop="schedulePage">{{ actionMessage }}</ui-button>
       <ui-button v-else :disabled="isArchived || hasErrors" class="action-button" buttonType="button" color="accent" @click.stop="publishPage">{{ actionMessage }}</ui-button>
@@ -387,8 +387,7 @@
           .then(() => {
             store.commit(FINISH_PROGRESS);
             // reset date and time values
-            this.dateValue = null;
-            this.timeValue = '';
+            this.clearScheduleForm();
             store.dispatch('showSnackbar', {
               message: `Scheduled to publish ${calendar(datetime)}`,
               action: 'Undo',
@@ -418,7 +417,7 @@
       },
       clearScheduleForm() {
         this.dateValue = null;
-        this.timeValue = '';
+        this.$refs.timepicker.clear();
       },
       saveLocation(undoUrl) {
         const prefix = _.get(this.$store, 'state.site.prefix'),

--- a/lib/drawers/publish.vue
+++ b/lib/drawers/publish.vue
@@ -152,9 +152,9 @@
         <ui-icon icon="open_in_new"></ui-icon>
         <span class="status-link-text">View public page</span>
       </a>
-      <ui-button v-if="isScheduled" class="status-undo-button" buttonType="button" color="accent" @click.stop="unschedulePage">Unschedule</ui-button>
-      <ui-button v-else-if="isPublished" class="status-undo-button" buttonType="button" color="accent" @click.stop="unpublishPage">Unpublish</ui-button>
-      <ui-button v-else-if="isArchived" class="status-undo-button" buttonType="button" color="accent" @click.stop="archivePage(false)">Unarchive</ui-button>
+      <ui-button v-if="isScheduled" class="status-undo-button" buttonType="button" color="red" @click.stop="unschedulePage">Unschedule</ui-button>
+      <ui-button v-else-if="isPublished" class="status-undo-button" buttonType="button" color="red" @click.stop="unpublishPage">Unpublish</ui-button>
+      <ui-button v-else-if="isArchived" class="status-undo-button" buttonType="button" color="red" @click.stop="archivePage(false)">Unarchive</ui-button>
     </div>
 
     <!-- publish actions -->
@@ -164,7 +164,7 @@
         <ui-datepicker class="schedule-date" color="accent" v-model="dateValue" :minDate="today" :customFormatter="formatDate" label="Date" :disabled="hasErrors"></ui-datepicker>
         <timepicker class="schedule-time" :value="timeValue" label="Time" :disabled="hasErrors" @update="updateTime"></timepicker>
       </form>
-      <ui-button v-if="showSchedule" :disabled="disableSchedule || isArchived || hasErrors" class="action-button" buttonType="button" color="accent" @click.stop="schedulePage">{{ actionMessage }}</ui-button>
+      <ui-button v-if="showSchedule" :disabled="disableSchedule || isArchived || hasErrors" class="action-button" buttonType="button" color="orange" @click.stop="schedulePage">{{ actionMessage }}</ui-button>
       <ui-button v-else :disabled="isArchived || hasErrors" class="action-button" buttonType="button" color="accent" @click.stop="publishPage">{{ actionMessage }}</ui-button>
       <span v-if="hasErrors" class="action-error-message" @click="goToHealth">Please fix errors before publishing</span>
       <span v-else-if="hasWarnings" class="action-warning-message" @click="goToHealth">Please review warnings before publishing</span>

--- a/lib/forms/overlay.vue
+++ b/lib/forms/overlay.vue
@@ -103,7 +103,7 @@
 
 <template>
   <transition name="overlay-fade-resize" appear mode="out-in" :css="false" @enter="enter" @leave="leave">
-    <form class="kiln-overlay-form" v-if="hasCurrentOverlayForm" :key="formKey" :style="{ top: formTop, left: formLeft }" @click.stop @submit.stop.prevent="save">
+    <form class="kiln-overlay-form" v-if="hasCurrentOverlayForm" :key="formKey" :style="{ top: formTop, left: formLeft }" @submit.stop.prevent="save">
       <div class="form-header">
         <h2 class="form-header-title">{{ formHeader }}</h2>
         <div class="form-header-actions">

--- a/lib/utils/timepicker.vue
+++ b/lib/utils/timepicker.vue
@@ -68,6 +68,9 @@
       },
       enableInput() {
         this.isDisabled = false;
+      },
+      clear() {
+        this.timeValue = '';
       }
     },
     components: {


### PR DESCRIPTION
* new button colors! #1089
* ability to clear `timepicker` (which fixes the timepicker not clearing) #1084
* deep-links fix for inline wysiwyg fields #1102
* quick syntax fix for paragraph merging / caret setting #1111
* refactored click handlers, so inputs can listen for document-level clicks #1087