### PR TITLE
fix variations and checking for settings group

### DIFF
--- a/lib/core-data/get-variations.js
+++ b/lib/core-data/get-variations.js
@@ -1,7 +1,23 @@
 import _ from 'lodash';
-import logger from '../utils/log';
 
-const log = logger(__filename);
+/**
+ * update a schema with a settings group if the component does not have one,
+ * otherwise return the schema unchanged
+ *
+ * @param {object} schema
+ * @returns {object}
+**/
+function createSettings(schema) {
+  let processedSchema = schema;
+
+  if (!_.has(processedSchema, '_groups.settings')) {
+    _.set(processedSchema, '_groups.settings', {
+      fields: []
+    });
+  }
+
+  return processedSchema;
+}
 
 /**
  * adds a 'componentVariation' field to the components schema. This function
@@ -49,28 +65,6 @@ function addField(schema, componentVariations) {
   } else {
     return _.set(processedSchema, 'componentVariation', variationField);
   }
-}
-
-/**
- * update a schema with a settings group if the component does not have one else
- * return the schema unchanged
- *
- * @param {object} schema
- * @returns {object}
-**/
-function createSettings(schema) {
-  let processedSchema = schema;
-
-  if (!_.has(processedSchema, '_groups')) {
-    _.set(processedSchema, '_groups', {
-      settings: {
-        fields: []
-      }
-    });
-    log.debug('Kiln created a settings group to this schema because it was missing.', { action: 'addSettings'});
-  }
-
-  return processedSchema;
 }
 
 /**

--- a/lib/core-data/groups.js
+++ b/lib/core-data/groups.js
@@ -118,3 +118,19 @@ export function get(uri, path) {
     throw new Error(`No group or field found at '${path}' (in ${getComponentName(uri)})`);
   }
 }
+
+/**
+ * check to see if a group exists, failing gracefully if it doesn't
+ * @param  {string}  uri
+ * @param  {string}  path
+ * @return {Boolean}
+ */
+export function has(uri, path) {
+  try {
+    get(uri, path); // this will return a field/group or throw an error
+
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/lib/core-data/groups.test.js
+++ b/lib/core-data/groups.test.js
@@ -163,4 +163,44 @@ describe('groups', () => {
       } });
     });
   });
+
+  describe('has', () => {
+    const fn = lib.has;
+
+    it('returns false if field not found in schema', () => {
+      components.getData.returns({ bar });
+      components.getSchema.returns({});
+      expect(fn('foo', 'bar')).to.equal(false);
+    });
+
+    it('returns true if field not found in data', () => {
+      components.getData.returns({});
+      components.getSchema.returns({ bar: {} });
+      expect(fn('foo', 'bar')).to.equal(true);
+    });
+
+    it('returns true for a single field', () => {
+      components.getData.returns({ bar });
+      components.getSchema.returns({ bar: { _has: 'text' } });
+      expect(fn('foo', 'bar')).to.equal(true);
+    });
+
+    it('returns true for a group', () => {
+      const baz = {
+        fields: ['foo', 'bar'],
+        sections: [general(['foo', 'bar'])],
+        _placeholder: true // this should be merged into the resulting schema
+      };
+
+      components.getData.returns({ foo, bar });
+      components.getSchema.returns({
+        foo: {},
+        bar: {},
+        _groups: {
+          settings: baz
+        }
+      });
+      expect(fn('foo', 'settings')).to.equal(true);
+    });
+  });
 });

--- a/lib/decorators/selector.vue
+++ b/lib/decorators/selector.vue
@@ -208,6 +208,7 @@
   import _ from 'lodash';
   import getRect from 'element-client-rect';
   import { getSchema, getData } from '../core-data/components';
+  import { has as hasGroup } from '../core-data/groups';
   import { getComponentName, componentListProp } from '../utils/references';
   import { getComponentEl } from '../utils/component-elements';
   import label from '../utils/label';
@@ -267,7 +268,7 @@
         return Object.keys(_.get(window, 'kiln.selectorButtons', {}));
       },
       hasSettings() {
-        return _.has(this.schema, '_groups.settings');
+        return hasGroup(this.uri, 'settings');
       },
       hasDuplicateComponent() {
         return this.hasAddComponent && !_.get(this.$store, 'state.ui.metaKey');

--- a/lib/forms/overlay.vue
+++ b/lib/forms/overlay.vue
@@ -147,9 +147,10 @@
   import { mapState } from 'vuex';
   import velocity from 'velocity-animate/velocity.min.js';
   import { getSchema, getData } from '../core-data/components';
+  import { has as hasGroup } from '../core-data/groups';
   import label from '../utils/label';
   import logger from '../utils/log';
-  import { fieldProp, groupsProp, getComponentName, componentListProp } from '../utils/references';
+  import { fieldProp, getComponentName, componentListProp } from '../utils/references';
   import { getComponentEl } from '../utils/component-elements';
   import field from './field.vue';
   import UiIconButton from 'keen/UiIconButton';
@@ -219,7 +220,7 @@
       },
       componentLabel: (state) => label(getComponentName(state.ui.currentForm.uri)),
       hasSettings(state) {
-        return state.ui.currentForm.path !== 'settings' && _.has(this.schema, `${groupsProp}.settings`);
+        return state.ui.currentForm.path !== 'settings' && hasGroup(state.ui.currentForm.uri, 'settings');
       },
       customButtons() {
         return Object.keys(_.get(window, 'kiln.selectorButtons', {}));

--- a/lib/utils/filterable-list-item.vue
+++ b/lib/utils/filterable-list-item.vue
@@ -103,11 +103,10 @@
 </template>
 
 <script>
-  import _ from 'lodash';
   import UiIconButton from 'keen/UiIconButton';
   import UiRippleInk from 'keen/UiRippleInk';
-  import { isComponent, getComponentName } from './references';
-  import { getSchema } from '../core-data/components';
+  import { isComponent } from './references';
+  import { has as hasGroup } from '../core-data/groups';
 
   export default {
     props: ['item', 'index', 'onClick', 'onSettings', 'onDelete', 'onReorder', 'focused', 'active', 'selected', 'focusOnIndex', 'setActive', 'settingsTitle'],
@@ -117,9 +116,7 @@
     computed: {
       hasSettings() {
         if (isComponent(this.item.id)) {
-          const schema = getSchema(getComponentName(this.item.id));
-
-          return _.has(schema, '_groups.settings');
+          return hasGroup(this.item.id, 'settings');
         } else {
           return true; // settings icon checks for onSettings() before displaying
         }


### PR DESCRIPTION
if `settings` didn't exist on a component, other parts of kiln will _not_ know that there are relevant variations that could be edited. this PR fixes that, and makes the settings checking more consistent across kiln.