### PR TITLE
Confirm reason 2

### DIFF
--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -163,10 +163,10 @@ export function saveComponent(store, {uri, data, eventID, snapshot, prevData}) {
  * remove a component from its parent
  * note: removes from parent component OR page
  * @param  {object} store
- * @param  {Element} el    inside the component to delete
+ * @param  {Element} data   el || {el, msg} where el is the component to delete
  * @return {Promise}
  */
-export function removeComponent(store, data) { // eslint-disable-line
+export function removeComponent(store, data) {
   const el = data.el || data,
     componentEl = getComponentEl(el),
     uri = componentEl && componentEl.getAttribute(refAttr),

--- a/lib/component-data/actions.js
+++ b/lib/component-data/actions.js
@@ -166,14 +166,16 @@ export function saveComponent(store, {uri, data, eventID, snapshot, prevData}) {
  * @param  {Element} el    inside the component to delete
  * @return {Promise}
  */
-export function removeComponent(store, el) {
-  const componentEl = getComponentEl(el),
+export function removeComponent(store, data) { // eslint-disable-line
+  const el = data.el || data,
+    componentEl = getComponentEl(el),
     uri = componentEl && componentEl.getAttribute(refAttr),
     parentEl = getParentComponent(componentEl),
     parentURI = parentEl && parentEl.getAttribute(layoutAttr) || parentEl.getAttribute(refAttr),
     path = componentEl && componentEl.parentNode && componentEl.parentNode.getAttribute(editAttr),
     list = getData(parentURI, path),
-    prevURI = getPrevComponent(componentEl) && getPrevComponent(componentEl).getAttribute(refAttr);
+    prevURI = getPrevComponent(componentEl) && getPrevComponent(componentEl).getAttribute(refAttr),
+    msg = data.msg || '';
 
   let newList = [],
     promise;
@@ -197,7 +199,7 @@ export function removeComponent(store, el) {
   }
 
   return promise.then(() => {
-    store.commit(REMOVE_COMPONENT, {uri});
+    store.commit(REMOVE_COMPONENT, msg ? {uri, msg} : {uri});
     return find(`[${refAttr}="${prevURI}"]`);
   });
 }

--- a/lib/component-data/actions.test.js
+++ b/lib/component-data/actions.test.js
@@ -5,6 +5,7 @@ import * as components from '../core-data/components';
 import * as componentElements from '../utils/component-elements';
 import * as queue from '../core-data/queue';
 import * as lib from './actions';
+import * as dom from '@nymag/dom';
 
 describe('component-data actions', () => {
   const uri = 'domain.com/_components/foo',
@@ -105,5 +106,37 @@ describe('component-data actions', () => {
         expect(store.dispatch).to.not.have.been.calledWith('setFixedPoint');
       });
     });
+  });
+
+  describe('removeComponent', () => {
+    const fn = lib.removeComponent,
+      parentEl = dom.create('<div data-uri="domain.com/_components/foo" data-editable="settings"></div>'),
+      el = dom.create('<div data-uri="domain.com/_components/bar"></div>'),
+      dataWithEl = {el: el, msg: 'testing'};
+
+    it('accepts an element as the second argument', () => {
+      componentElements.getComponentEl.returns(el);
+      componentElements.getParentComponent.returns(parentEl);
+      components.getData.returns(Promise.resolve([]));
+      model.save.returns(Promise.resolve());
+
+      return fn(store, data).then(() => {
+        expect(store.commit.called).to.equal(true);
+        expect(store.commit).to.have.been.calledWith('REMOVE_COMPONENT', { uri: 'domain.com/_components/bar' });
+      });
+    });
+
+    it('it accepts and object containing `el` and `msg` properties as the second argument', () => {
+      componentElements.getComponentEl.returns(el);
+      componentElements.getParentComponent.returns(parentEl);
+      components.getData.returns(Promise.resolve([]));
+      model.save.returns(Promise.resolve());
+
+      return fn(store, dataWithEl).then(() => {
+        expect(store.commit.called).to.equal(true);
+        expect(store.commit).to.have.been.calledWith('REMOVE_COMPONENT', { uri: 'domain.com/_components/bar', msg: 'testing' });
+      });
+    });
+
   });
 });

--- a/lib/decorators/selector.vue
+++ b/lib/decorators/selector.vue
@@ -379,13 +379,13 @@
         if (shouldConfirm) {
           this.$store.dispatch('openModal', {
             title: 'Remove Component',
-            type: 'type-confirm',
+            type: 'type-reason',
             data: {
               text: `Are you sure you want to remove this <strong>${this.componentName}</strong>?`,
               name: this.componentName,
-              onConfirm: () => {
+              onConfirm: (input) => {
                 this.$store.dispatch('unselect');
-                return this.$store.dispatch('unfocus').then(() => this.$store.dispatch('removeComponent', el));
+                return this.$store.dispatch('unfocus').then(() => this.$store.dispatch('removeComponent', {el: el, msg: input}));
               }
             }
           });

--- a/lib/drawers/head-components.vue
+++ b/lib/drawers/head-components.vue
@@ -70,8 +70,8 @@
             data: {
               text: `Are you sure you want to remove this <strong>${name}</strong>?`,
               name: name,
-              onConfirm: () => {
-                this.$store.dispatch('removeHeadComponent', componentNode);
+              onConfirm: (input) => {
+                this.$store.dispatch('removeHeadComponent', {el: componentNode, msg: input});
               }
             }
           });

--- a/lib/drawers/invisible-components.vue
+++ b/lib/drawers/invisible-components.vue
@@ -66,8 +66,8 @@
             data: {
               text: `Are you sure you want to remove this <strong>${name}</strong>?`,
               name: name,
-              onConfirm: () => {
-                this.$store.dispatch('removeComponent', componentEl);
+              onConfirm: (input) => {
+                this.$store.dispatch('removeComponent', {el: componentEl, msg: input});
               }
             }
           });

--- a/lib/forms/overlay.vue
+++ b/lib/forms/overlay.vue
@@ -387,9 +387,9 @@
             data: {
               text: `Are you sure you want to remove this <strong>${componentName}</strong>?`,
               name: componentName,
-              onConfirm: () => {
+              onConfirm: (input) => {
                 this.$store.dispatch('unselect');
-                return this.$store.dispatch('unfocus').then(() => this.$store.dispatch('removeComponent', el));
+                return this.$store.dispatch('unfocus').then(() => this.$store.dispatch('removeComponent', {el: el, msg: input}));
               }
             }
           });

