### PR TITLE
Add removal confirmation to overlay

### DIFF
--- a/lib/forms/overlay.vue
+++ b/lib/forms/overlay.vue
@@ -353,10 +353,27 @@
       },
       removeComponent() {
         const currentURI = _.get(this.$store, 'state.ui.currentSelection.uri'),
-          el = currentURI && getComponentEl(currentURI);
+          el = currentURI && getComponentEl(currentURI),
+          componentName = getComponentName(currentURI),
+          shouldConfirm = _.get(this.$store, `state.schemas['${componentName}']._confirmRemoval`);
 
-        this.$store.dispatch('unselect');
-        return this.$store.dispatch('unfocus').then(() => this.$store.dispatch('removeComponent', el));
+        if (shouldConfirm) {
+          this.$store.dispatch('openModal', {
+            title: 'Remove Component',
+            type: 'type-confirm',
+            data: {
+              text: `Are you sure you want to remove this <strong>${componentName}</strong>?`,
+              name: componentName,
+              onConfirm: () => {
+                this.$store.dispatch('unselect');
+                return this.$store.dispatch('unfocus').then(() => this.$store.dispatch('removeComponent', el));
+              }
+            }
+          });
+        } else {
+          this.$store.dispatch('unselect');
+          return this.$store.dispatch('unfocus').then(() => this.$store.dispatch('removeComponent', el));
+        }
       },
       openAddComponentPane() {
         return this.$store.dispatch('openAddComponent', {


### PR DESCRIPTION
# Actual Behaviour: 

When a component has `_confirmRemoval: true`, the confirmation modal is only displayed when the user tries to delete the component from the `selector.vue` component. This lets the user delete a component from the page without displaying the confirmation modal when they delete the component from the `overlay.vue` component. Even though the component has the `_confirmRemoval: true`.

# Added behaviour

When the component has `_confirmRemoval: true`, the confirmation removal modal is displayed when the user tries to delete the component from the `overlay.vue` component.
