### PR TITLE
support comparing against multiple values in conditional required validation

### DIFF
--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -232,6 +232,7 @@ export function shouldBeRequired(field, componentData) {
   const compareField = _.get(field, 'validate.required.field'),
     compareOperator = _.get(field, 'validate.required.operator'),
     compareValue = _.get(field, 'validate.required.value'),
+    compareValues = _.get(field, 'validate.required.values'),
     path = _.get(field, 'path'),
     pathArray = path.split('.');
 
@@ -256,6 +257,10 @@ export function shouldBeRequired(field, componentData) {
     });
   } else {
     comparePath = compareField;
+  }
+
+  if (!_.isEmpty(compareValues)) {
+    return _.some(compareValues, (v) => compare({ data: _.get(componentData, comparePath), operator: compareOperator, value: v }));
   }
 
   return compare({ data: _.get(componentData, comparePath), operator: compareOperator, value: compareValue });

--- a/lib/validators/helpers.test.js
+++ b/lib/validators/helpers.test.js
@@ -748,6 +748,18 @@ describe('validation helpers', () => {
         }}, { b: '' })).toBe(true);
     });
 
+    test('compares fields against an array of values', () => {
+      expect(fn({
+        path: 'a',
+        validate: {
+          required: {
+            field: 'b',
+            operator: '===',
+            values: ['foo', 'bar']
+          }
+        }}, { b: 'foo' })).toBe(true);
+    });
+
     test('compares complex-list field to root field', () => {
       expect(fn({
         path: 'a.0.b',


### PR DESCRIPTION
The kiln guide says that validate.required supports the same properties as `_reveal` to decide whether or not a field is required. This isn't exactly true as validate.required wasn't looking for a `values` array to compare against. Now it is.