### PR TITLE
trim leading and trailing spaces from input and add test

### DIFF
--- a/inputs/magic-button-transformers.js
+++ b/inputs/magic-button-transformers.js
@@ -93,7 +93,7 @@ export default {
    * @returns {string}
    */
   formatUrl(data, format) {
-    var datafield = toPlainText(data).toLowerCase().replace(/[^\w]/g, '-').replace(/--+/g, '-');
+    var datafield = toPlainText(data).trim().toLowerCase().replace(/[^\w]/g, '-').replace(/--+/g, '-');
 
     if (_.isString(format) && !_.isEmpty(format)) {
       return format.replace(/\$DATAFIELD/g, datafield);

--- a/inputs/magic-button-transformers.test.js
+++ b/inputs/magic-button-transformers.test.js
@@ -78,6 +78,10 @@ describe('magic-button transformers', () => {
       expect(fn('TV Show', format)).to.equal('http://pixel.nymag.com/imgs/custom/tvrecaps/recaps-tv-show-160x160.png');
     });
 
+    it('trims leading and trailing spaces', () => {
+      expect(fn(' TV Show ', format)).to.equal('http://pixel.nymag.com/imgs/custom/tvrecaps/recaps-tv-show-160x160.png');
+    });
+
     it('removes html tags', () => {
       expect(fn('Foo<br /> <h1>Bar</h1>', format)).to.equal('http://pixel.nymag.com/imgs/custom/tvrecaps/recaps-foo-bar-160x160.png');
     });


### PR DESCRIPTION
Magic button should trim leading and trailing spaces from a string before creating a url.  Otherwise, it will put dashes at the beginning and end of a slug whose input string contains extra space (e.g. `mysite.com/-weather-`)

(Duplicate of the accidentally closed https://github.com/clay/clay-kiln/pull/1219)