### PR TITLE
Removes delay in edit-toolbar hasChanges computation

### DIFF
--- a/lib/toolbar/edit-toolbar.vue
+++ b/lib/toolbar/edit-toolbar.vue
@@ -108,7 +108,6 @@
   import _ from 'lodash';
   import { mapState } from 'vuex';
   import isAfter from 'date-fns/is_after';
-  import addSeconds from 'date-fns/add_seconds';
   import toggleEdit from '../utils/toggle-edit';
   import { getItem } from '../utils/local';
   import progressBar from './progress.vue';

--- a/lib/toolbar/edit-toolbar.vue
+++ b/lib/toolbar/edit-toolbar.vue
@@ -152,7 +152,7 @@
           upTime = _.get(state, 'page.state.updateTime'); // latest updated timestamp
 
         if (pubTime && upTime) {
-          return isAfter(upTime, addSeconds(pubTime, 30)); // give it 30 seconds of leeway, in case there are slow updates to the server
+          return isAfter(upTime, pubTime);
         } else {
           return false;
         }


### PR DESCRIPTION
We don't need this delay anymore because we are no longer dependent on the server for updates. Resolves #1136.