### PR TITLE
don't publish to components that have been deleted

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,7 @@ const path = require('path'),
       module: {
         rules: [{
           // todo: remove vue-unit (and update vue-unit dep) once vue-unit hits 0.3.0
-          test: /node_modules\/(vue-unit|keen-ui|striptags)\//,
+          test: /node_modules\/(@tom-kitchin\/vue-unit|keen-ui|striptags)\//,
           loader: 'babel-loader'
         }, {
           test: /\.js$/,

--- a/lib/component-data/pubsub.js
+++ b/lib/component-data/pubsub.js
@@ -281,9 +281,10 @@ function updateComponentInstances({ eventID, snapshot, pubData, store }) {
     } else {
       // we're updating other components on the page!
       // get all their instances from the store,
+      // (making sure to ignore deleted/empty instances)
       // then see if there's any scoping to the published stuff
       // then update them
-      const instances = _.filter(Object.keys(store.state.components), (uri) => _.includes(uri, `${componentRoute}${name}/`));
+      const instances = _.filter(Object.keys(store.state.components), (uri) => _.includes(uri, `${componentRoute}${name}/`) && !_.isEmpty(store.state.components[uri]));
 
       return Promise.all(_.compact(_.map(instances, (uri) => {
         if (scope && subscriberInScope({ scope, publisherURI, subscriberURI: uri, pubData, store })) {

--- a/lib/component-data/pubsub.test.js
+++ b/lib/component-data/pubsub.test.js
@@ -8,6 +8,7 @@ const data = { foo: 'harder', bar: 'better', baz: 'faster', qux: 'stronger' },
   bInstance = `${componentPrefix}B/instances/1`,
   cInstance = `${componentPrefix}C/instances/1`,
   dInstance = `${componentPrefix}D/instances/1`,
+  eInstance = `${componentPrefix}/E/instances/1`,
   aData = _.assign({}, data, { content: [{ [refProp]: bInstance }]}),
   bData = _.assign({}, data, { content: [{ [refProp]: cInstance }]}),
   eventID = 'abcdef',
@@ -107,7 +108,8 @@ describe('pubsub', () => {
           [aInstance]: aData,
           [bInstance]: bData,
           [cInstance]: data,
-          [dInstance]: data
+          [dInstance]: data,
+          [eInstance]: {}
         }
       }
     };
@@ -203,6 +205,14 @@ describe('pubsub', () => {
       lib.register('A', schemas.pub1);
       return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
         expect(store.dispatch.callCount).to.equal(0); // nothing else saves
+      });
+    });
+
+    it('does nothing if no subscribed component has been deleted', () => {
+      lib.register('A', schemas.pub1);
+      lib.register('E', schemas.sub1);
+      return fn(`${componentPrefix}A`, data, eventID, null, store).then(() => {
+        expect(store.dispatch.callCount).to.equal(0); // E/instances/1 does not save
       });
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,34 @@
         }
       }
     },
+    "@tom-kitchin/vue-unit": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@tom-kitchin/vue-unit/-/vue-unit-0.3.4.tgz",
+      "integrity": "sha512-Kx3+f67swg6AmCnVwC2S6xI7vnigLbPwhohyTvADnR3clOOrN1GEVxZKpjPHzwtKZGvzKuP3GlomimePAzXwKQ==",
+      "dev": true,
+      "requires": {
+        "lodash.kebabcase": "4.1.1",
+        "sinon": "2.4.1"
+      },
+      "dependencies": {
+        "sinon": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+          "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+          "dev": true,
+          "requires": {
+            "diff": "3.3.1",
+            "formatio": "1.2.0",
+            "lolex": "1.6.0",
+            "native-promise-only": "0.8.1",
+            "path-to-regexp": "1.7.0",
+            "samsam": "1.3.0",
+            "text-encoding": "0.6.4",
+            "type-detect": "4.0.3"
+          }
+        }
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -136,11 +164,6 @@
         "longest": "1.0.1",
         "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
       }
-    },
-    "amdefine": {
-      "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "dev": true
     },
     "ansi-escape-sequences": {
       "version": "3.0.0",
@@ -418,6 +441,16 @@
           "dev": true,
           "requires": {
             "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
+          },
+          "dependencies": {
+            "color-convert": {
+              "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+              "integrity": "sha512-cBdgwBveAUUexnimWkdqoTDizLaNhyWPRTvsNQI7eg2k5Y8sqQzymwc2V0qGhX0QdsPS9pqR5nOxEiMAE7SmHQ==",
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.2"
+              }
+            }
           }
         },
         "browserslist": {
@@ -499,9 +532,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
       "dev": true
     },
     "babel-code-frame": {
@@ -1768,6 +1801,15 @@
         "lodash": "3.10.1"
       },
       "dependencies": {
+        "dom-serializer": {
+          "version": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+          "integrity": "sha512-Fql7PX6CmQNVmoLfp7DlmvFMIL5cwLbm302SycA2iAMr95t1ITX4ilIsUG75rYtMiVLb4EMC5b2o7ApEpIXROg==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.1.3",
+            "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+          }
+        },
         "domhandler": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
@@ -2161,14 +2203,6 @@
       "requires": {
         "stream-connect": "1.0.2",
         "stream-via": "1.0.4"
-      }
-    },
-    "color-convert": {
-      "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha512-cBdgwBveAUUexnimWkdqoTDizLaNhyWPRTvsNQI7eg2k5Y8sqQzymwc2V0qGhX0QdsPS9pqR5nOxEiMAE7SmHQ==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.2"
       }
     },
     "color-name": {
@@ -2575,6 +2609,13 @@
           "dev": true,
           "requires": {
             "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+          },
+          "dependencies": {
+            "domelementtype": {
+              "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+              "integrity": "sha512-hhqPxYi0xK5i9fBMHEgWFxicJy62e5nxy0NdnjGE+DqovMcUsUbIPSkBzZ2O6PwYuwNGTf7bh/DMKmMdATSsTg==",
+              "dev": true
+            }
           }
         }
       }
@@ -3612,6 +3653,13 @@
           "dev": true,
           "requires": {
             "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+          },
+          "dependencies": {
+            "amdefine": {
+              "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+              "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+              "dev": true
+            }
           }
         },
         "uglify-js": {
@@ -3669,23 +3717,6 @@
         "void-elements": "2.0.1"
       }
     },
