### PR TITLE
Add 'size-of' Comparator

### DIFF
--- a/docs/editing-components.md
+++ b/docs/editing-components.md
@@ -244,7 +244,7 @@ When comparing against multiple `values`, the comparison will be true if at leas
 * `>=`
 * `typeof`
 * `regex`
-* `size-of`
+* `length-equals`
 * `empty` (only checks field data, no value needed)
 * `not-empty` (only checks field data, no value needed)
 * `truthy` (only checks field data, no value needed)

--- a/docs/editing-components.md
+++ b/docs/editing-components.md
@@ -244,6 +244,7 @@ When comparing against multiple `values`, the comparison will be true if at leas
 * `>=`
 * `typeof`
 * `regex`
+* `size-of`
 * `empty` (only checks field data, no value needed)
 * `not-empty` (only checks field data, no value needed)
 * `truthy` (only checks field data, no value needed)

--- a/docs/editing-components.md
+++ b/docs/editing-components.md
@@ -244,7 +244,9 @@ When comparing against multiple `values`, the comparison will be true if at leas
 * `>=`
 * `typeof`
 * `regex`
-* `length-equals`
+* `length-equals` (compares the length of strings and arrays)
+* `length-less-than` (compares the length of strings and arrays)
+* `length-greater-than` (compares the length of strings and arrays)
 * `empty` (only checks field data, no value needed)
 * `not-empty` (only checks field data, no value needed)
 * `truthy` (only checks field data, no value needed)

--- a/inputs/segmented-button-group.vue
+++ b/inputs/segmented-button-group.vue
@@ -159,7 +159,6 @@
         return !this.showError && this.args.help;
       },
       hasReveal() {
-        console.log('has reveal?', _.some(this.args.options, (option) => _.has(option, revealProp)));
         return _.some(this.args.options, (option) => _.has(option, revealProp));
       }
     },

