### PR TITLE
Add underline support to wysiwyg

### DIFF
--- a/inputs/wysiwyg-sanitize.js
+++ b/inputs/wysiwyg-sanitize.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import sanitize from 'sanitize-html';
 
-const allowedInlineTags = ['strong', 'em', 'a', 'br', 's', 'span', 'sup', 'sub', 'p'], // note: p gets parsed out in sanitizeInlineHTML
+const allowedInlineTags = ['strong', 'em', 'a', 'br', 's', 'span', 'sup', 'sub', 'p', 'u'], // note: p gets parsed out in sanitizeInlineHTML
   allowedBlockTags = allowedInlineTags.concat(['h1', 'h2', 'h3', 'h4', 'blockquote', 'ul', 'ol', 'li']),
   allowedAttributes = {
     a: ['href']

--- a/inputs/wysiwyg-sanitize.test.js
+++ b/inputs/wysiwyg-sanitize.test.js
@@ -15,7 +15,7 @@ describe('wysiwyg sanitize', () => {
 
     it('unescapes html tags', () => expect(fn('&lt;strong&gt;hi&lt;/strong&gt;')).to.equal('<strong>hi</strong>'));
 
-    it('allows strong, em, a (with href), br, s, sup, sub', () => {
+    it('allows strong, em, a (with href), br, s, sup, sub, u', () => {
       expectTag(fn, 'strong');
       expectTag(fn, 'em');
       expect(fn('<a href="http://google.com">hi</a>')).to.equal('<a href="http://google.com">hi</a>');
@@ -27,6 +27,7 @@ describe('wysiwyg sanitize', () => {
       expect(fn('<span class="kiln-phrase clay-designed">hi</span>')).to.equal('<span class="kiln-phrase clay-designed">hi</span>');
       expectTag(fn, 'sup');
       expectTag(fn, 'sub');
+      expectTag(fn, 'u');
     });
 
     it('transforms div to p (and converts to br)', () => {


### PR DESCRIPTION
This prevents the sanitizer to remove underline tag in order to allow underline tags in wysiwyg input component.