### PR TITLE
fix various issues with numbers and reveal

### DIFF
--- a/inputs/text.vue
+++ b/inputs/text.vue
@@ -109,7 +109,9 @@
     methods: {
       // every time the value of the input changes, update the store
       update(val) {
-        if (_.isString(val)) {
+        if (this.isNumerical) {
+          val = parseFloat(val, 10);
+        } else if (_.isString(val)) {
           // remove 'line separator' and 'paragraph separator' characters from text inputs
           // (not visible in text editors, but get added when pasting from pdfs and old systems)
           val = val.replace(/(\u2028|\u2029)/g, '');

--- a/lib/forms/field-helpers.js
+++ b/lib/forms/field-helpers.js
@@ -229,12 +229,12 @@ function shouldBeRevealedBySite(sites, currentSlug) {
  * @return {boolean}
  */
 function shouldBeRevealedByData(data, operator, value, values) {
-  if (typeof value !== 'undefined') {
-    // compare against a single value
-    return compare({ data, operator, value });
-  } else {
+  if (!_.isEmpty(values)) {
     // compare against multiple values. will return true if any of them match
     return _.some(values, (v) => compare({ data, operator, value: v }));
+  } else {
+    // compare against a single value (note: value might be undefined if we're comparing with certain operators)
+    return compare({ data, operator, value });
   }
 }
 

--- a/lib/forms/field-helpers.js
+++ b/lib/forms/field-helpers.js
@@ -200,12 +200,16 @@ export function getValidationError(data, validate, store, name) { // eslint-disa
     return shouldBeRequired(validate, store, name) ? messages.required : null;
   } else if (!isFieldEmpty && validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig'))) {
     return messages.pattern;
-  } else if (!isFieldEmpty && validate.min && isLengthy) {
-    return length < validate.min ? messages.min : '';
+  } else if (!isFieldEmpty && isLengthy) {
+    // if we're checking stuff with lengths (strings + arrays),
+    // DON'T check for values against min/max
+    if (validate.min && length < validate.min) {
+      return messages.min;
+    } else if (validate.max && length > validate.max) {
+      return messages.max;
+    }
   } else if (!isFieldEmpty && validate.min && data < validate.min) {
     return messages.min;
-  } else if (!isFieldEmpty && validate.max && isLengthy) {
-    return length > validate.max ? messages.max : '';
   } else if (!isFieldEmpty && validate.max && data > validate.max) {
     return messages.max;
   }

--- a/lib/forms/field-helpers.js
+++ b/lib/forms/field-helpers.js
@@ -127,13 +127,14 @@ export function getFieldData(store, prop, path, uri) {
  * generate error messages from validation rules,
  * specifying default error messages
  * @param  {object} [validate]
+ * @param {boolean} [isLengthy]
  * @return {object}
  */
-function errorMessages(validate = {}) {
+function errorMessages(validate = {}, isLengthy) {
   return {
-    required: validate.requiredMessage || 'Please fill out this field.',
-    min: validate.minMessage || `Please enter at least ${validate.min} characters.`,
-    max: validate.maxMessage || `Please enter fewer than ${validate.max + 1} characters`,
+    required: validate.requiredMessage || 'Please fill out this field',
+    min: validate.minMessage || isLengthy ? `Please enter at least ${validate.min} characters` : `Please enter a value of ${validate.min} or above`,
+    max: validate.maxMessage || isLengthy ? `Please enter fewer than ${validate.max + 1} characters` : `Please enter a value of ${validate.max} or below`,
     pattern: validate.patternMessage || `Please match the pattern "/${validate.pattern}/ig"`
   };
 }
@@ -176,7 +177,8 @@ function cleanValue(value) {
  */
 export function getValidationError(data, validate, store, name) { // eslint-disable-line
   const isFieldEmpty = isEmpty(data),
-    messages = errorMessages(validate),
+    isLengthy = _.isString(data) || _.isArray(data),
+    messages = errorMessages(validate, isLengthy),
     strValue = _.isString(data) && cleanValue(data);
 
   let length;
@@ -187,7 +189,7 @@ export function getValidationError(data, validate, store, name) { // eslint-disa
 
   // if we're dealing with strings or arrays, we'll want to check min/max against the length
   // (if it's numbers, dates, or other things, we want to check min/max against the value directly)
-  if (strValue || _.isArray(data)) {
+  if (isLengthy) {
     length = (strValue || data).length;
   }
 
@@ -198,12 +200,12 @@ export function getValidationError(data, validate, store, name) { // eslint-disa
     return shouldBeRequired(validate, store, name) ? messages.required : null;
   } else if (!isFieldEmpty && validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig'))) {
     return messages.pattern;
-  } else if (!isFieldEmpty && validate.min && length < validate.min) {
-    return messages.min;
+  } else if (!isFieldEmpty && validate.min && isLengthy) {
+    return length < validate.min ? messages.min : '';
   } else if (!isFieldEmpty && validate.min && data < validate.min) {
     return messages.min;
-  } else if (!isFieldEmpty && validate.max && length > validate.max) {
-    return messages.max;
+  } else if (!isFieldEmpty && validate.max && isLengthy) {
+    return length > validate.max ? messages.max : '';
   } else if (!isFieldEmpty && validate.max && data > validate.max) {
     return messages.max;
   }

--- a/lib/utils/comparators.js
+++ b/lib/utils/comparators.js
@@ -46,14 +46,15 @@ export function isEmpty(val) {
  * @return {boolean}
  */
 export function compare({ data, operator, value }) {
-  if (!operator && value === undefined) {
+  if (!operator && typeof value === 'undefined') {
     // if neither operator or value are specified, default to
     // checking if field has a value
     return !isEmpty(data);
-  } else if (!operator) {
-    // if no operator, default to equal
+  } else if (!operator && typeof value !== 'undefined') {
+    // if no operator (but there is a value!), default to equal
     return operators['==='](data, value);
   } else if (operators[operator]) {
+    // if there's an operator, use it (value may be undefined, e.g. when using the 'truthy'/'empty'/etc operators)
     return operators[operator](data, value);
   } else {
     throw new Error(`Unknown operator: ${operator}`);


### PR DESCRIPTION
* fix issue where `input type=number` wasn't being auto-cast to numbers, breaking validation
* fix #1245, reveal config issues with non-value operators (e.g. `falsy`)
* fix #1244, certain strings being considered as numbers when validating min/max
* added better default error messages for min/max on non-string/array values