### PR TITLE
Lists for ui select

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -83,7 +83,7 @@ An array of objects with arbitrary properties. Each property may have any inputs
 
 ### Complex List Arguments
 
-* **props** an array of objects, represending the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
+* **props** an array of objects, representing the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
 
 ### Complex List Usage
 
@@ -91,7 +91,7 @@ An array of objects with arbitrary properties. Each property may have any inputs
 * Items can be added by clicking the `add` button
 * When a complex-list is _not_ empty, the focused item will have actions it, with `add` and `remove` buttons
 * Items can be removed by clicking the `remove` button
-* Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list.
+* Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list, except before the first item.
 
 ```yaml
 links:
@@ -407,8 +407,10 @@ An enhanced browser `<select>` element, allowing the user to select one (or more
 
 * **multiple** - allow multiple options to be selected. data will be an object with options as keys, similar to checkbox-group
 * **search** - allow users to type stuff in to filter options. Extremely useful for longer options lists
-* **list** - The key `list`  is where the value is the name of a list that Amphora knows about accessible via `/<site>/_lists/<listName>`.
+* **list** - The key `list` is where the value is the name of a list that Amphora knows about accessible via `/<site>/_lists/<listName>`.
 * **options** - an array of strings or objects (with `name`, `value`, and optionally `sites`)
+* **keys** passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists
+* **storeRawData** normally only the `value` of each option is stored, but with this option you can store the entire input object
 * **help** - description / helper text for the field
 * **attachedButton** - an icon button that should be attached to the field, to allow additional functionality
 * **validate.required** - either `true` or an object that described the conditions that should make this field required

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -83,7 +83,7 @@ An array of objects with arbitrary properties. Each property may have any inputs
 
 ### Complex List Arguments
 
-* **props** an array of objects, representing the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
+* **props** an array of objects, represending the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
 
 ### Complex List Usage
 
@@ -91,7 +91,7 @@ An array of objects with arbitrary properties. Each property may have any inputs
 * Items can be added by clicking the `add` button
 * When a complex-list is _not_ empty, the focused item will have actions it, with `add` and `remove` buttons
 * Items can be removed by clicking the `remove` button
-* Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list, except before the first item.
+* Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list.
 
 ```yaml
 links:
@@ -409,7 +409,7 @@ An enhanced browser `<select>` element, allowing the user to select one (or more
 * **search** - allow users to type stuff in to filter options. Extremely useful for longer options lists
 * **list** - The key `list` is where the value is the name of a list that Amphora knows about accessible via `/<site>/_lists/<listName>`.
 * **options** - an array of strings or objects (with `name`, `value`, and optionally `sites`)
-* **keys** passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists
+* **keys** passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists. Defaults to `{label: 'name', value: 'value'}`
 * **storeRawData** normally only the `value` of each option is stored, but with this option you can store the entire input object
 * **help** - description / helper text for the field
 * **attachedButton** - an icon button that should be attached to the field, to allow additional functionality

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -407,6 +407,7 @@ An enhanced browser `<select>` element, allowing the user to select one (or more
 
 * **multiple** - allow multiple options to be selected. data will be an object with options as keys, similar to checkbox-group
 * **search** - allow users to type stuff in to filter options. Extremely useful for longer options lists
+* **list** - The key `list`  is where the value is the name of a list that Amphora knows about accessible via `/<site>/_lists/<listName>`.
 * **options** - an array of strings or objects (with `name`, `value`, and optionally `sites`)
 * **help** - description / helper text for the field
 * **attachedButton** - an icon button that should be attached to the field, to allow additional functionality

--- a/inputs/complex-list.vue
+++ b/inputs/complex-list.vue
@@ -5,7 +5,7 @@
 
   ### Complex List Arguments
 
-  * **props** an array of objects, representing the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
+  * **props** an array of objects, represending the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
 
   ### Complex List Usage
 
@@ -13,7 +13,7 @@
   * Items can be added by clicking the `add` button
   * When a complex-list is _not_ empty, the focused item will have actions it, with `add` and `remove` buttons
   * Items can be removed by clicking the `remove` button
-  * Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list, except before the first item.
+  * Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list.
 
   ```yaml
   links:

--- a/inputs/complex-list.vue
+++ b/inputs/complex-list.vue
@@ -5,7 +5,7 @@
 
   ### Complex List Arguments
 
-  * **props** an array of objects, represending the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
+  * **props** an array of objects, representing the fields in each item. Each item should have a name, defined by `prop: 'name'`, as well as `_label` and the input that item uses.
 
   ### Complex List Usage
 
@@ -13,7 +13,7 @@
   * Items can be added by clicking the `add` button
   * When a complex-list is _not_ empty, the focused item will have actions it, with `add` and `remove` buttons
   * Items can be removed by clicking the `remove` button
-  * Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list.
+  * Items in a complex-list cannot be reordered, but can be added and removed from anywhere in the list, except before the first item.
 
   ```yaml
   links:

--- a/inputs/select.vue
+++ b/inputs/select.vue
@@ -9,7 +9,7 @@
   * **search** - allow users to type stuff in to filter options. Extremely useful for longer options lists
   * **list** - The key `list` is where the value is the name of a list that Amphora knows about accessible via `/<site>/_lists/<listName>`.
   * **options** - an array of strings or objects (with `name`, `value`, and optionally `sites`)
-  * **keys** passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists
+  * **keys** passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists. Defaults to `{label: 'name', value: 'value'}`
   * **storeRawData** normally only the `value` of each option is stored, but with this option you can store the entire input object
   * **help** - description / helper text for the field
   * **attachedButton** - an icon button that should be attached to the field, to allow additional functionality
@@ -108,7 +108,7 @@
     computed: {
       keys () {
         return {
-          label: 'name', // backwards compatibility I guess?
+          label: 'name',
           value: 'value',
           ...this.args.keys
         }

--- a/lib/page-state/actions.js
+++ b/lib/page-state/actions.js
@@ -10,7 +10,7 @@ import { searchRoute, replaceVersion } from '../utils/references';
 const postPageList = _.debounce((endpoint, data, store) => {
   return postJSON(endpoint, data).then((response) => {
     store.commit(UPDATE_PAGE_STATE, response.value);
-  });
+  }).catch(console.error);
 }, 500); // only update the page list every 500ms
 
 /**


### PR DESCRIPTION
Hi! This PR allows for supporting three new options in the UiSelect input:

1. `list` - similar to the `list` option used for autocomplete, this will look for the list in /lists/ endpoint of your site and create the select options based on that list
2. `keys` - passthrough option for Keen to specify keys for input objects, especially for use when you don't control the input shape, e.g. lists. Defaults to `{label: 'name', value: 'value'}`
3. `storeRawData` - normally only the `value` of each option is stored, but with this option you can store the entire input object

The use-case for all three of these together is when you have a list on /lists/ that looks like:

```
rubrics:
  - sectionSlug: human-interest
    slug: relationships
    text: Relationships
  - sectionSlug: human-interest
    slug: work
    text: Work
  - sectionSlug: human-interest
    slug: care-and-feeding
    text: Care and Feeding
...
```

UiSelect can now fetch that list and use keys that don't have specific names. It can also store more than just the value (e.g. the entire resulting object).
