### PR TITLE
Drop support for non-underscored URIs

### DIFF
--- a/inputs/magic-button-transformers.test.js
+++ b/inputs/magic-button-transformers.test.js
@@ -29,15 +29,15 @@ describe('magic-button transformers', () => {
     const fn = lib.getComponentInstance;
 
     it('gets default component ref', () => {
-      expect(fn('nymag.com/scienceofus/components/article')).to.equal('/components/article');
+      expect(fn('nymag.com/scienceofus/_components/article')).to.equal('/_components/article');
     });
 
     it('gets instance component ref', () => {
-      expect(fn('nymag.com/scienceofus/components/article/instances/ciovznh8t004jyjy76b897d7k')).to.equal('/components/article/instances/ciovznh8t004jyjy76b897d7k');
+      expect(fn('nymag.com/scienceofus/_components/article/instances/ciovznh8t004jyjy76b897d7k')).to.equal('/_components/article/instances/ciovznh8t004jyjy76b897d7k');
     });
 
     it('gets instance with version', () => {
-      expect(fn('nymag.com/scienceofus/components/article/instances/ciovznh8t004jyjy76b897d7k@published')).to.equal('/components/article/instances/ciovznh8t004jyjy76b897d7k@published');
+      expect(fn('nymag.com/scienceofus/_components/article/instances/ciovznh8t004jyjy76b897d7k@published')).to.equal('/_components/article/instances/ciovznh8t004jyjy76b897d7k@published');
     });
   });
 

