### PR TITLE
Magic button trim

### DIFF
--- a/inputs/magic-button-transformers.js
+++ b/inputs/magic-button-transformers.js
@@ -93,7 +93,9 @@ export default {
    * @returns {string}
    */
   formatUrl(data, format) {
-    var datafield = toPlainText(data).toLowerCase().replace(/[^\w]/g, '-').replace(/--+/g, '-');
+    var data = data.trim(),
+      datafield = toPlainText(data).toLowerCase().replace(/[^\w]/g, '-').replace(/--+/g, '-');
+
 
     if (_.isString(format) && !_.isEmpty(format)) {
       return format.replace(/\$DATAFIELD/g, datafield);

--- a/inputs/magic-button-transformers.js
+++ b/inputs/magic-button-transformers.js
@@ -93,9 +93,7 @@ export default {
    * @returns {string}
    */
   formatUrl(data, format) {
-    var data = data.trim(),
-      datafield = toPlainText(data).toLowerCase().replace(/[^\w]/g, '-').replace(/--+/g, '-');
-
+    var datafield = toPlainText(data).trim().toLowerCase().replace(/[^\w]/g, '-').replace(/--+/g, '-');
 
     if (_.isString(format) && !_.isEmpty(format)) {
       return format.replace(/\$DATAFIELD/g, datafield);


### PR DESCRIPTION
Magic button should trim leading and trailing spaces from a string before creating a url.  Otherwise, it will put dashes at the beginning and end of a slug whose input string contains extra space (e.g. `mysite.com/-weather-`)