### PR TITLE
Fixes missing import preventing deletion of layout-level cmpts

### DIFF
--- a/lib/drawers/invisible-components.vue
+++ b/lib/drawers/invisible-components.vue
@@ -5,7 +5,7 @@
 <script>
   import _ from 'lodash';
   import { find } from '@nymag/dom';
-  import { getComponentName, refProp, refAttr } from '../utils/references';
+  import { getComponentName, refProp, refAttr, removeProp } from '../utils/references';
   import label from '../utils/label';
   import filterableList from '../utils/filterable-list.vue';
 


### PR DESCRIPTION
Fixes #1122, caused by a missing import.

This does not to relate to an ongoing error in which `Error Saving Layout` may appear if a layout-level component is added or removed.
