### PR TITLE
Fixes health check drawer not updating

### DIFF
--- a/lib/core-data/mutations.js
+++ b/lib/core-data/mutations.js
@@ -31,7 +31,8 @@ let vanityFunction = (state) => state,
     'OPEN_VALIDATION_LINK',
     'CREATE_COMPONENTS',
     'DUPLICATE_COMPONENT',
-    'DUPLICATE_COMPONENT_WITH_DATA'
+    'DUPLICATE_COMPONENT_WITH_DATA',
+    'VALIDATE'
   ];
 
 const mutations = _.assign({}, preloader, pageData, pageState, decorators, forms, components, toolbar, deepLinking, validators, undo, lists, drawers, nav, _.reduce(vanityMutations, (obj, name) => _.assign(obj, { [name]: vanityFunction }), {}));

--- a/lib/core-data/mutations.js
+++ b/lib/core-data/mutations.js
@@ -31,8 +31,7 @@ let vanityFunction = (state) => state,
     'OPEN_VALIDATION_LINK',
     'CREATE_COMPONENTS',
     'DUPLICATE_COMPONENT',
-    'DUPLICATE_COMPONENT_WITH_DATA',
-    'VALIDATE'
+    'DUPLICATE_COMPONENT_WITH_DATA'
   ];
 
 const mutations = _.assign({}, preloader, pageData, pageState, decorators, forms, components, toolbar, deepLinking, validators, undo, lists, drawers, nav, _.reduce(vanityMutations, (obj, name) => _.assign(obj, { [name]: vanityFunction }), {}));

--- a/lib/core-data/plugins.js
+++ b/lib/core-data/plugins.js
@@ -1,8 +1,8 @@
 import pubsub from '../component-data/pubsub';
 import undo from '../undo/plugin';
+import validation from '../validators/plugin';
 
 // note: external plugins might be added after DOMContentLoaded,
 // so we manually add them in edit.js
-const plugins = [pubsub, undo];
-
+const plugins = [pubsub, undo, validation];
 export default plugins;

--- a/lib/core-data/plugins.js
+++ b/lib/core-data/plugins.js
@@ -5,4 +5,5 @@ import validation from '../validators/plugin';
 // note: external plugins might be added after DOMContentLoaded,
 // so we manually add them in edit.js
 const plugins = [pubsub, undo, validation];
+
 export default plugins;

--- a/lib/drawers/drawer.vue
+++ b/lib/drawers/drawer.vue
@@ -139,9 +139,7 @@
       },
       tabType() {
         return this.name === 'publish' ? 'icon-and-text' : 'text';
-      }
-    },
-    asyncComputed: {
+      },
       tabs() {
         if (this.name === 'contributors') {
           return [{
@@ -169,19 +167,17 @@
             selected: true
           }];
         } else if (this.name === 'publish') {
-          return this.$store.dispatch('validate').then(() => {
-            const errors = _.get(this.$store, 'state.validation.errors');
+          const errors = _.get(this.$store, 'state.validation.errors');
 
-            return [{
-              title: 'Health',
-              component: 'health',
-              selected: errors.length > 0
-            }, {
-              title: 'Publish',
-              component: 'publish',
-              selected: errors.length === 0
-            }];
-          });
+          return [{
+            title: 'Health',
+            component: 'health',
+            selected: errors.length > 0
+          }, {
+            title: 'Publish',
+            component: 'publish',
+            selected: errors.length === 0
+          }];
         }
       }
     },

--- a/lib/validators/plugin.js
+++ b/lib/validators/plugin.js
@@ -10,12 +10,7 @@ const relevantMutations = [
     UPDATE_PAGE
   ],
   relevantDrawers = ['health', 'publish'],
