### PR TITLE
fetch styles when adding new components

### DIFF
--- a/lib/component-data/create.js
+++ b/lib/component-data/create.js
@@ -1,14 +1,15 @@
-// note: creation is purely client-side, now that we're generating unique IDs on both the client and server
 import _ from 'lodash';
 import cuid from 'cuid';
+import { create as createElement } from '@nymag/dom';
 import store from '../core-data/store';
 import { UPDATE_COMPONENT, ADD_DEFAULT_DATA, ADD_SCHEMA } from './mutationTypes';
 import { getDefaultData, getSchema, getModel, getData } from '../core-data/components';
 import { save as modelSave, render as modelRender } from './model';
 import { isDefaultComponent, getComponentName, refProp, componentRoute, schemaRoute, instancesRoute } from '../utils/references';
-import { getObject, getSchema as getSchemaFromAPI, getText } from '../core-data/api';
+import { getObject, getSchema as getSchemaFromAPI } from '../core-data/api';
 import { convertSchema, hasAnyBehaviors } from '../core-data/behaviors2input';
 import { props } from '../utils/promises';
+import { uriToUrl } from '../utils/urls';
 
 /**
  * get default data for a component, from the store or an api call
@@ -33,40 +34,78 @@ function resolveDefaultData(name) {
 }
 
 /**
- * append styles to the head of the page
- * @param  {string} styles
+ * fetch styleguide styles, falling back to _default styles
+ * @param  {string} prefix
+ * @param  {string} name       or variation
+ * @param  {string} styleguide
  */