--- a/lib/component-data/actions.test.js
+++ b/lib/component-data/actions.test.js
@@ -7,7 +7,7 @@ import * as queue from '../core-data/queue';
 import * as lib from './actions';
 
 describe('component-data actions', () => {
-  const uri = 'domain.com/components/foo',
+  const uri = 'domain.com/_components/foo',
     data = { a: 'b' },
     prevData = { c: 'd' },
     store = {};

--- a/lib/component-data/create.test.js
+++ b/lib/component-data/create.test.js
@@ -49,7 +49,7 @@ describe('component creator', () => {
   it('creates a single component with a child list', () => {
     components.getSchema.returns({});
     // no store.state.site.prefix, hence undefined
-    components.getDefaultData.withArgs('foo').returns({ a: 'b', children: [{ _ref: 'undefined/components/bar' }] });
+    components.getDefaultData.withArgs('foo').returns({ a: 'b', children: [{ _ref: 'undefined/_components/bar' }] });
     components.getDefaultData.withArgs('bar').returns({ c: 'd' });
     components.getModel.returns(null);
     // note: the _ref will be a uid that we can't test against
@@ -59,7 +59,7 @@ describe('component creator', () => {
   it('creates a single component with a child prop', () => {
     components.getSchema.returns({});
     // no store.state.site.prefix, hence undefined
-    components.getDefaultData.withArgs('foo').returns({ a: 'b', child: { _ref: 'undefined/components/bar' } });
+    components.getDefaultData.withArgs('foo').returns({ a: 'b', child: { _ref: 'undefined/_components/bar' } });
     components.getDefaultData.withArgs('bar').returns({ c: 'd' });
     components.getModel.returns(null);
     // note: the _ref will be a uid that we can't test against

--- a/lib/component-data/mutations.test.js
+++ b/lib/component-data/mutations.test.js
@@ -1,7 +1,7 @@
 import lib from './mutations';
 import { UPDATE_COMPONENT, REVERT_COMPONENT, ADD_SCHEMA, RENDER_COMPONENT, REMOVE_COMPONENT, ADD_DEFAULT_DATA, OPEN_ADD_COMPONENT, CLOSE_ADD_COMPONENT } from './mutationTypes';
 
-const uri = 'domain.com/components/a/instances/b',
+const uri = 'domain.com/_components/a/instances/b',
   data = {
     foo: 'bar'
   },

--- a/lib/component-data/pubsub.test.js
+++ b/lib/component-data/pubsub.test.js
@@ -3,7 +3,7 @@ import * as lib from './pubsub';
 import { refProp } from '../utils/references';
 
 const data = { foo: 'harder', bar: 'better', baz: 'faster', qux: 'stronger' },
-  componentPrefix = 'domain.com/components/',
+  componentPrefix = 'domain.com/_components/',
   aInstance = `${componentPrefix}A/instances/1`,
   bInstance = `${componentPrefix}B/instances/1`,
   cInstance = `${componentPrefix}C/instances/1`,

--- a/lib/core-data/api.test.js
+++ b/lib/core-data/api.test.js
@@ -94,8 +94,8 @@ describe('api', () => {
     it('gets schema for a component', () => {
       respond(goodObj);
 
-      return fn('domain.com/components/foo').then(() => {
-        expect(rest.send).to.have.been.calledWith('http://domain.com/components/foo/schema');
+      return fn('domain.com/_components/foo').then(() => {
+        expect(rest.send).to.have.been.calledWith('http://domain.com/_components/foo/schema');
       });
     });
   });

--- a/lib/core-data/components.test.js
+++ b/lib/core-data/components.test.js
@@ -1,6 +1,6 @@
 import * as lib from './components';
 
-const uri = '/components/foo',
+const uri = '/_components/foo',
   ok = { bar: 'baz' },
   testStore = {
     state: {
@@ -23,6 +23,6 @@ describe('components helper functions', () => {
   it('gets subset of schema with path', () => expect(lib.getSchema(uri, 'bar', testStore)).to.eql('baz'));
   it('gets template', () => expect(lib.getTemplate(uri, testStore)).to.eql(ok));
   it('gets model', () => expect(lib.getModel(uri, testStore)).to.eql(ok));
-  it('uses camelCase for models', () => expect(lib.getModel('/components/foo', testStore)).to.eql(ok));
+  it('uses camelCase for models', () => expect(lib.getModel('/_components/foo', testStore)).to.eql(ok));
   it('gets locals', () => expect(lib.getLocals(testStore)).to.eql(ok));
 });

--- a/lib/core-data/groups.test.js
+++ b/lib/core-data/groups.test.js
@@ -155,7 +155,7 @@ describe('groups', () => {
           settings: baz
         }
       });
-      expect(fn('/components/foo', 'settings')).to.eql({ fields: {foo, bar}, schema: {
+      expect(fn('/_components/foo', 'settings')).to.eql({ fields: {foo, bar}, schema: {
         fields: ['foo', 'bar'],
         sections: [general(['foo', 'bar'])],
         _label: 'Foo Settings',

--- a/lib/decorators/select.test.js
+++ b/lib/decorators/select.test.js
@@ -34,9 +34,9 @@ describe('select', () => {
     });
 
     it('warns if path not found in schema', () => {
-      components.getData.returns({ fooProp: { [refProp]: '/components/foo' } });
+      components.getData.returns({ fooProp: { [refProp]: '/_components/foo' } });
       components.getSchema.returns({});
-      fn('/components/foo', '/components/bar');
+      fn('/_components/foo', '/_components/bar');
       expect(loggerStub.warn.called).to.equal(true);
     });
 

--- a/lib/drawers/publish.vue
+++ b/lib/drawers/publish.vue
@@ -355,7 +355,7 @@
           })
           .then(() => {
             if (_.includes(window.location.href, uriToUrl(uri))) {
-              // if we're already looking at /pages/whatever, display the status message
+              // if we're already looking at /_pages/whatever, display the status message
               store.commit(FINISH_PROGRESS);
               store.dispatch('showSnackbar', 'Unpublished Page');
             } else {

--- a/lib/forms/field-helpers.test.js
+++ b/lib/forms/field-helpers.test.js
@@ -4,7 +4,7 @@ describe('field helpers', () => {
   describe('getFieldData', () => {
     const fn = lib.getFieldData,
       prop = 'foo',
-      uri = 'domain.com/components/abc/instances/def',
+      uri = 'domain.com/_components/abc/instances/def',
       storeWithList = {
         state: {
           ui: {

--- a/lib/utils/caret.test.js
+++ b/lib/utils/caret.test.js
@@ -6,7 +6,7 @@ import * as lib from './caret';
 describe('caret', () => {
   let textNode = document.createTextNode('Hello World'),
     span = create(`<span ${editAttr}="foo"></span>`),
-    el = create(`<div ${refAttr}="domain.com/components/hi"></div>`),
+    el = create(`<div ${refAttr}="domain.com/_components/hi"></div>`),
     sandbox;
 
   span.appendChild(textNode);

--- a/lib/utils/component-elements.js
+++ b/lib/utils/component-elements.js
@@ -46,7 +46,7 @@ export function getLayout() {
  */
 function matchComponent(el, name) {
   if (name) {
-    return el.nodeType === el.ELEMENT_NODE && _.includes(el.getAttribute(refAttr), `/components/${name}`);
+    return el.nodeType === el.ELEMENT_NODE && _.includes(el.getAttribute(refAttr), `/_components/${name}`);
   } else {
     return el.nodeType === el.ELEMENT_NODE && el.hasAttribute(refAttr);
   }

--- a/lib/utils/component-elements.test.js
+++ b/lib/utils/component-elements.test.js
@@ -9,7 +9,7 @@ function stubComponent(name) {
   child.classList.add('child');
   el.appendChild(child);
 
-  el.setAttribute(refAttr, `domain.com/components/${name}`);
+  el.setAttribute(refAttr, `domain.com/_components/${name}`);
   el.classList.add(name);
   return el;
 }
@@ -86,12 +86,12 @@ describe('component-elements', () => {
     const fn = lib.getLayout;
 
     document.firstElementChild.setAttribute(refAttr, 'domain.com/pages/1');
-    document.firstElementChild.setAttribute(layoutAttr, 'domain.com/components/layout');
+    document.firstElementChild.setAttribute(layoutAttr, 'domain.com/_components/layout');
 
     it('finds layout element and uri', () => {
       expect(fn()).to.eql({
         el: document.firstElementChild,
-        uri: 'domain.com/components/layout'
+        uri: 'domain.com/_components/layout'
       });
     });
   });
@@ -141,9 +141,9 @@ describe('component-elements', () => {
   describe('getVisibleList', () => {
     const fn = lib.getVisibleList,
       doc = create(`<div>
-        <span ${refAttr}="domain.com/components/a"></span>
-        <span ${refAttr}="domain.com/components/b"></span>
-        <span ${refAttr}="domain.com/components/c" ${hiddenAttr}="true"></span>
+        <span ${refAttr}="domain.com/_components/a"></span>
+        <span ${refAttr}="domain.com/_components/b"></span>
+        <span ${refAttr}="domain.com/_components/c" ${hiddenAttr}="true"></span>
       </div>`);
 
     // append to the dom, so the offsetParent isn't null
@@ -157,40 +157,40 @@ describe('component-elements', () => {
   describe('getPrevVisible', () => {
     const fn = lib.getPrevVisible,
       doc = create(`<div>
-        <span ${refAttr}="domain.com/components/a"></span>
-        <span ${refAttr}="domain.com/components/b" ${hiddenAttr}="true"></span>
-        <span ${refAttr}="domain.com/components/c"></span>
+        <span ${refAttr}="domain.com/_components/a"></span>
+        <span ${refAttr}="domain.com/_components/b" ${hiddenAttr}="true"></span>
+        <span ${refAttr}="domain.com/_components/c"></span>
       </div>`);
 
     // append to the dom, so the offsetParent isn't null
     document.body.appendChild(doc);
 
     it('returns previous visible component', () => {
-      expect(fn(find(doc, `[${refAttr}="domain.com/components/c"]`), doc)).to.equal(find(doc, `[${refAttr}="domain.com/components/a"]`));
+      expect(fn(find(doc, `[${refAttr}="domain.com/_components/c"]`), doc)).to.equal(find(doc, `[${refAttr}="domain.com/_components/a"]`));
     });
 
     it('returns undefined if no previous visible component', () => {
-      expect(fn(find(doc, `[${refAttr}="domain.com/components/a"]`), doc)).to.equal(undefined);
+      expect(fn(find(doc, `[${refAttr}="domain.com/_components/a"]`), doc)).to.equal(undefined);
     });
   });
 
   describe('getNextVisible', () => {
     const fn = lib.getNextVisible,
       doc = create(`<div>
-        <span ${refAttr}="domain.com/components/a"></span>
-        <span ${refAttr}="domain.com/components/b" ${hiddenAttr}="true"></span>
-        <span ${refAttr}="domain.com/components/c"></span>
+        <span ${refAttr}="domain.com/_components/a"></span>
+        <span ${refAttr}="domain.com/_components/b" ${hiddenAttr}="true"></span>
+        <span ${refAttr}="domain.com/_components/c"></span>
       </div>`);
 
     // append to the dom, so the offsetParent isn't null
     document.body.appendChild(doc);
 
     it('returns next visible component', () => {
-      expect(fn(find(doc, `[${refAttr}="domain.com/components/a"]`), doc)).to.equal(find(doc, `[${refAttr}="domain.com/components/c"]`));
+      expect(fn(find(doc, `[${refAttr}="domain.com/_components/a"]`), doc)).to.equal(find(doc, `[${refAttr}="domain.com/_components/c"]`));
     });
 
     it('returns undefined if no next visible component', () => {
-      expect(fn(find(doc, `[${refAttr}="domain.com/components/c"]`), doc)).to.equal(undefined);
+      expect(fn(find(doc, `[${refAttr}="domain.com/_components/c"]`), doc)).to.equal(undefined);
     });
   });
 

--- a/lib/utils/component-elements.test.js
+++ b/lib/utils/component-elements.test.js
@@ -85,7 +85,7 @@ describe('component-elements', () => {
   describe('getLayout', () => {
     const fn = lib.getLayout;
 
-    document.firstElementChild.setAttribute(refAttr, 'domain.com/pages/1');
+    document.firstElementChild.setAttribute(refAttr, 'domain.com/_pages/1');
     document.firstElementChild.setAttribute(layoutAttr, 'domain.com/_components/layout');
 
     it('finds layout element and uri', () => {

--- a/lib/utils/deep-reduce.test.js
+++ b/lib/utils/deep-reduce.test.js
@@ -2,7 +2,7 @@ import { reduce } from 'lodash';
 import { refProp } from './references';
 import lib from './deep-reduce';
 
-const ref = 'domain.com/components/foo',
+const ref = 'domain.com/_components/foo',
   component = {
     [refProp]: ref,
     a: 'b'

--- a/lib/utils/deep-reduce.test.js
+++ b/lib/utils/deep-reduce.test.js
@@ -30,7 +30,7 @@ describe('deep reduce', () => {
   it('does not call fn on non-component refs', () => {
     let obj = {};
 
-    reduce([{ [refProp]: 'domain.com/pages/foo' }], (result, val) => lib(result, val, compose(obj)), {});
+    reduce([{ [refProp]: 'domain.com/_pages/foo' }], (result, val) => lib(result, val, compose(obj)), {});
     expect(obj).to.deep.equal({});
   });
 

--- a/lib/utils/references.js
+++ b/lib/utils/references.js
@@ -22,9 +22,9 @@ export function isDefaultComponent(uri) {
 
 /**
  * get component name from uri
- * @example /components/base  returns base
- * @example /components/text/instances/0  returns text
- * @example /components/image.html  returns image
+ * @example /_components/base  returns base
+ * @example /_components/text/instances/0  returns text
+ * @example /_components/image.html  returns image
  * @param  {string} uri
  * @return {string|null}
  */
@@ -105,7 +105,7 @@ export const hiddenAttr = 'data-kiln-hidden';
 // properties
 export const refProp = '_ref';
 export const fieldProp = '_has'; // used to determine if a node (in the schema) is a field
-export const componentListProp = '_componentList';
+export const componentLipubsubstProp = '_componentList';
 export const componentProp = '_component';
 export const displayProp = '_display'; // note: deprecated in kiln 5.x, should be removed in kiln 6.x
 export const placeholderProp = '_placeholder';

--- a/lib/utils/references.js
+++ b/lib/utils/references.js
@@ -2,11 +2,6 @@ import _ from 'lodash';
 import dom from '@nymag/dom';
 import store from '../core-data/store';
 
-// route prefix (e.g. '_' or just '') is determined in the template when kiln loads.
-// amphora 4.x and below don't have a prefix, whereas amphora 5.x and above use
-// /_components, /_pages, /_uris, etc
-const routePrefix = _.get(window, 'kiln.routePrefix', '');
-
 /**
  * determine if a uri points to a component
  * @param  {string}  uri
@@ -88,7 +83,7 @@ export function getComponentByNameAndInstance(name, instance) {
     uri;
 
   if (name && instance && sitePrefix) {
-    uri = `${sitePrefix}/${routePrefix}components/${name}/instances/${instance}`;
+    uri = `${sitePrefix}/_components/${name}/instances/${instance}`;
 
     return {
       uri,
@@ -126,15 +121,15 @@ export const revealProp = '_reveal';
 export const behaviorKey = 'fn'; // note: deprecated in kiln 5.x, should be removed in kiln 6.x
 export const inputProp = 'input'; // used to determine input name
 // api routes, extensions, and headers
-export const componentRoute = `/${routePrefix}components/`;
-export const pagesRoute = `/${routePrefix}pages/`;
-export const urisRoute = `/${routePrefix}uris/`;
-export const usersRoute = `/${routePrefix}users/`;
-export const usersBareRoute = `/${routePrefix}users`;
-export const listsRoute = `/${routePrefix}lists/`;
-export const scheduleRoute = `/${routePrefix}schedule`; // no ending slash
-export const loginRoute = `/${routePrefix}auth/login`;
-export const logoutRoute = `/${routePrefix}auth/logout`;
+export const componentRoute = '/_components/';
+export const pagesRoute = '/_pages/';
+export const urisRoute = '/_uris/';
+export const usersRoute = '/_users/';
+export const usersBareRoute = '/_users';
+export const listsRoute = '/_lists/';
+export const scheduleRoute = '/_schedule'; // no ending slash
+export const loginRoute = '/_auth/login';
+export const logoutRoute = '/_auth/logout';
 export const schemaRoute = '/schema'; // no ending slash
 export const instancesRoute = '/instances'; // no ending slash
 export const searchRoute = '/_search';

--- a/lib/utils/references.js
+++ b/lib/utils/references.js
@@ -105,7 +105,7 @@ export const hiddenAttr = 'data-kiln-hidden';
 // properties
 export const refProp = '_ref';
 export const fieldProp = '_has'; // used to determine if a node (in the schema) is a field
-export const componentLipubsubstProp = '_componentList';
+export const componentListProp = '_componentList';
 export const componentProp = '_component';
 export const displayProp = '_display'; // note: deprecated in kiln 5.x, should be removed in kiln 6.x
 export const placeholderProp = '_placeholder';

--- a/lib/utils/references.test.js
+++ b/lib/utils/references.test.js
@@ -1,26 +1,19 @@
 import _ from 'lodash';
 import * as lib from './references';
 
-// note: all tests are doubled, so we can maintain both amphora 4.x (/components)
-// and amphora 5.x (/_components) compatibility
-
 describe('references', () => {
   describe('isComponent', () => {
     const fn = lib.isComponent;
 
     it('returns true if component reference', () => {
-      expect(fn('domain.com/components/foo')).to.equal(true);
       expect(fn('domain.com/_components/foo')).to.equal(true);
     });
 
     it('returns true if component instance reference', () => {
-      expect(fn('domain.com/components/foo/instances/bar')).to.equal(true);
       expect(fn('domain.com/_components/foo/instances/bar')).to.equal(true);
     });
 
     it('returns false if non-component reference', () => {
-      expect(fn('domain.com/_users/foo')).to.equal(false);
-      expect(fn('domain.com/_pages/foo')).to.equal(false);
       expect(fn('domain.com/_users/foo')).to.equal(false);
       expect(fn('domain.com/_pages/foo')).to.equal(false);
     });
@@ -30,18 +23,14 @@ describe('references', () => {
     const fn = lib.isDefaultComponent;
 
     it('returns true if default component reference', () => {
-      expect(fn('domain.com/components/foo')).to.equal(true);
       expect(fn('domain.com/_components/foo')).to.equal(true);
     });
 
     it('returns false if component instance reference', () => {
-      expect(fn('domain.com/components/foo/instances/bar')).to.equal(false);
       expect(fn('domain.com/_components/foo/instances/bar')).to.equal(false);
     });
 
     it('returns false if non-component reference', () => {
-      expect(fn('domain.com/_users/foo')).to.equal(false);
-      expect(fn('domain.com/_pages/foo')).to.equal(false);
       expect(fn('domain.com/_users/foo')).to.equal(false);
       expect(fn('domain.com/_pages/foo')).to.equal(false);
     });
@@ -51,29 +40,23 @@ describe('references', () => {
     const fn = lib.getComponentName;
 
     it('gets name from default uri', function () {
-      expect(fn('/components/base')).to.equal('base');
       expect(fn('/_components/base')).to.equal('base');
     });
 
     it('gets name from instance uri', function () {
-      expect(fn('/components/base/instances/0')).to.equal('base');
       expect(fn('/_components/base/instances/0')).to.equal('base');
     });
 
     it('gets name from versioned uri', function () {
-      expect(fn('/components/base/instances/0@published')).to.equal('base');
       expect(fn('/_components/base/instances/0@published')).to.equal('base');
     });
 
     it('gets name from uri with extension', function () {
-      expect(fn('/components/base.html')).to.equal('base');
-      expect(fn('/components/base.json')).to.equal('base');
       expect(fn('/_components/base.html')).to.equal('base');
       expect(fn('/_components/base.json')).to.equal('base');
     });
 
     it('gets name from full uri', function () {
-      expect(fn('nymag.com/press/components/base/instances/foobarbaz@published')).to.equal('base');
       expect(fn('nymag.com/press/_components/base/instances/foobarbaz@published')).to.equal('base');
     });
   });
@@ -82,27 +65,22 @@ describe('references', () => {
     const fn = lib.getComponentInstance;
 
     it('gets instance from uri', function () {
-      expect(fn('/components/base/instances/0')).to.equal('0');
       expect(fn('/_components/base/instances/0')).to.equal('0');
     });
 
     it('gets instance from uri with extension', function () {
-      expect(fn('/components/base/instances/0.html')).to.equal('0');
       expect(fn('/_components/base/instances/0.html')).to.equal('0');
     });
 
     it('gets instance from uri with version', function () {
-      expect(fn('/components/base/instances/0@published')).to.equal('0');
       expect(fn('/_components/base/instances/0@published')).to.equal('0');
     });
 
     it('gets instance from full uri', function () {
-      expect(fn('nymag.com/press/components/base/instances/foobarbaz@published')).to.equal('foobarbaz');
       expect(fn('nymag.com/press/_components/base/instances/foobarbaz@published')).to.equal('foobarbaz');
     });
 
     it('CANNOT get instance from default uri', function () {
-      expect(fn('/components/base')).to.not.equal('0');
       expect(fn('/_components/base')).to.not.equal('0');
     });
   });
@@ -111,18 +89,14 @@ describe('references', () => {
     const fn = lib.getComponentVersion;
 
     it('gets version from instance uri', () => {
-      expect(fn('/components/foo/instances/bar@published')).to.equal('published');
       expect(fn('/_components/foo/instances/bar@published')).to.equal('published');
     });
 
     it('gets version from default uri', () => {
-      expect(fn('/components/base@published')).to.equal('published');
       expect(fn('/_components/base@published')).to.equal('published');
     });
 
     it('returns null if no version', () => {
-      expect(fn('/components/foo/instances/bar')).to.equal(null);
-      expect(fn('/components/base')).to.equal(null);
       expect(fn('/_components/foo/instances/bar')).to.equal(null);
       expect(fn('/_components/base')).to.equal(null);
     });
@@ -133,16 +107,13 @@ describe('references', () => {
 
     it('adds version to base', function () {
       expect(fn('domain.com/_pages/foo', 'bar')).to.equal('domain.com/_pages/foo@bar');
-      expect(fn('domain.com/_pages/foo', 'bar')).to.equal('domain.com/_pages/foo@bar');
     });
 
     it('replaces version', function () {
       expect(fn('domain.com/_pages/foo@bar', 'baz')).to.equal('domain.com/_pages/foo@baz');
-      expect(fn('domain.com/_pages/foo@bar', 'baz')).to.equal('domain.com/_pages/foo@baz');
     });
 
     it('removes version', function () {
-      expect(fn('domain.com/_pages/foo@bar')).to.equal('domain.com/_pages/foo');
       expect(fn('domain.com/_pages/foo@bar')).to.equal('domain.com/_pages/foo');
     });
 
@@ -168,11 +139,11 @@ describe('references', () => {
     });
 
     it('returns object w/ uri if no component found', () => {
-      expect(fn('not-found', 'not-found')).to.eql({ uri: 'domain.com/components/not-found/instances/not-found', el: null });
+      expect(fn('not-found', 'not-found')).to.eql({ uri: 'domain.com/_components/not-found/instances/not-found', el: null });
     });
 
     it('finds components in the dom', () => {
-      const uri = 'domain.com/components/found-instance/instances/1',
+      const uri = 'domain.com/_components/found-instance/instances/1',
         el = document.createElement('div');
 
       el.setAttribute('data-uri', uri);
@@ -183,7 +154,7 @@ describe('references', () => {
 
     it('does NOT find default component instances', () => {
       // todo: we should support this
-      const uri = 'domain.com/components/not-found',
+      const uri = 'domain.com/_components/not-found',
         el = document.createElement('div');
 
       el.setAttribute('data-uri', uri);

--- a/lib/utils/references.test.js
+++ b/lib/utils/references.test.js
@@ -19,8 +19,8 @@ describe('references', () => {
     });
 
     it('returns false if non-component reference', () => {
-      expect(fn('domain.com/users/foo')).to.equal(false);
-      expect(fn('domain.com/pages/foo')).to.equal(false);
+      expect(fn('domain.com/_users/foo')).to.equal(false);
+      expect(fn('domain.com/_pages/foo')).to.equal(false);
       expect(fn('domain.com/_users/foo')).to.equal(false);
       expect(fn('domain.com/_pages/foo')).to.equal(false);
     });
@@ -40,8 +40,8 @@ describe('references', () => {
     });
 
     it('returns false if non-component reference', () => {
-      expect(fn('domain.com/users/foo')).to.equal(false);
-      expect(fn('domain.com/pages/foo')).to.equal(false);
+      expect(fn('domain.com/_users/foo')).to.equal(false);
+      expect(fn('domain.com/_pages/foo')).to.equal(false);
       expect(fn('domain.com/_users/foo')).to.equal(false);
       expect(fn('domain.com/_pages/foo')).to.equal(false);
     });
@@ -132,17 +132,17 @@ describe('references', () => {
     const fn = lib.replaceVersion;
 
     it('adds version to base', function () {
-      expect(fn('domain.com/pages/foo', 'bar')).to.equal('domain.com/pages/foo@bar');
+      expect(fn('domain.com/_pages/foo', 'bar')).to.equal('domain.com/_pages/foo@bar');
       expect(fn('domain.com/_pages/foo', 'bar')).to.equal('domain.com/_pages/foo@bar');
     });
 
     it('replaces version', function () {
-      expect(fn('domain.com/pages/foo@bar', 'baz')).to.equal('domain.com/pages/foo@baz');
+      expect(fn('domain.com/_pages/foo@bar', 'baz')).to.equal('domain.com/_pages/foo@baz');
       expect(fn('domain.com/_pages/foo@bar', 'baz')).to.equal('domain.com/_pages/foo@baz');
     });
 
     it('removes version', function () {
-      expect(fn('domain.com/pages/foo@bar')).to.equal('domain.com/pages/foo');
+      expect(fn('domain.com/_pages/foo@bar')).to.equal('domain.com/_pages/foo');
       expect(fn('domain.com/_pages/foo@bar')).to.equal('domain.com/_pages/foo');
     });
 

--- a/lib/validators/built-in/beyonce.test.js
+++ b/lib/validators/built-in/beyonce.test.js
@@ -7,7 +7,7 @@ describe('validators: beyonce', () => {
 
   describe('validate', () => {
     const fn = lib.validate,
-      uri = 'domain.com/components/foo/instances/bar',
+      uri = 'domain.com/_components/foo/instances/bar',
       name = 'foo';
 
     it('passes if no components', () => {

--- a/lib/validators/built-in/conditional-required.test.js
+++ b/lib/validators/built-in/conditional-required.test.js
@@ -7,7 +7,7 @@ describe('validators: conditional-required', () => {
 
   describe('validate', () => {
     const fn = lib.validate,
-      uri = 'domain.com/components/foo/instances/bar',
+      uri = 'domain.com/_components/foo/instances/bar',
       name = 'foo';
 
     it('passes if no components', () => {

--- a/lib/validators/built-in/edit-links.test.js
+++ b/lib/validators/built-in/edit-links.test.js
@@ -7,7 +7,7 @@ describe('validators: edit-links', () => {
 
   describe('validate', () => {
     const fn = lib.validate,
-      uri = 'domain.com/components/foo/instances/bar',
+      uri = 'domain.com/_components/foo/instances/bar',
       name = 'foo';
 
     it('passes if no components', () => {

--- a/lib/validators/built-in/max.test.js
+++ b/lib/validators/built-in/max.test.js
@@ -7,7 +7,7 @@ describe('validators: max', () => {
 
   describe('validate', () => {
     const fn = lib.validate,
-      uri = 'domain.com/components/foo/instances/bar',
+      uri = 'domain.com/_components/foo/instances/bar',
       name = 'foo';
 
     it('passes if no components', () => {
@@ -92,7 +92,7 @@ describe('validators: max', () => {
     it('passes if component list has fewer components than length', () => {
       expect(fn({
         components: {
-          [uri]: { a: [{ _ref: 'domain.com/components/foo' }, { _ref: 'domain.com/components/bar' }] }
+          [uri]: { a: [{ _ref: 'domain.com/_components/foo' }, { _ref: 'domain.com/_components/bar' }] }
         },
         schemas: {
           [name]: {
@@ -136,7 +136,7 @@ describe('validators: max', () => {
     it('fails if component list has more components than length', () => {
       expect(fn({
         components: {
-          [uri]: { a: [{ _ref: 'domain.com/components/foo' }, { _ref: 'domain.com/components/bar' }] }
+          [uri]: { a: [{ _ref: 'domain.com/_components/foo' }, { _ref: 'domain.com/_components/bar' }] }
         },
         schemas: {
           [name]: {

--- a/lib/validators/built-in/min.test.js
+++ b/lib/validators/built-in/min.test.js
@@ -7,7 +7,7 @@ describe('validators: min', () => {
 
   describe('validate', () => {
     const fn = lib.validate,
-      uri = 'domain.com/components/foo/instances/bar',
+      uri = 'domain.com/_components/foo/instances/bar',
       name = 'foo';
 
     it('passes if no components', () => {
@@ -92,7 +92,7 @@ describe('validators: min', () => {
     it('passes if component list has more components than length', () => {
       expect(fn({
         components: {
-          [uri]: { a: [{ _ref: 'domain.com/components/foo' }, { _ref: 'domain.com/components/bar' }] }
+          [uri]: { a: [{ _ref: 'domain.com/_components/foo' }, { _ref: 'domain.com/_components/bar' }] }
         },
         schemas: {
           [name]: {
@@ -136,7 +136,7 @@ describe('validators: min', () => {
     it('fails if component list has fewer components than length', () => {
       expect(fn({
         components: {
-          [uri]: { a: [{ _ref: 'domain.com/components/foo' }, { _ref: 'domain.com/components/bar' }] }
+          [uri]: { a: [{ _ref: 'domain.com/_components/foo' }, { _ref: 'domain.com/_components/bar' }] }
         },
         schemas: {
           [name]: {

--- a/lib/validators/built-in/pattern.test.js
+++ b/lib/validators/built-in/pattern.test.js
@@ -7,7 +7,7 @@ describe('validators: pattern', () => {
 
   describe('validate', () => {
     const fn = lib.validate,
-      uri = 'domain.com/components/foo/instances/bar',
+      uri = 'domain.com/_components/foo/instances/bar',
       name = 'foo';
 
     it('passes if no components', () => {

--- a/lib/validators/built-in/required.test.js
+++ b/lib/validators/built-in/required.test.js
@@ -7,7 +7,7 @@ describe('validators: required', () => {
 
   describe('validate', () => {
     const fn = lib.validate,
-      uri = 'domain.com/components/foo/instances/bar',
+      uri = 'domain.com/_components/foo/instances/bar',
       name = 'foo';
 
     it('passes if no components', () => {

--- a/lib/validators/built-in/tk.test.js
+++ b/lib/validators/built-in/tk.test.js
@@ -7,7 +7,7 @@ describe('validators: tk', () => {
 
   describe('validate', () => {
     const fn = lib.validate,
-      uri = 'domain.com/components/foo/instances/bar',
+      uri = 'domain.com/_components/foo/instances/bar',
       name = 'foo';
 
     it('passes if no components', () => {
@@ -68,7 +68,7 @@ describe('validators: tk', () => {
       })).to.eql([]);
       expect(fn({
         components: {
-          [uri]: { a: 'host/components/whatever/instances/000tk00' }
+          [uri]: { a: 'host/_components/whatever/instances/000tk00' }
         }
       }), 'passes classic amphora-style refs').to.eql([]);
       expect(fn({

--- a/lib/validators/helpers.test.js
+++ b/lib/validators/helpers.test.js
@@ -100,7 +100,7 @@ describe('validation helpers', () => {
     });
 
     it('gets schema for uri', () => {
-      expect(fn({ schemas: { foo: { a: 'b' }}}, 'domain.com/components/foo/instances/bar')).to.eql({ a: 'b' });
+      expect(fn({ schemas: { foo: { a: 'b' }}}, 'domain.com/_components/foo/instances/bar')).to.eql({ a: 'b' });
     });
   });
 
@@ -178,13 +178,13 @@ describe('validation helpers', () => {
             a: { _componentList: true }
           }
         }
-      }, { a: [{ _ref: 'domain.com/components/bar' }] }, 'foo', spy);
+      }, { a: [{ _ref: 'domain.com/_components/bar' }] }, 'foo', spy);
       expect(spy.callCount).to.equal(1);
       expect(getFirstArg(spy)).to.eql({
         type: 'component-list',
         name: 'a',
         path: 'a',
-        value: ['domain.com/components/bar'],
+        value: ['domain.com/_components/bar'],
         schema: { _componentList: true },
         validate: undefined
       });
@@ -237,13 +237,13 @@ describe('validation helpers', () => {
             a: { _component: true }
           }
         }
-      }, { a: { _ref: 'domain.com/components/bar' } }, 'foo', spy);
+      }, { a: { _ref: 'domain.com/_components/bar' } }, 'foo', spy);
       expect(spy.callCount).to.equal(1);
       expect(getFirstArg(spy)).to.eql({
         type: 'component-prop',
         name: 'a',
         path: 'a',
-        value: 'domain.com/components/bar',
+        value: 'domain.com/_components/bar',
         schema: { _component: true },
         validate: undefined
       });

--- a/template.handlebars
+++ b/template.handlebars
@@ -11,8 +11,6 @@
     <script>
       // start scaffolding kiln stuff
       window.kiln = window.kiln || {};
-      // figure out the route prefix (e.g. /components, or /_components) based on the _ref of kiln itself
-      window.kiln.routePrefix = '{{ default _ref _self }}'.indexOf('/_components/') > -1 ? '_' : '';
     </script>
     {{#if @root.locals.edit}}
       {{! show edit mode styles and preload data}}


### PR DESCRIPTION
Stable versions of other Clay resources (e.g. amphora-search, clay-utils) no longer support non-underscored URIs. Let's have Kiln follow suit.