-    "dom-serializer": {
-      "version": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha512-Fql7PX6CmQNVmoLfp7DlmvFMIL5cwLbm302SycA2iAMr95t1ITX4ilIsUG75rYtMiVLb4EMC5b2o7ApEpIXROg==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
-        }
-      }
-    },
     "domain-browser": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
@@ -3693,8 +3724,9 @@
       "dev": true
     },
     "domelementtype": {
-      "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha512-hhqPxYi0xK5i9fBMHEgWFxicJy62e5nxy0NdnjGE+DqovMcUsUbIPSkBzZ2O6PwYuwNGTf7bh/DMKmMdATSsTg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+      "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
       "dev": true
     },
     "domhandler": {
@@ -3746,12 +3778,6 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
           "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-          "dev": true
-        },
-        "entities": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
           "dev": true
         }
       }
@@ -4745,12 +4771,6 @@
         "pinkie-promise": "2.0.1"
       },
       "dependencies": {
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
         "pinkie-promise": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
@@ -5946,11 +5966,6 @@
         "is-property": "1.0.2"
       }
     },
-    "get-caller-file": {
-      "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha512-A6srK23btrgde1mUYEzplvRPjdwkZXrHsIRNRZnG5p8ZEJHG+QB8ENw16MtH7NWiyDGiSF2giAlJpcls/y2wxQ==",
-      "dev": true
-    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
@@ -6061,19 +6076,8 @@
         "inflight": "1.0.6",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-        "once": "1.4.0",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
         "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-      },
-      "dependencies": {
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        }
       }
     },
     "glob-base": {
@@ -6247,12 +6251,6 @@
         "pinkie-promise": "2.0.1"
       },
       "dependencies": {
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
         "pinkie-promise": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
@@ -6271,14 +6269,6 @@
       "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        }
       }
     },
     "has-binary": {
@@ -6415,12 +6405,20 @@
       "integrity": "sha512-RSOwLNCnCLDRB9XpSfCzsLzzX8COezhJ3D4kRBNWh0NC/facp1hAMmM8zD7kC01My8vD6lGEbPMlbRW/EwGK5w==",
       "dev": true,
       "requires": {
-        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+        "domelementtype": "1.3.0",
         "domhandler": "2.4.1",
         "domutils": "1.7.0",
         "entities": "1.1.1",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "readable-stream": "2.2.9"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+          "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+          "dev": true
+        }
       }
     },
     "http-errors": {
@@ -6852,14 +6850,6 @@
       "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
-      },
-      "dependencies": {
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        }
       }
     },
     "is-fullwidth-code-point": {
@@ -8190,14 +8180,6 @@
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
     },