-function appendToHead(styles) {
-  const head = document.getElementsByTagName('head')[0],
-    el = document.createElement('style');
+function fetchStyleguideFallback(prefix, name, styleguide) {
+  const styleguidePath = `${prefix}/css/${name}.${styleguide}.css`,
+    defaultPath = `${prefix}/css/${name}._default.css`,
+    head = document.getElementsByTagName('head')[0],
+    styleguideLink = createElement(`<link rel="stylesheet" type="text/css" href="${styleguidePath}" />`);
 
-  el.appendChild(document.createTextNode(styles));
-  head.appendChild(el);
+  styleguideLink.onerror = () => {
+    // only load the _default styleguide if the site's styleguide doesn't have styles for this component
+    const defaultLink = createElement(`<link rel="stylesheet" type="text/css" href="${defaultPath}" />`);
+
+    head.appendChild(defaultLink);
+  };
+
+  // attempt to load styleguide's styles
+  head.appendChild(styleguideLink);
+}
+
+/**
+ * fetch styleguide styles for a component (and variations),
+ * falling back to using the '_default' styleguide
+ * todo: currently this loads ALL variations, but we want to be more selective in the future
+ * @param  {string} prefix     of site
+ * @param  {string} name       of component
+ * @param  {string} styleguide used by site
+ * @param  {array} variations of component styles (both from site styleguide and from _default)
+ */
+function fetchStyleguideStyles(prefix, name, styleguide, variations) {
+  fetchStyleguideFallback(prefix, name, styleguide);
+
+  _.each(variations, (variation) => fetchStyleguideFallback(prefix, variation, styleguide));
+}
+
+/**
+ * fetch legacy (non-styleguide) styles for a component
+ * @param  {string} prefix of site
+ * @param  {string} name   of component
+ * @param  {string} slug   of site
+ */
+function fetchLegacyStyles(prefix, name, slug) {
+  const baseStylePath = `${prefix}/css/${name}.css`,
+    siteStylePath = `${prefix}/css/${name}.${slug}.css`,
+    head = document.getElementsByTagName('head')[0],
+    baseLink = createElement(`<link rel="stylesheet" type="text/css" href="${baseStylePath}" />`),
+    siteLink = createElement(`<link rel="stylesheet" type="text/css" href="${siteStylePath}" />`);
+
+  head.appendChild(baseLink);
+  head.appendChild(siteLink);
 }
 
 /**
  * fetch styles for new components
  * @param  {string} name of component
- * @return {Promise}
  */
 function fetchComponentStyles(name) {
   const prefix = _.get(store, 'state.site.prefix'),
-    slug = _.get(store, 'state.site.slug'),
-    baseStylePath = `${prefix}/css/${name}.css`,
-    siteStylePath = `${prefix}/css/${name}.${slug}.css`;
+    styleguide = _.get(store, 'state.site.styleguide'),
+    variations = _.get(store, `state.componentVariations['${name}']`),
+    slug = _.get(store, 'state.site.slug');
 
-  return props({
-    base: getText(baseStylePath).catch(_.noop),
-    site: getText(siteStylePath).catch(_.noop)
-  }).then(({ base, site }) => {
-    if (base) {
-      appendToHead(base);
-    }
-
-    if (site) {
-      appendToHead(site);
-    }
-  });
+  if (styleguide) {
+    // site has a styleguide! attempt to load component + variation styles,
+    // falling back to using the '_default' styleguide
+    fetchStyleguideStyles(uriToUrl(prefix), name, styleguide, variations);
+  } else {
+    // legacy: site has no styleguide, so load <component>.css and <component>.<site>.css
+    fetchLegacyStyles(uriToUrl(prefix), name, slug);
+  }
 }
 
 /**

--- a/lib/component-data/create.js
+++ b/lib/component-data/create.js
@@ -93,7 +93,7 @@ function fetchLegacyStyles(prefix, name, slug) {
  * @param  {string} name of component
  */
 function fetchComponentStyles(name) {
-  const prefix = _.get(store, 'state.site.prefix'),
+  const prefix = _.get(store, 'state.site.prefix', ''), // default to emptystring for testing
     styleguide = _.get(store, 'state.site.styleguide'),
     variations = _.get(store, `state.componentVariations['${name}']`, []),
     slug = _.get(store, 'state.site.slug');

--- a/lib/component-data/create.js
+++ b/lib/component-data/create.js
@@ -95,7 +95,7 @@ function fetchLegacyStyles(prefix, name, slug) {
 function fetchComponentStyles(name) {
   const prefix = _.get(store, 'state.site.prefix'),
     styleguide = _.get(store, 'state.site.styleguide'),
-    variations = _.get(store, `state.componentVariations['${name}']`),
+    variations = _.get(store, `state.componentVariations['${name}']`, []),
     slug = _.get(store, 'state.site.slug');
 
   if (styleguide) {

--- a/lib/component-data/create.test.js
+++ b/lib/component-data/create.test.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import * as store from '../core-data/store';
 import * as components from '../core-data/components';
 import * as api from '../core-data/api';
@@ -91,18 +90,6 @@ describe('component creator', () => {
     return lib([{ name: 'foo' }]).then(() => {
       expect(model.save).to.have.been.called;
       expect(model.render).to.have.been.called;
-    });
-  });
-
-  it('fetches base component styles for new components', () => {
-    components.getSchema.returns(null);
-    api.getSchema.returns(Promise.resolve({}));
-    components.getDefaultData.returns({ a: 'b' });
-    components.getModel.returns(null);
-    api.getText.returns(Promise.resolve('.foobarbaz { color: red; }')); // base and site
-    return lib([{ name: 'foobarbaz' }]).then(() => {
-      expect(api.getText.callCount).to.equal(2);
-      expect(_.last(document.getElementsByTagName('head')[0].children).textContent).to.equal('.foobarbaz { color: red; }');
     });
   });
 


### PR DESCRIPTION
* updates component creation to support new styleguides
* refactors legacy style fetching to use `<link>` tags rather than inlining styles (matching how edit mode works nowadays)
* supports both site styleguides and `_default` styleguide, as well as variations in both
* only loads `_default` styles if site styleguide does not contain styles for specified component