### PR TITLE
front-port #1149 to kiln 6

### DIFF
--- a/lib/forms/overlay.vue
+++ b/lib/forms/overlay.vue
@@ -79,7 +79,7 @@
     .input-container-wrapper {
       height: 100%;
       margin: 0;
-      overflow: scroll;
+      overflow: auto;
       padding: 0;
       width: 100%;
     }

--- a/styleguide/_forms.scss
+++ b/styleguide/_forms.scss
@@ -30,7 +30,7 @@
     display: flex;
     flex: 0 0 auto;
     flex-flow: row wrap;
-    overflow: scroll;
+    overflow: auto;
     padding: 18px;
   }
 


### PR DESCRIPTION
port #1149 to kiln 6, as we don't need `overflow: scroll` to enable smooth scrolling on mobile devices anymore