-    "lcid": {
-      "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
-      "dev": true,
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
-    },
     "lcov-parse": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
@@ -8238,25 +8220,10 @@
         "strip-bom": "2.0.0"
       },
       "dependencies": {
-        "error-ex": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-          "dev": true,
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
-        },
         "graceful-fs": {
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "parse-json": {
@@ -8272,12 +8239,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
@@ -8372,6 +8333,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
       "dev": true
     },
     "lodash.omit": {
@@ -8510,6 +8477,11 @@
         "readable-stream": "1.0.34"
       },
       "dependencies": {
+        "core-util-is": {
+          "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+          "dev": true
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -8526,13 +8498,6 @@
             "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "isarray": "0.0.1",
             "string_decoder": "0.10.31"
-          },
-          "dependencies": {
-            "core-util-is": {
-              "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-              "dev": true
-            }
           }
         },
         "string_decoder": {
@@ -12811,6 +12776,14 @@
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true
         },
+        "block-stream": {
+          "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+          }
+        },
         "fstream": {
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
@@ -14323,16 +14296,6 @@
             "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "fstream": "1.0.10",
             "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-          },
-          "dependencies": {
-            "block-stream": {
-              "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-              "integrity": "sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==",
-              "dev": true,
-              "requires": {
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-              }
-            }
           }
         },
         "text-table": {
@@ -14521,22 +14484,10 @@
       "requires": {
         "deep-is": "0.1.3",
         "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2",
         "wordwrap": "1.0.0"
-      },
-      "dependencies": {
-        "levn": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "dev": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        }
       }
     },
     "options": {
@@ -14696,12 +14647,6 @@
         "pinkie-promise": "2.0.1"
       },
       "dependencies": {
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
         "pinkie-promise": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
@@ -14773,12 +14718,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
@@ -15663,11 +15602,6 @@
         "kind-of": "4.0.0"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-          "integrity": "sha512-miqftL8E53hH0dtQqLdN+3JwClyJiITcif3gy+RiUlnLJUhEwdyRC29/gpYbuC9IhazGSnP8TjbvxWw2AZylWQ==",
-          "dev": true
-        },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -15684,6 +15618,13 @@
               "dev": true,
               "requires": {
                 "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              },
+              "dependencies": {
+                "is-buffer": {
+                  "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                  "integrity": "sha512-miqftL8E53hH0dtQqLdN+3JwClyJiITcif3gy+RiUlnLJUhEwdyRC29/gpYbuC9IhazGSnP8TjbvxWw2AZylWQ==",
+                  "dev": true
+                }
               }
             }
           }
@@ -16066,10 +16007,10 @@
       "dev": true,
       "requires": {
         "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
+        "aws4": "1.7.0",
         "caseless": "0.11.0",
         "combined-stream": "1.0.6",
-        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+        "extend": "3.0.1",
         "forever-agent": "0.6.1",
         "form-data": "2.1.4",
         "har-validator": "2.0.6",
@@ -16085,12 +16026,15 @@
         "tough-cookie": "2.3.2",
         "tunnel-agent": "0.4.3",
         "uuid": "3.0.1"
+      },
+      "dependencies": {
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+          "dev": true
+        }
       }
