### PR TITLE
Fix min validation for complex-list when is empty

### DIFF
--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -558,7 +558,7 @@ A basic text input. Can be single line or multi-line. Uses the float label patte
 * **help** - description / helper text for the field
 * **attachedButton** - an icon button that should be attached to the field, to allow additional functionality
 * **validate.required** - either `true` or an object that described the conditions that should make this field required
-* **validate.min** - minimum number (for `type=numer`) or length (for other types) that the field must meet
+* **validate.min** - minimum number (for `type=number`) or length (for other types) that the field must meet
 * **validate.max** - maximum number (for `type=number`) or length (for other types) that the field must not exceed
 * **validate.pattern** - regex pattern
 * **validate.requiredMessage** - will appear when required validation fails

--- a/inputs/text.vue
+++ b/inputs/text.vue
@@ -12,7 +12,7 @@
   * **help** - description / helper text for the field
   * **attachedButton** - an icon button that should be attached to the field, to allow additional functionality
   * **validate.required** - either `true` or an object that described the conditions that should make this field required
-  * **validate.min** - minimum number (for `type=numer`) or length (for other types) that the field must meet
+  * **validate.min** - minimum number (for `type=number`) or length (for other types) that the field must meet
   * **validate.max** - maximum number (for `type=number`) or length (for other types) that the field must not exceed
   * **validate.pattern** - regex pattern
   * **validate.requiredMessage** - will appear when required validation fails

--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -249,7 +249,7 @@ export function shouldBeRequired(field, componentData) {
           return true;
         } else {
           return false;
-        };
+        }
       } else {
         return false;
       }
@@ -293,7 +293,7 @@ export function isValid(field, componentData, type) { // eslint-disable-line
       case 'required': return !(validate.required === true && isFieldEmpty);
       case 'conditional-required': return !(_.isObject(validate.required) && shouldBeRequired(field, componentData) && isFieldEmpty);
       case 'pattern': return !(!isFieldEmpty && validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')));
-      case 'min': return !(!isFieldEmpty && validate.min && (length || fieldValue) < validate.min);
+      case 'min': return !(isFieldEmpty && validate.min || !isFieldEmpty && validate.min && (length || fieldValue) < validate.min);
       case 'max': return !(!isFieldEmpty && validate.max && (length || fieldValue) > validate.max);
       default: throw new Error(`Unsupported validation type: ${type}`);
     }
@@ -303,7 +303,7 @@ export function isValid(field, componentData, type) { // eslint-disable-line
     return !(validate.required === true && isFieldEmpty || // regular required
       _.isObject(validate.required) && shouldBeRequired(field, componentData) && isFieldEmpty || // conditional-required
       !isFieldEmpty && validate.pattern && !strValue.match(new RegExp(validate.pattern, 'ig')) || // pattern validation
-      !isFieldEmpty && validate.min && (length || fieldValue) < validate.min || // minimum length / value
+      isFieldEmpty && validate.min || !isFieldEmpty && validate.min && (length || fieldValue) < validate.min || // minimum length / value
       !isFieldEmpty && validate.max && (length || fieldValue) > validate.max); // maximum length / value
   }
 }


### PR DESCRIPTION
There was an issue where complex-list components were specified a minimum amount of fields were been checked as valid and allowing the page to be published.

```yml
validate:
      min: 1
      max: 4
```