### PR TITLE
fix issues with falsy values, object comparison

### DIFF
--- a/lib/forms/field-helpers.js
+++ b/lib/forms/field-helpers.js
@@ -229,14 +229,12 @@ function shouldBeRevealedBySite(sites, currentSlug) {
  * @return {boolean}
  */
 function shouldBeRevealedByData(data, operator, value, values) {
-  if (value) {
+  if (value !== undefined) {
     // compare against a single value
     return compare({ data, operator, value });
   } else {
     // compare against multiple values. will return true if any of them match
-    return _.some(values, (v) => {
-      return compare({ data, operator, value: v });
-    });
+    return _.some(values, (v) => compare({ data, operator, value: v }));
   }
 }
 

--- a/lib/utils/comparators.js
+++ b/lib/utils/comparators.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 
 const operators = {
-  '===': (l, r) => l === r,
-  '!==': (l, r) => l !== r,
+  '===': (l, r) => _.isEqual(l, r), // allow comparing by value
+  '!==': (l, r) => !_.isEqual(l, r),
   '<': (l, r) => l < r,
   '>': (l, r) => l > r,
   '<=': (l, r) => l <= r,

--- a/lib/utils/comparators.test.js
+++ b/lib/utils/comparators.test.js
@@ -56,6 +56,14 @@ describe('comparators', () => {
       expect(fn({data: 1, operator: '!==', value: 0})).toBe(true);
     });
 
+    test('compares equality by value', () => {
+      let obj1 = { a: 'b' },
+        obj2 = { a: 'b' };
+
+      expect(obj1).not.toBe(obj2);
+      expect(fn({ data: obj1, operator: '===', value: obj2 })).toBe(true);
+    });
+
     test('compares range', () => {
       expect(fn({data: 1, operator: '<', value: 2})).toBe(true);
       expect(fn({data: 1, operator: '>', value: 0})).toBe(true);


### PR DESCRIPTION
* fixes issue when comparing against a falsy `value`
* fixes issues when comparing objects and arrays (`===` comparator now runs `_.isEqual` which checks equality by value)