-    },
-    "require-directory": {
-      "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true
     },
     "require-from-string": {
       "version": "1.2.1",
@@ -18128,6 +18072,12 @@
             "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
             "string-width": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -18137,14 +18087,41 @@
                 "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                 "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                 "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+                  "dev": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "wrap-ansi": {
+              "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+              "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
               }
             }
           }
-        },
-        "code-point-at": {
-          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
-          "dev": true
         },
         "decamelize": {
           "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -18165,14 +18142,6 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
         },
         "load-json-file": {
           "version": "2.0.0",
@@ -18195,6 +18164,16 @@
             "execa": "0.7.0",
             "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "mem": "1.1.0"
+          },
+          "dependencies": {
+            "lcid": {
+              "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+              "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
+              "dev": true,
+              "requires": {
+                "invert-kv": "1.0.0"
+              }
+            }
           }
         },
         "path-type": {
@@ -18254,22 +18233,6 @@
             }
           }
         },
-        "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            }
-          }
-        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -18310,6 +18273,23 @@
             "which-module": "2.0.0",
             "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
             "yargs-parser": "7.0.0"
+          },
+          "dependencies": {
+            "get-caller-file": {
+              "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+              "integrity": "sha512-A6srK23btrgde1mUYEzplvRPjdwkZXrHsIRNRZnG5p8ZEJHG+QB8ENw16MtH7NWiyDGiSF2giAlJpcls/y2wxQ==",
+              "dev": true
+            },
+            "require-directory": {
+              "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+              "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+              "dev": true
+            },
+            "y18n": {
+              "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha512-Vd1yWKYGMtzFB6bAuTI7/POwJnwQStQXOe1PW1GmjUZgkaKYGc6/Pl3IDGFgplEklF65niuwBHeS5yve4+U01Q==",
+              "dev": true
+            }
           }
         },
         "yargs-parser": {
@@ -18368,55 +18348,6 @@
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
       }
     },
     "window-size": {
@@ -18439,15 +18370,6 @@
       "requires": {
         "reduce-flatten": "1.0.1",
         "typical": "2.6.1"
-      }
-    },
-    "wrap-ansi": {
-      "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -18501,11 +18423,6 @@
     "xtend": {
       "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha512-iTwvhNBRetXWe81+VcIw5YeadVSWyze7uA7nVnpP13ulrpnJ3UfQm5ApGnrkmxDJFdrblRdZs0EvaTCIfei5oQ==",
-      "dev": true
-    },
-    "y18n": {
-      "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha512-Vd1yWKYGMtzFB6bAuTI7/POwJnwQStQXOe1PW1GmjUZgkaKYGc6/Pl3IDGFgplEklF65niuwBHeS5yve4+U01Q==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "vue-observe-visibility": "^0.3.1",
     "vue-style-loader": "^3.0.3",
     "vue-template-compiler": "^2.5.9",
-    "vue-unit": "github:tom-kitchin/vue-unit",
+    "@tom-kitchin/vue-unit": "^0.3.4",
     "vuex": "^3.0.0",
     "webpack": "^3.8.1",
     "whatwg-fetch": "^2.0.3"

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import Vue from 'vue';
 import Vuex from 'vuex';
-import { beforeEachHooks, afterEachHooks, mount } from 'vue-unit/src';
+import { beforeEachHooks, afterEachHooks, mount } from '@tom-kitchin/vue-unit';
 import * as logger from '../lib/utils/log'; // allow us to stub the default
 
 const testsContext = require.context('../', true, /^\.\/(lib|inputs)\/.*?\.test\.js$/);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,7 +93,7 @@ module.exports = {
   module: {
     rules: [{
       // todo: remove vue-unit (and update vue-unit dep) once vue-unit hits 0.3.0
-      test: /node_modules\/(vue-unit|keen-ui|striptags|clayutils)\//,
+      test: /node_modules\/(@tom-kitchin\/vue-unit|keen-ui|striptags|clayutils)\//,
       loader: 'babel-loader'
     }, {
       test: /\.js$/,


### PR DESCRIPTION
* prevents publishing to component instances that have been deleted from the store, by checking them when updating subscribers
* updates `vue-unit` dependency to a more stable version
* fixes #1191