### PR TITLE
update page list + queue library to remove race conditions

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -401,8 +401,6 @@ A group of segmented buttons allowing the user to select one (or more!) of a few
 
 Each option should be an object with `title` and `values` properties. The `values` should be an array of objects with `icon`, `text`, and `value` properties, which will be passed into each `segmented-button`.
 
-Options may also contain a `_reveal` property containing rules for when they should display. [The config is the same as the field-level `_reveal` property.](https://claycms.gitbooks.io/kiln/editing-components.html#reveal)
-
 > #### info::Data Format
 >
 > By default, the data for this field will be the selected option's `value`. If multiple selection is turned on, it'll be an object with boolean values keyed to each option's `value`, similar to `checkbox-group`.

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -401,6 +401,8 @@ A group of segmented buttons allowing the user to select one (or more!) of a few
 
 Each option should be an object with `title` and `values` properties. The `values` should be an array of objects with `icon`, `text`, and `value` properties, which will be passed into each `segmented-button`.
 
+Options may also contain a `_reveal` property containing rules for when they should display. [The config is the same as the field-level `_reveal` property.](https://claycms.gitbooks.io/kiln/editing-components.html#reveal)
+
 > #### info::Data Format
 >
 > By default, the data for this field will be the selected option's `value`. If multiple selection is turned on, it'll be an object with boolean values keyed to each option's `value`, similar to `checkbox-group`.

--- a/lib/core-data/queue.js
+++ b/lib/core-data/queue.js
@@ -34,17 +34,18 @@ export function isPending() {
 export function add(fn, args, type) {
   const cacheHash = fn.name + JSON.stringify(args);
 
-  let newPromise;
-
   // every time we add a function to the queue, check to see if it's already added
   if (queueCache[cacheHash]) {
     return queueCache[cacheHash]; // this will resolve when it's time to resolve
   } else {
-    // create a function that returns a promise.
-    // it warms the cache and gets passed to the queue
-    newPromise = fn.apply(null, args);
-    queueCache[cacheHash] = newPromise;
-    return queue.add(() => newPromise).then(function (res) {
+    return queue.add(() => {
+      // create a function that returns a promise.
+      // it warms the cache and gets passed to the queue
+      const newPromise = fn.apply(null, args);
+
+      queueCache[cacheHash] = newPromise;
+      return newPromise;
+    }).then(function (res) {
       // after individual promise resolves, remove it from the cache
       delete queueCache[cacheHash];
       // if there are no more pending promises, make sure to finish the progress bar

--- a/lib/core-data/queue.test.js
+++ b/lib/core-data/queue.test.js
@@ -9,17 +9,21 @@ describe('queue', () => {
 
       function update(prop) {
         data[prop]++;
+        if (prop === 'a') {
+          expect(data.a).toBe(1);
+          expect(data.b).toBe(0);
+        } else {
+          expect(data.a).toBe(1);
+          expect(data.b).toBe(1);
+        }
         return Promise.resolve();
       }
 
-      fn(update, ['a']).then(() => {
-        expect(data.a).toBe(1);
-        expect(data.b).toBe(0);
-      });
-      return fn(update, ['b']).then(() => {
-        expect(data.a).toBe(1);
-        expect(data.b).toBe(1);
-      });
+      return Promise.resolve(data)
+        .then(() => {
+          fn(update, ['a']);
+          fn(update, ['b']);
+        });
     });
 
     test('caches promises', () => {

--- a/lib/page-state/actions.js
+++ b/lib/page-state/actions.js
@@ -1,17 +1,13 @@
 import _ from 'lodash';
 import { postJSON } from '../core-data/api';
+import updatedStore from '../core-data/store';
 import { UPDATE_PAGE_STATE } from './mutationTypes';
 import { searchRoute, replaceVersion } from '../utils/references';
+import { add as addToQueue } from '../core-data/queue';
 
 /**
  * @module page-state
  */
-
-const postPageList = _.debounce((endpoint, data, store) => {
-  return postJSON(endpoint, data).then((response) => {
-    store.commit(UPDATE_PAGE_STATE, response.value);
-  }).catch(console.error);
-}, 500); // only update the page list every 500ms
 
 /**
  * updates the state's history array to make sure the latest item is an
@@ -52,19 +48,14 @@ export function updateHistoryWithEditAction(state, currentUser) {
 }
 
 /**
- * update page list with data provided from pubsub
- * note: if called without data, this just updates the updateTime and user
- * (e.g. when saving components in the page)
- * note: if called with a user, it adds the user (with updateTime) to the page (instead of current user)
- * @param  {object} store
- * @param  {object} [data]
- * @returns {Promise}
+ * run page list updates sequentially, grabbing from the store after each to prevent race conditions
+ * @param  {string} prefix
+ * @param  {string} uri
+ * @param  {object} data
+ * @return {Promise}
  */
-export function updatePageList(store, data = {}) {
-  const prefix = _.get(store, 'state.site.prefix'),
-    uri = _.get(store, 'state.page.uri');
-
-  let fullCurrentState = _.get(store, 'state.page.state'),
+function sequentialUpdate(prefix, uri, data) {
+  let fullCurrentState = _.get(updatedStore, 'state.page.state'),
     userToAdd = data.user, // grab this (if it exists), so we can omit it from the data
     currentState = _.omit(fullCurrentState, ['published', 'scheduled', 'publishTime', 'scheduledTime']),
     // never try to save these to the page list, since amphora-search will handle them server-side
@@ -75,7 +66,7 @@ export function updatePageList(store, data = {}) {
     // currentUser is usually the current logged-in user, but may be a different person
     // if you're explicitly adding another user to the page.
     // the logic for updating the users list is the same, though
-    currentUser = userToAdd ? _.assign({}, userToAdd, { updateTime }) : _.assign({}, _.get(store, 'state.user'), { updateTime }),
+    currentUser = userToAdd ? _.assign({}, userToAdd, { updateTime }) : _.assign({}, _.get(updatedStore, 'state.user'), { updateTime }),
     userIndex = _.findIndex(users, (user) => user.username === currentUser.username),
     newState = _.assign({}, currentState, _.omit(data, ['user']), { updateTime });
 
@@ -93,10 +84,28 @@ export function updatePageList(store, data = {}) {
 
   newState.history = updateHistoryWithEditAction(newState, _.omit(currentUser, 'updateTime'));
 
-  return postPageList(`${prefix}/_pagelist`, {
+  return postJSON(`${prefix}/_pagelist`, {
     url: uri,
     value: newState
-  }, store);
+  }).then((response) => {
+    updatedStore.commit(UPDATE_PAGE_STATE, response.value);
+  }).catch(console.error);
+}
+
+/**
+ * update page list with data provided from pubsub
+ * note: if called without data, this just updates the updateTime and user
+ * (e.g. when saving components in the page)
+ * note: if called with a user, it adds the user (with updateTime) to the page (instead of current user)
+ * @param  {object} store
+ * @param  {object} [data]
+ * @returns {Promise}
+ */
+export function updatePageList(store, data = {}) {
+  const prefix = _.get(store, 'state.site.prefix'),
+    uri = _.get(store, 'state.page.uri');
+
+  return addToQueue(sequentialUpdate, [prefix, uri, data], 'save');
 }
 
 /**


### PR DESCRIPTION
* updating the page list had a race condition when both the `title` and `authors` were being updated
* new page list updating will queue the updates, and make them check the store for the latest state after each one runs (removing that race condition)
* updated the queue service to fix an issue with promises not actually waiting to run before the previous has finished