--- a/lib/toolbar/simple-modal.vue
+++ b/lib/toolbar/simple-modal.vue
@@ -29,6 +29,7 @@
   import addPageModal from './add-page-modal.vue';
   import addUserModal from './add-user-modal.vue';
   import typeConfirmModal from './type-confirm-modal.vue';
+  import typeReasonModal from './type-reason-modal.vue';
 
   const noscrollClass = 'noscroll',
     htmlElement = document.documentElement;
@@ -93,7 +94,8 @@
       'add-contributor': addContributorModal,
       'add-page': addPageModal,
       'add-user': addUserModal,
-      'type-confirm': typeConfirmModal
+      'type-confirm': typeConfirmModal,
+      'type-reason': typeReasonModal
     })
   };
 </script>

--- a/lib/toolbar/type-reason-modal.vue
+++ b/lib/toolbar/type-reason-modal.vue
@@ -1,0 +1,64 @@
+<style lang="sass">
+  .type-reason {
+    .type-reason-input {
+      margin: 8px 0 16px;
+    }
+
+    .ui-reason__footer {
+      justify-content: flex-end;
+
+      .ui-button {
+        margin-left: 16px;
+      }
+    }
+  }
+</style>
+
+<template>
+  <div class="ui-reason type-reason">
+    <div class="ui-reason__message" v-html="data.text"></div>
+    <div class="ui-reason__message">This component was marked as critical and is not frequently deleted. Please specify a reason for removal.</div>
+    <ui-textbox class="type-reason-input" v-model="input" @keydown-enter="onEnter"></ui-textbox>
+    <div class="ui-reason__footer">
+      <ui-button ref="confirmButton" color="primary" :disabled="incorrectInput" @click="confirm">Submit</ui-button>
+      <ui-button ref="denyButton" @click="deny">Cancel</ui-button>
+    </div>
+  </div>
+</template>
+
+<script>
+  import UiTextbox from 'keen/UiTextbox';
+  import UiButton from 'keen/UiButton';
+
+  export default {
+    props: ['data'],
+    data() {
+      return {
+        input: ''
+      };
+    },
+    computed: {
+      incorrectInput() {
+        return !this.input.length;
+      }
+    },
+    methods: {
+      onEnter() {
+        if (!this.incorrectInput) {
+          this.confirm();
+        }
+      },
+      confirm() {
+        this.$emit('close');
+        return this.data.onConfirm(this.input);
+      },
+      deny() {
+        this.$emit('close');
+      }
+    },
+    components: {
+      UiTextbox,
+      UiButton
+    }
+  };
+</script>


### PR DESCRIPTION
[Github Issue](https://app.zenhub.com/workspace/o/clay/clay-kiln/issues/1177)

Rewires `_confirmRemoval` to prompt the user for a reason for deleting a component instead of asking the user to confirm the name of the component