### PR TITLE
numerical emptiness

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -45,6 +45,18 @@ Property | Description
 `utils` | various utilities, useful for plugins
 `validators` | object containing all validators. attach custom validators here
 
+### Custom Validators
+
+You may add custom validation to `window.kiln.validators`. A validator should export `label`, `description`, `type` (either `error` or `warning`), and a `validate` method. The `validate` method receives the whole page `state`, so validators can be extremely flexible.
+
+Most validators concern themselves with components and/or fields, and should make use of the helper functions in `kiln.utils.validationHelpers` such as `forEachComponent` and `forEachField`. The built-in validators such as [`required`](https://github.com/clay/clay-kiln/blob/master/lib/validators/built-in/required.js) are good examples to work off of.
+
+Validators must return an array of errors (or warnings), where each issue includes `uri`, and `field` properties. Optionally, an issue may include `location` (which creates a link to the relevant form) and `preview` (which displays context for an issue).
+
+> #### info::Validating The DOM
+>
+> While validators may do DOM lookups to determine validity, remember that DOM lookups are slow compared to reducing on the `state` object directly. Please keep this in mind when writing validators that only concern themselves with page/component/etc data.
+
 ### Utilities
 
 Kiln exports a number of JavaScript utils to the browser in the `window.kiln.utils` object.

--- a/docs/editing-components.md
+++ b/docs/editing-components.md
@@ -251,7 +251,7 @@ When comparing against multiple `values`, the comparison will be true if at leas
 
 > #### info::Deep Field Comparisons
 >
-> You can compare against deep fields (like `checkbox-group` or `complex-list`) by using dot-separated paths, e.g. `featureTypes.New York Magazine Story`. Don't worry about the spaces, as Kiln will parse it correctly to pull the relevant data.
+> You can compare against deep fields (like `checkbox-group` or `complex-list`) by using dot-separated paths, e.g. `featureTypes.New York Magazine Story`. Don't worry about the spaces, as Kiln will parse it correctly to pull the relevant data. Note that this only works against proper _fields_, not any arbitrary non-kiln property.
 
 ### Standard Input Arguments
 

--- a/inputs/text.vue
+++ b/inputs/text.vue
@@ -95,7 +95,7 @@
         return `${label(this.name, this.schema)}${this.isRequired ? '*' : ''}`;
       },
       errorMessage() {
-        const validationData = this.isNumerical ? parseFloat(this.data) : this.data;
+        const validationData = this.isNumerical && _.isNumber(this.data) ? parseFloat(this.data) : this.data;
 
         return getValidationError(validationData, this.args.validate, this.$store, this.name);
       },

--- a/lib/utils/comparators.js
+++ b/lib/utils/comparators.js
@@ -20,7 +20,7 @@ const operators = {
  * @param  {*}  val
  * @return {Boolean}
  */
-export function isEmpty(val) {
+export function isEmpty(val) { // eslint-disable-line
   if (_.isArray(val)) {
     // an array is empty if it has no items, if all of the items are considered empty, or if the item contains props that are considered empty
     // (e.g. complex-list items)
@@ -30,8 +30,8 @@ export function isEmpty(val) {
     return _.isEmpty(val) || _.every(val, (prop) => !prop);
   } else if (_.isString(val)) {
     return val.length === 0; // emptystring is empty
-  } else if (_.isNull(val) || _.isUndefined(val)) {
-    return true; // null and undefined are empty
+  } else if (_.isNull(val) || _.isUndefined(val) || _.isNaN(val)) {
+    return true; // null, undefined, and NaN are empty
   } else {
     // numbers, booleans, etc are never empty
     return false;

--- a/lib/utils/comparators.test.js
+++ b/lib/utils/comparators.test.js
@@ -31,6 +31,7 @@ describe('comparators', () => {
       'returns true if array with objects with empty props',
       () => expect(fn([{ foo: '' }])).toBe(true)
     );
+    test('returns true if NaN', () => expect(fn(NaN)).toBe(true));
   });
 
   describe('compare', () => {

--- a/lib/utils/filterable-list-item.vue
+++ b/lib/utils/filterable-list-item.vue
@@ -120,7 +120,7 @@
       <list-item-child
         v-for="(child, childIndex) in item.children"
         :child="child"
-        :key="child.id"
+        :key="`${child.id}-${childIndex}`"
         :secondaryActions="secondaryActions"
         :hasChildAction="hasChildAction"
         :parentIndex="index"

--- a/lib/utils/filterable-list.vue
+++ b/lib/utils/filterable-list.vue
@@ -99,7 +99,7 @@
           :item="item"
           :index="index"
           :selected="selectedIndex === index"
-          :key="item.id"
+          :key="`${item.id}-${index}`"
           :hasReorder="hasReorder"
           :hasRootAction="hasRootAction"
           :hasChildAction="hasChildAction"

--- a/lib/validators/built-in/max.js
+++ b/lib/validators/built-in/max.js
@@ -2,8 +2,8 @@ import _ from 'lodash';
 import labelUtil from '../../utils/label';
 import { forEachComponent, forEachField, labelComponent, isValid, getPlaintextValue } from '../helpers';
 
-export const label = 'Max Length',
-  description = 'Some fields must be less than a certain length for consistent formatting across all syndications',
+export const label = 'Max',
+  description = 'Some fields must be less than a certain length (or value)',
   type = 'error';
 
 export function validate(state) {

--- a/lib/validators/built-in/min.js
+++ b/lib/validators/built-in/min.js
@@ -2,8 +2,8 @@ import _ from 'lodash';
 import labelUtil from '../../utils/label';
 import { forEachComponent, forEachField, labelComponent, isValid, getPlaintextValue } from '../helpers';
 
-export const label = 'Min Length',
-  description = 'Some fields must be more than a certain length for consistent formatting across all syndications',
+export const label = 'Minimum',
+  description = 'Some fields must be more than a certain length (or value)',
   type = 'error';
 
 export function validate(state) {


### PR DESCRIPTION
* fix error when using filterable-lists with items that have duplicate keys (which you shouldn't do, but it shouldn't break the lists)
* fix issue when validating the emptiness of numerical inputs (NaN / null handled correctly)
* update min/max error messages to take into account value, not just length
* add docs for custom validators + reveal edge cases