### PR TITLE
fix #1271, open last used category

### DIFF
--- a/lib/nav/new-page.vue
+++ b/lib/nav/new-page.vue
@@ -15,6 +15,7 @@
   import { pagesRoute, htmlExt, editExt } from '../utils/references';
   import filterableList from '../utils/filterable-list.vue';
   import { sortPages } from '../lists/helpers';
+  import { setItem } from '../utils/local';
 
   export default {
     props: ['content'],
@@ -59,8 +60,11 @@
     },
     methods: {
       itemClick(id, title) {
+        const category = _.find(this.pages, (category) => _.find(category.children, (child) => child.id === id));
+
         this.$store.commit('CREATE_PAGE', title);
-        return this.$store.dispatch('createPage', id).then((url) => window.location.href = url);
+        return setItem('kiln-page-category', category.id) // save category so it'll be open next time
+          .then(() => this.$store.dispatch('createPage', id).then((url) => window.location.href = url));
       },
       editTemplate(id) {
         const prefix = _.get(this.$store, 'state.site.prefix');

--- a/lib/preloader/actions.js
+++ b/lib/preloader/actions.js
@@ -11,6 +11,7 @@ import normalize from '../utils/normalize-component-data';
 import getSites from './sites';
 import parseUrl from './parse-url';
 import { hasAnyBehaviors, convertSchema } from '../core-data/behaviors2input';
+import { getItem } from '../utils/local';
 
 /**
  * @module preloader
@@ -122,7 +123,8 @@ export default function preload({ commit, dispatch }) {
     layoutState: dispatch('fetchLayoutState', { uri: data._layoutRef, prefix: site.prefix, user: user }),
     pageData: getObject(data._self),
     allSites: getSites(site),
-  }).then(({ pageState, layoutState, pageData, allSites }) => {
+    favoritePageCategory: getItem('kiln-page-category')
+  }).then(({ pageState, layoutState, pageData, allSites, favoritePageCategory }) => {
     // register custom helpers
     window.kiln.helpers = window.kiln.helpers || {};
     _.forOwn(window.kiln.helpers, (helperFn, helperName) => {
@@ -155,6 +157,11 @@ export default function preload({ commit, dispatch }) {
       url: urlProps
     }));
     commit(LOADING_SUCCESS);
+    // if the user has a favorite new page category set,
+    // make sure it'll be in the state when they open that list
+    if (favoritePageCategory) {
+      commit('CHANGE_FAVORITE_PAGE_CATEGORY', favoritePageCategory);
+    }
     dispatch('createSnapshot');
     dispatch('finishProgress', getPageStatus(pageState));
   });

--- a/view.js
+++ b/view.js
@@ -12,6 +12,7 @@ import { PRELOAD_PENDING, LOADING_SUCCESS, PRELOAD_SITE, PRELOAD_ALL_SITES, PREL
 import { UPDATE_PAGE_STATE, UPDATE_PAGEURI } from './lib/page-state/mutationTypes';
 import { META_PRESS, META_UNPRESS } from './lib/preloader/mutationTypes';
 import { props } from './lib/utils/promises';
+import { getItem } from './lib/utils/local';
 import conditionalFocus from './directives/conditional-focus';
 import 'keen-ui/src/bootstrap'; // import this once, for KeenUI components
 
@@ -64,14 +65,20 @@ document.addEventListener('DOMContentLoaded', function () {
   props({
     pageState: store.dispatch('getListData', { uri: pageUri(), prefix: window.kiln.preloadSite.prefix }),
     allSites: getSites(window.kiln.preloadSite),
-    lists: store.dispatch('getList', 'new-pages')
-  }).then(({ pageState, allSites }) => {
+    lists: store.dispatch('getList', 'new-pages'),
+    favoritePageCategory: getItem('kiln-page-category')
+  }).then(({ pageState, allSites, favoritePageCategory }) => {
     store.commit(UPDATE_PAGE_STATE, pageState);
     store.commit(UPDATE_PAGEURI, pageUri());
     store.commit(PRELOAD_ALL_SITES, allSites);
     store.commit(PRELOAD_USER, window.kiln.preloadUser);
     store.commit(PRELOAD_URL, parseUrl());
     store.commit(LOADING_SUCCESS);
+    // if the user has a favorite new page category set,
+    // make sure it'll be in the state when they open that list
+    if (favoritePageCategory) {
+      store.commit('CHANGE_FAVORITE_PAGE_CATEGORY', favoritePageCategory);
+    }
   }).then(() => store.dispatch('parseURLHash')); // check for deep-linked clay menu
 
   // when ESC bubbles up to the document, close the current form or pane / unselect components


### PR DESCRIPTION
open the category of the previously-added page, when opening the New Page list in edit or view mode. Note that adding and removing pages will change this, but reloading the current page will reset it.