### PR TITLE
fix settings modal css weirdness

### DIFF
--- a/lib/forms/overlay.vue
+++ b/lib/forms/overlay.vue
@@ -79,7 +79,7 @@
     .input-container-wrapper {
       height: 100%;
       margin: 0;
-      overflow: scroll;
+      overflow: auto;
       padding: 0;
       width: 100%;
     }

--- a/styleguide/_forms.scss
+++ b/styleguide/_forms.scss
@@ -30,7 +30,7 @@
     display: flex;
     flex: 0 0 auto;
     flex-flow: row wrap;
-    overflow: scroll;
+    overflow: auto;
     padding: 18px;
   }
 


### PR DESCRIPTION
### Description of changes
The modal css was looking off so I fixed it. The scroll bar will show up when it's needed.

**Before:**
![editing__slate_magazine_-_politics__business__technology__and_the_arts](https://user-images.githubusercontent.com/458068/38206957-46e7e9e8-367a-11e8-87d8-2aa86ca19479.png)

**After:**
![editing__new_page](https://user-images.githubusercontent.com/458068/38204111-893e7d76-366f-11e8-9b53-0b0674dbd6dd.png)