-  validateDebounced = _.debounce(validate);
-
-function validate(store) {
-  store.dispatch('validate')
-      .then(() => store.commit('VALIDATE'));
-}
+  validate = _.debounce(store => store.dispatch('validate'), 250);
 
 export default (store) => {
   store.subscribe(({type}, state) => {
@@ -24,11 +19,8 @@ export default (store) => {
     if (!relevantDrawers.includes(_.get(state, 'ui.currentDrawer'))) return;
 
     // only revalidate on mutations we care about
-    if (relevantMutations.includes(type)) {
-      validateDebounced(store);
-    } else if (type !== 'VALIDATE') {
-      // commit vanity mutation so a plugin could conduct its own validations
-      store.commit('VALIDATE');
-    }
+    if (!relevantMutations.includes(type)) return;
+
+    validate(store);
   });
 };

--- a/lib/validators/plugin.js
+++ b/lib/validators/plugin.js
@@ -1,9 +1,7 @@
 import _ from 'lodash';
-import { UPDATE_PAGE_STATE } from '../page-state/mutationTypes';
 import { UPDATE_COMPONENT, REMOVE_COMPONENT, CREATE_COMPONENTS } from '../component-data/mutationTypes';
 import { OPEN_DRAWER } from '../drawers/mutationTypes';
 const relevantMutations = [
-    UPDATE_PAGE_STATE,
     UPDATE_COMPONENT,
     OPEN_DRAWER,
     REMOVE_COMPONENT,

--- a/lib/validators/plugin.js
+++ b/lib/validators/plugin.js
@@ -1,8 +1,14 @@
 import _ from 'lodash';
 import { UPDATE_PAGE_STATE } from '../page-state/mutationTypes';
-import { UPDATE_COMPONENT } from '../component-data/mutationTypes';
+import { UPDATE_COMPONENT, REMOVE_COMPONENT, CREATE_COMPONENTS } from '../component-data/mutationTypes';
 import { OPEN_DRAWER } from '../drawers/mutationTypes';
-const relevantMutations = [UPDATE_PAGE_STATE, UPDATE_COMPONENT, OPEN_DRAWER],
+const relevantMutations = [
+  UPDATE_PAGE_STATE,
+  UPDATE_COMPONENT,
+  OPEN_DRAWER,
+  REMOVE_COMPONENT,
+  CREATE_COMPONENTS
+],
   relevantDrawers = ['health', 'publish'];
 
 export default (store) => {

--- a/lib/validators/plugin.js
+++ b/lib/validators/plugin.js
@@ -3,12 +3,12 @@ import { UPDATE_PAGE_STATE } from '../page-state/mutationTypes';
 import { UPDATE_COMPONENT, REMOVE_COMPONENT, CREATE_COMPONENTS } from '../component-data/mutationTypes';
 import { OPEN_DRAWER } from '../drawers/mutationTypes';
 const relevantMutations = [
-  UPDATE_PAGE_STATE,
-  UPDATE_COMPONENT,
-  OPEN_DRAWER,
-  REMOVE_COMPONENT,
-  CREATE_COMPONENTS
-],
+    UPDATE_PAGE_STATE,
+    UPDATE_COMPONENT,
+    OPEN_DRAWER,
+    REMOVE_COMPONENT,
+    CREATE_COMPONENTS
+  ],
   relevantDrawers = ['health', 'publish'];
 
 export default (store) => {

--- a/lib/validators/plugin.js
+++ b/lib/validators/plugin.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { validate } from './actions';
 import { UPDATE_PAGE_STATE } from '../page-state/mutationTypes';
 import { UPDATE_COMPONENT } from '../component-data/mutationTypes';
 import { OPEN_DRAWER } from '../drawers/mutationTypes';

--- a/lib/validators/plugin.js
+++ b/lib/validators/plugin.js
@@ -10,6 +10,8 @@ const relevantMutations = [
     UPDATE_PAGE
   ],
   relevantDrawers = ['health', 'publish'],
+  // debounce because some of these relevant mutations may happen in short
+  // succession, but we only need to revalidate (an expensive operation) once
   validate = _.debounce(store => store.dispatch('validate'), 250);
 
 export default (store) => {

--- a/lib/validators/plugin.js
+++ b/lib/validators/plugin.js
@@ -1,23 +1,34 @@
 import _ from 'lodash';
 import { UPDATE_COMPONENT, REMOVE_COMPONENT, CREATE_COMPONENTS } from '../component-data/mutationTypes';
+import { UPDATE_PAGE } from '../page-data/mutationTypes';
 import { OPEN_DRAWER } from '../drawers/mutationTypes';
 const relevantMutations = [
     UPDATE_COMPONENT,
     OPEN_DRAWER,
     REMOVE_COMPONENT,
-    CREATE_COMPONENTS
+    CREATE_COMPONENTS,
+    UPDATE_PAGE
   ],
-  relevantDrawers = ['health', 'publish'];
+  relevantDrawers = ['health', 'publish'],
+  validateDebounced = _.debounce(validate);
+
+function validate(store) {
+  store.dispatch('validate')
+      .then(() => store.commit('VALIDATE'));
+}
 
 export default (store) => {
   store.subscribe(({type}, state) => {
 
-    // only revalidate on mutations we care about
-    if (!relevantMutations.includes(type)) return;
-
     // only revalidate if publish or health drawer is open
     if (!relevantDrawers.includes(_.get(state, 'ui.currentDrawer'))) return;
 
-    store.dispatch('validate');
+    // only revalidate on mutations we care about
+    if (relevantMutations.includes(type)) {
+      validateDebounced(store);
+    } else if (type !== 'VALIDATE') {
+      // commit vanity mutation so a plugin could conduct its own validations
+      store.commit('VALIDATE');
+    }
   });
 };

--- a/lib/validators/plugin.js
+++ b/lib/validators/plugin.js
@@ -1,0 +1,20 @@
+import _ from 'lodash';
+import { validate } from './actions';
+import { UPDATE_PAGE_STATE } from '../page-state/mutationTypes';
+import { UPDATE_COMPONENT } from '../component-data/mutationTypes';
+import { OPEN_DRAWER } from '../drawers/mutationTypes';
+const relevantMutations = [UPDATE_PAGE_STATE, UPDATE_COMPONENT, OPEN_DRAWER],
+  relevantDrawers = ['health', 'publish'];
+
+export default (store) => {
+  store.subscribe(({type}, state) => {
+
+    // only revalidate on mutations we care about
+    if (!relevantMutations.includes(type)) return;
+
+    // only revalidate if publish or health drawer is open
+    if (!relevantDrawers.includes(_.get(state, 'ui.currentDrawer'))) return;
+
+    store.dispatch('validate');
+  });
+};


### PR DESCRIPTION
Fixes #1127 

The problem is caused by the Drawer component attempting to update application state in one of its own data computation functions, rendering it unable to reliably detect relevant changes to application state, e.g. editing a new component will _not_ trigger a re-computation of the Drawer, which means validation state will not be re-computed. Revalidation needs to be more directly tied to the actions that should trigger it. As far as I understand, we need to revalidate (a potentially expensive operation) only in these scenarios:

1. User opens publish or health drawer
2. User updates, creates, or removes a component while publish/health drawer is open

One possible solution would be to add logic to some actions to revalidate if the drawer condition is met. An alternative approach, which I've taken in this PR, is to create a plugin that listens for relevant mutations. I slightly prefer this approach because it isolates the validation logic instead of spreading it among various actions.
