### PR TITLE
Fixes timepicker component not populating value

### DIFF
--- a/lib/utils/timepicker.vue
+++ b/lib/utils/timepicker.vue
@@ -52,7 +52,7 @@
       }
     },
     mounted() {
-      this.timeValue = !!this.value && _.isString(this.value) ? this.value : '';
+      this.timeValue = _.isString(this.value) ? this.value : '';
     },
     methods: {
       // every time the value of the input changes, update the store

--- a/lib/utils/timepicker.vue
+++ b/lib/utils/timepicker.vue
@@ -52,7 +52,7 @@
       }
     },
     mounted() {
-      this.timeValue = !!this.value && _.isString(this.value) ? dateFormat(this.value, 'h:mm A') : '';
+      this.timeValue = !!this.value && _.isString(this.value) ? dateFormat(parseNaturalDate(this.value), 'HH:mm') : '';
     },
     methods: {
       // every time the value of the input changes, update the store

--- a/lib/utils/timepicker.vue
+++ b/lib/utils/timepicker.vue
@@ -52,7 +52,7 @@
       }
     },
     mounted() {
-      this.timeValue = !!this.value && _.isString(this.value) ? dateFormat(parseNaturalDate(this.value), 'HH:mm') : '';
+      this.timeValue = !!this.value && _.isString(this.value) ? this.value : '';
     },
     methods: {
       // every time the value of the input changes, update the store


### PR DESCRIPTION
Fixes #1110

The problem:
* The native HTML time input element expects `HH:mm` format for its `value` attribute. Supplying it a value that does not match this format will trigger a console warning and render an empty input.
* Currently, the `mounted` hook of the `timepicker` util component is transforming `value` into the `h:mm A` format and setting `timeValue` with the result. Note this is **not** what the native time input element accepts.

This is causing the timepicker to fail to reflect its current value.

The fix: Inside the `mounted` hook of the timepicker util component, do not change the date format of `value` when setting `timeValue`.