### PR TITLE
Removes Elastic type

### DIFF
--- a/lib/nav/page-list.vue
+++ b/lib/nav/page-list.vue
@@ -219,7 +219,6 @@
   function buildQuery({ siteFilter, queryText, queryUser, offset, statusFilter, isMyPages, username }) { // eslint-disable-line
     let query = {
       index: 'pages',
-      type: 'general',
       body: {
         size: DEFAULT_QUERY_SIZE,
         from: offset,

--- a/lib/nav/users.vue
+++ b/lib/nav/users.vue
@@ -150,7 +150,6 @@
 
         return postJSON(prefix + searchRoute, {
           index: 'users',
-          type: 'general',
           body: {
             query: buildUserQuery(query),
             size: 500, // todo: paginate this once we redesign the clay menu (use the same pagination UI)

--- a/lib/page-state/actions.js
+++ b/lib/page-state/actions.js
@@ -113,7 +113,6 @@ export function getListData(store, { uri, prefix }) {
 
   let query = {
     index: 'pages',
-    type: 'general',
     body: {
       size: 1,
       query: {

--- a/lib/toolbar/add-contributor-modal.vue
+++ b/lib/toolbar/add-contributor-modal.vue
@@ -84,7 +84,6 @@
 
         return postJSON(prefix + searchRoute, {
           index: 'users',
-          type: 'general',
           body: {
             query: buildUserQuery(query),
             size: 500, // todo: paginate this once we redesign the clay menu (use the same pagination UI)

--- a/package.json
+++ b/package.json
@@ -128,6 +128,6 @@
     "whatwg-fetch": "^2.0.3"
   },
   "peerDependencies": {
-    "amphora-search": "^4.5.0"
+    "amphora-search": "^6.0.0"
   }
 }


### PR DESCRIPTION
(Do not merge until amphora-search 6 is released)

We're upgrading amphora-search to use Elastic 6. As part of this effort, we are having amphora-search automatically set document type in requests sent to the `_search` endpoint. This is because only one type is allowed per index in Elastic 6 anyway. By making it amphora-search's responsibility to set the type, we don't have to change Kiln again when migrating to future versions of Elastic, which will remove document types entirely.