--- a/lib/utils/comparators.js
+++ b/lib/utils/comparators.js
@@ -13,7 +13,7 @@ const operators = {
   'not-empty': (l) => !isEmpty(l),
   truthy: (l) => !!l,
   falsy: (l) => !!!l,
-  'size-of': (l, r) => _.size(l) === r
+  'length-equals': (l, r) => _.size(l) === r
 };
 
 /**

--- a/lib/utils/comparators.js
+++ b/lib/utils/comparators.js
@@ -12,7 +12,8 @@ const operators = {
   empty: (l) => isEmpty(l),
   'not-empty': (l) => !isEmpty(l),
   truthy: (l) => !!l,
-  falsy: (l) => !!!l
+  falsy: (l) => !!!l,
+  'size-of': (l, r) => _.size(l) === r
 };
 
 /**

--- a/lib/utils/comparators.js
+++ b/lib/utils/comparators.js
@@ -13,7 +13,9 @@ const operators = {
   'not-empty': (l) => !isEmpty(l),
   truthy: (l) => !!l,
   falsy: (l) => !!!l,
-  'length-equals': (l, r) => _.size(l) === r
+  'length-equals': (l, r) => _.size(l) === r,
+  'length-less-than': (l, r) => _.size(l) < r,
+  'length-greater-than': (l, r) => _.size(l) > r
 };
 
 /**

--- a/lib/utils/comparators.test.js
+++ b/lib/utils/comparators.test.js
@@ -92,12 +92,30 @@ describe('comparators', () => {
       expect(fn({data: false, operator: 'falsy'})).toBe(true);
     });
 
-    test('compares field size', () => {
+    test('compares field length equality', () => {
       expect(fn({data: [], operator: 'length-equals', value: 0})).toBe(true);
       expect(fn({data: ['a'], operator: 'length-equals', value: 1})).toBe(true);
       expect(fn({data: false, operator: 'length-equals', value: 0})).toBe(true);
       expect(fn({data: null, operator: 'length-equals', value: 0})).toBe(true);
       expect(fn({data: undefined, operator: 'length-equals', value: 0})).toBe(true);
+    });
+
+    test('compares field length less than', () => {
+      expect(fn({data: [], operator: 'length-less-than', value: 0})).toBe(false);
+      expect(fn({data: ['a'], operator: 'length-less-than', value: 0})).toBe(false);
+      expect(fn({data: ['a'], operator: 'length-less-than', value: 2})).toBe(true);
+      expect(fn({data: false, operator: 'length-less-than', value: 1})).toBe(true);
+      expect(fn({data: null, operator: 'length-less-than', value: 1})).toBe(true);
+      expect(fn({data: undefined, operator: 'length-less-than', value: 1})).toBe(true);
+    });
+
+    test('compares field length greater than', () => {
+      expect(fn({data: [], operator: 'length-greater-than', value: 0})).toBe(false);
+      expect(fn({data: ['a'], operator: 'length-greater-than', value: 1})).toBe(false);
+      expect(fn({data: ['a'], operator: 'length-greater-than', value: 0})).toBe(true);
+      expect(fn({data: false, operator: 'length-greater-than', value: 1})).toBe(false);
+      expect(fn({data: null, operator: 'length-greater-than', value: 1})).toBe(false);
+      expect(fn({data: undefined, operator: 'length-greater-than', value: 1})).toBe(false);
     });
   });
 });

--- a/lib/utils/comparators.test.js
+++ b/lib/utils/comparators.test.js
@@ -93,11 +93,11 @@ describe('comparators', () => {
     });
 
     test('compares field size', () => {
-      expect(fn({data: [], operator: 'size-of', value: 0})).toBe(true);
-      expect(fn({data: ['a'], operator: 'size-of', value: 1})).toBe(true);
-      expect(fn({data: false, operator: 'size-of', value: 0})).toBe(true);
-      expect(fn({data: null, operator: 'size-of', value: 0})).toBe(true);
-      expect(fn({data: undefined, operator: 'size-of', value: 0})).toBe(true);
+      expect(fn({data: [], operator: 'length-equals', value: 0})).toBe(true);
+      expect(fn({data: ['a'], operator: 'length-equals', value: 1})).toBe(true);
+      expect(fn({data: false, operator: 'length-equals', value: 0})).toBe(true);
+      expect(fn({data: null, operator: 'length-equals', value: 0})).toBe(true);
+      expect(fn({data: undefined, operator: 'length-equals', value: 0})).toBe(true);
     });
   });
 });

--- a/lib/utils/comparators.test.js
+++ b/lib/utils/comparators.test.js
@@ -91,5 +91,13 @@ describe('comparators', () => {
       expect(fn({data: [], operator: 'truthy'})).toBe(true);
       expect(fn({data: false, operator: 'falsy'})).toBe(true);
     });
+
+    test('compares field size', () => {
+      expect(fn({data: [], operator: 'size-of', value: 0})).toBe(true);
+      expect(fn({data: ['a'], operator: 'size-of', value: 1})).toBe(true);
+      expect(fn({data: false, operator: 'size-of', value: 0})).toBe(true);
+      expect(fn({data: null, operator: 'size-of', value: 0})).toBe(true);
+      expect(fn({data: undefined, operator: 'size-of', value: 0})).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Related to the outcome of https://github.com/clay/clay-kiln/issues/1258 this PR adds a new comparator `size-of` which is useful for triggering schema `_reveal` logic based on the size of a complex list.  Here's an example of a how this could be used:

```yml
description: |
  Sample Component

collection:
  _has:
    input: complex-list
    props:
      -
        prop: data
        _label: Data
        _has:
          input: text
          help: Some sample data url

collectionLayout:
  _label: Sample Collection Layout
  _has:
    input: segmented-button-group
    options:
      - title: 2 Images
        values:
          - icon: icon-thumbnail.svg
            text: Two Vertical
            value: two-vertical
          - icon: icon-thumbnail.svg
            text: Two Square
            value: two-square
        _reveal:
          field: collection
          operator: 'size-of'
          value: 2
      - title: 3 Images
        values:
          - icon: icon-thumbnail.svg
            text: Three Vertical
            value: three-vertical
          - icon: icon-thumbnail.svg
            text: Three Square
            value: three-square
        _reveal:
          field: collection
          operator: 'size-of'
          value: 3
  _reveal:
    field: collection
    operator: 'size-of'
    value: 0

_groups:
  settings:
    fields:
      - collection (Items)
      - collectionLayout (Item Layout)
```

With this operator it will now trigger the `_reveal` actions as makes changes and switches tabs.