### PR TITLE
add focus to deep-linking

### DIFF
--- a/inputs/codemirror.vue
+++ b/inputs/codemirror.vue
@@ -99,7 +99,7 @@
   require('codemirror/addon/selection/active-line.js');
 
   export default {
-    props: ['name', 'data', 'schema', 'args'],
+    props: ['name', 'data', 'schema', 'args', 'initialFocus'],
     data() {
       return {
         isActive: false,
@@ -172,11 +172,17 @@
           }
         }),
         store = this.$store,
-        name = this.name;
+        name = this.name,
+        initialFocus = this.initialFocus;
 
       // refresh the codemirror instance after it instantiates
       // wait until it gets redrawn in the dom first
-      this.$nextTick(() => editor.refresh());
+      this.$nextTick(() => {
+        editor.refresh();
+        if (initialFocus === name) {
+          editor.focus();
+        }
+      });
 
       editor.on('change', (instance) => store.commit(UPDATE_FORMDATA, { path: name, data: instance.getValue() }));
 

--- a/inputs/complex-list-item.vue
+++ b/inputs/complex-list-item.vue
@@ -104,7 +104,7 @@
   <div class="complex-list-item" :class="{ 'is-current': isCurrentItem, 'is-expanded': isExpanded }" :ref="name" v-observe-visibility="visibilityChanged" @click.stop="onClick" @focusin.stop="onFocus">
     <transition name="complex-list-item-collapse" appear mode="out-in">
       <div key="expanded-visible" v-if="isVisible && isExpanded" class="complex-list-item-inner">
-        <field v-for="(field, fieldIndex) in fieldNames" :key="fieldIndex" :name="name + '.' + field" :data="fields[field]" :schema="fieldSchemas[field]"></field>
+        <field v-for="(field, fieldIndex) in fieldNames" :key="fieldIndex" :name="name + '.' + field" :data="fields[field]" :schema="fieldSchemas[field]" :initialFocus="initialFocus"></field>
         <div v-if="hasRequiredFields" class="required-footer">* Required fields</div>
           <div class="complex-list-item-actions">
             <div class="complex-list-item-actions-inner ui-button-group">
@@ -157,7 +157,8 @@
       'addItem',
       'removeItem',
       'currentItem',
-      'moveItem'
+      'moveItem',
+      'initialFocus'
     ],
     data() {
       return {

--- a/inputs/complex-list.vue
+++ b/inputs/complex-list.vue
@@ -93,6 +93,7 @@
           :addItem="addItem"
           :removeItem="removeItem"
           :moveItem="moveItem"
+          :initialFocus="initialFocus"
           @current="onCurrentChange">
         </item>
       </transition-group>
@@ -162,7 +163,7 @@
   }
 
   export default {
-    props: ['name', 'data', 'schema', 'args'],
+    props: ['name', 'data', 'schema', 'args', 'initialFocus'],
     data() {
       return {
         currentItem: _.isArray(this.data) ? this.data.length - 1 : 0,

--- a/inputs/inline.vue
+++ b/inputs/inline.vue
@@ -5,14 +5,14 @@
 </docs>
 
 <template>
-  <component is="wysiwyg" :name="name" :data="data" :schema="schema" :args="args"></component>
+  <component is="wysiwyg" :name="name" :data="data" :schema="schema" :args="args" :initialFocus="initialFocus"></component>
 </template>
 
 <script>
   import wysiwyg from './wysiwyg.vue';
 
   export default {
-    props: ['name', 'data', 'schema', 'args'],
+    props: ['name', 'data', 'schema', 'args', 'initialFocus'],
     data() {
       return {};
     },

--- a/inputs/simple-list-input.vue
+++ b/inputs/simple-list-input.vue
@@ -51,11 +51,10 @@
 
 <script>
   import _ from 'lodash';
-  import { isFirstField } from '../lib/forms/field-helpers';
   import autocomplete from './autocomplete.vue';
 
   export default {
-    props: ['items', 'allowRepeatedItems', 'autocomplete', 'currentItem', 'disabled'],
+    props: ['items', 'allowRepeatedItems', 'autocomplete', 'currentItem', 'disabled', 'isInitialFocus'],
     data() {
       return {
         val: '',
@@ -159,7 +158,7 @@
       }
     },
     mounted() {
-      if (isFirstField(this.$el)) {
+      if (this.isInitialFocus) {
         this.$refs.input.focus();
       }
     },

--- a/inputs/simple-list.vue
+++ b/inputs/simple-list.vue
@@ -109,6 +109,7 @@
             :autocomplete="args.autocomplete"
             :currentItem="currentItem"
             :disabled="isDisabled"
+            :isInitialFocus="initialFocus === name"
             @add="addItem"
             @select="selectItem"
             @focus="onFocus"
@@ -142,7 +143,7 @@
   const log = logger(__filename);
 
   export default {
-    props: ['name', 'data', 'schema', 'args'],
+    props: ['name', 'data', 'schema', 'args', 'initialFocus'],
     data() {
       return {
         isActive: false,

--- a/inputs/text.vue
+++ b/inputs/text.vue
@@ -50,13 +50,13 @@
 <script>
   import _ from 'lodash';
   import { UPDATE_FORMDATA } from '../lib/forms/mutationTypes';
-  import { setCaret, isFirstField, shouldBeRequired, getValidationError } from '../lib/forms/field-helpers';
+  import { setCaret, shouldBeRequired, getValidationError } from '../lib/forms/field-helpers';
   import label from '../lib/utils/label';
   import UiTextbox from 'keen/UiTextbox';
   import attachedButton from './attached-button.vue';
 
   export default {
-    props: ['name', 'data', 'schema', 'args'],
+    props: ['name', 'data', 'schema', 'args', 'initialFocus'],
     data() {
       return {
         isDisabled: false
@@ -133,11 +133,11 @@
       }
     },
     mounted() {
-      if (isFirstField(this.$el)) {
+      if (this.initialFocus === this.name) {
         const offset = _.get(this, '$store.state.ui.currentForm.initialOffset');
 
         this.$nextTick(() => {
-          if (_.includes(['text', 'search', 'url', 'tel', 'password', 'multi-line'], this.args.type)) {
+          if (_.includes(['text', 'search', 'url', 'tel', 'password', 'multi-line'], this.type)) {
             // selection range is only permitted on text-like input types
             setCaret(this.$el, offset, this.data);
           }

--- a/inputs/wysiwyg.vue
+++ b/inputs/wysiwyg.vue
@@ -196,7 +196,7 @@
   import { getComponentName, refAttr, editAttr } from '../lib/utils/references';
   import { UPDATE_FORMDATA } from '../lib/forms/mutationTypes';
   import { getPrevComponent, getNextComponent, getParentComponent, getComponentEl, getFieldEl } from '../lib/utils/component-elements';
-  import { isFirstField, shouldBeRequired, getValidationError } from '../lib/forms/field-helpers';
+  import { shouldBeRequired, getValidationError } from '../lib/forms/field-helpers';
   import label from '../lib/utils/label';
   import { sanitizeInlineHTML, sanitizeMultiComponentHTML, sanitizeBlockHTML } from './wysiwyg-sanitize';
   import { splitParagraphs, matchComponents, generatePasteRules } from './wysiwyg-paste';
@@ -263,7 +263,7 @@
   };
 
   export default {
-    props: ['name', 'data', 'schema', 'args'],
+    props: ['name', 'data', 'schema', 'args', 'initialFocus'],
     data() {
       return {
         editorData: this.data || '',
@@ -738,7 +738,7 @@
 
       this.editor = editor; // save reference to the editor
 
-      if (isFirstField(this.$el)) {
+      if (this.initialFocus === this.name) {
         const offset = _.get(this, '$store.state.ui.currentForm.initialOffset');
 
         this.$nextTick(() => {

--- a/lib/decorators/actions.js
+++ b/lib/decorators/actions.js
@@ -108,7 +108,7 @@ export function unfocus({ commit, dispatch, state }) {
   }
 }
 
-export function focus(store, { uri, path, el, offset, appendText, pos }) {
+export function focus(store, { uri, path, initialFocus, el, offset, appendText, pos }) {
   const isComponentSaving = _.get(store, 'state.ui.currentlySaving');
 
   offset = offset || 0; // if no offset is passed in, set it to zero
@@ -124,7 +124,7 @@ export function focus(store, { uri, path, el, offset, appendText, pos }) {
       // note: we don't select components automatically when we focus,
       // because you cannot 'select' head components
       store.commit(FOCUS, {uri, path});
-      store.dispatch('openForm', { uri, path, el: fieldEl, offset, appendText, pos }).then(() => {
+      store.dispatch('openForm', { uri, path, initialFocus, el: fieldEl, offset, appendText, pos }).then(() => {
         isCurrentlyFocusing = false;
       });
     }).catch(_.noop);

--- a/lib/deep-linking/actions.js
+++ b/lib/deep-linking/actions.js
@@ -12,7 +12,7 @@ import label from '../utils/label';
  */
 
 function openHashedForm(store, urlProps) {
-  let isAdmin, component, instance, path, foundComponent, uri, el, group, groupEl;
+  let isAdmin, component, instance, path, foundComponent, uri, el, group, groupEl, initialFocus;
 
   // get user permissions
   // note: as clay always opens pages in page edit mode (not layout),
@@ -24,6 +24,7 @@ function openHashedForm(store, urlProps) {
   component = _.get(urlProps, 'component', null);
   instance = _.get(urlProps, 'instance', null);
   path = _.get(urlProps, 'path', null);
+  initialFocus = _.get(urlProps, 'initialFocus', null);
 
   // Get the URI and grab the component element based on the name
   // of the component and the instance name
@@ -68,7 +69,7 @@ function openHashedForm(store, urlProps) {
 
   // If we have a uri, an element and a path then we can open the form
   if (uri && path) {
-    return store.dispatch('focus', { uri, path, el: groupEl || el, offset: 0 });
+    return store.dispatch('focus', { uri, path, initialFocus, el: groupEl || el, offset: 0 });
   }
 }
 
@@ -100,9 +101,10 @@ export function parseURLHash(store) {
  * @param  {function} commit
  * @param  {string} [uri]
  * @param  {string} [path]
+ * @param  {string} [initialFocus]
  * @param {object} [menu]
  */
-export function setHash({ commit }, { uri, path, menu }) {
+export function setHash({ commit }, { uri, path, initialFocus, menu }) {
   let urlObj, hashString;
 
   if (uri && path) {
@@ -110,8 +112,8 @@ export function setHash({ commit }, { uri, path, menu }) {
     const component = getComponentName(uri),
       instance = getComponentInstance(uri);
 
-    urlObj = { component, instance, path };
-    hashString = `#${component}~${instance}~${path}`;
+    urlObj = { component, instance, path, initialFocus };
+    hashString = `#${component}~${instance}~${path}${initialFocus ? '~' + initialFocus : ''}`;
   } else if (menu) {
     // set has for the clay menu
     urlObj = {

--- a/lib/drawers/health.vue
+++ b/lib/drawers/health.vue
@@ -139,7 +139,7 @@
       <span class="validation-info">Go To Components</span>
       <ul class="validation-items">
         <li v-for="item in error.items" class="validation-item">
-          <span class="validation-item-location" :class="{ 'validation-item-link': item.uri && item.field }" @click.stop="openLocation(item.uri, item.path, item.location)">{{ item.location }}</span> <span v-if="item.preview" class="validation-item-preview">{{ item.preview }}</span>
+          <span class="validation-item-location" :class="{ 'validation-item-link': item.uri && item.field }" @click.stop="openLocation(item.uri, item.field, item.path, item.location)">{{ item.location }}</span> <span v-if="item.preview" class="validation-item-preview">{{ item.preview }}</span>
         </li>
       </ul>
     </div>
@@ -150,7 +150,7 @@
       <span class="validation-info">Go To Components</span>
       <ul class="validation-items">
         <li v-for="item in warning.items" class="validation-item">
-          <span class="validation-item-location" :class="{ 'validation-item-link': item.uri && item.field }" @click.stop="openLocation(item.uri, item.path, item.location)">{{ item.location }}</span> <span v-if="item.preview" class="validation-item-preview">{{ item.preview }}</span>
+          <span class="validation-item-location" :class="{ 'validation-item-link': item.uri && item.field }" @click.stop="openLocation(item.uri, item.field, item.path, item.location)">{{ item.location }}</span> <span v-if="item.preview" class="validation-item-preview">{{ item.preview }}</span>
         </li>
       </ul>
     </div>
@@ -181,7 +181,7 @@
       }
     }),
     methods: {
-      openLocation(uri, path, location) {
+      openLocation(uri, field, path, location) {
         const el = getFieldEl(uri, path),
           componentEl = el && getComponentEl(el);
 
@@ -190,7 +190,7 @@
           // component exists and is in the body (not a head component)
           this.$store.dispatch('select', componentEl);
         }
-        this.$store.dispatch('focus', { uri, path, el });
+        this.$store.dispatch('focus', { uri, path, initialFocus: field, el });
       }
     },
     components: {

--- a/lib/forms/actions.js
+++ b/lib/forms/actions.js
@@ -28,12 +28,13 @@ function hasDataChanged(newData, oldData) {
  * @param  {object} store
  * @param  {string} uri        component uri
  * @param  {string} path       field/form path
- * @param  {Element} el         parent element (for inline forms)
- * @param  {number} offset     caret offset (for text inputs)
- * @param  {string} appendText text to append (for text inputs, used when splitting/merging components with text fields)
+ * @param  {Element} [el]         parent element (for inline forms)
+ * @param  {number} [offset]     caret offset (for text inputs)
+ * @param  {string} [appendText] text to append (for text inputs, used when splitting/merging components with text fields)
+ * @param  {string} [initialFocus] if focusing on a specific field when opening the form
  * @param  {object} pos        x/y coordinates used to position overlay forms
  */
-export function openForm(store, { uri, path, el, offset, appendText, pos }) {
+export function openForm(store, { uri, path, el, offset, appendText, pos, initialFocus }) {
   const group = get(uri, path),
     // take into account shorthand input definition, e.g. `_has: inline`, as well as regular input definition
     isInlineWYSIWYG = _.get(group, `schema.${fieldProp}`) === 'inline' || _.get(group, `schema.${fieldProp}.${inputProp}`) === 'inline';
@@ -41,10 +42,10 @@ export function openForm(store, { uri, path, el, offset, appendText, pos }) {
   // send the data to state.ui.currentForm!
   // this is needed for inline forms to render,
   // and will AUTOMAGICALLY make overlay/settings forms appear
-  store.commit(OPEN_FORM, { uri, path, inline: isInlineWYSIWYG, fields: _.cloneDeep(group.fields), schema: group.schema, initialOffset: offset, appendText, pos });
+  store.commit(OPEN_FORM, { uri, path, inline: isInlineWYSIWYG, initialFocus, fields: _.cloneDeep(group.fields), schema: group.schema, initialOffset: offset, appendText, pos });
 
   // Update the hash of the page so we can directly open this form on page load
-  store.dispatch('setHash', { uri, path });
+  store.dispatch('setHash', { uri, path, initialFocus });
 
   if (isInlineWYSIWYG) {
     // create an inline form, and keep the vm created in memory

--- a/lib/forms/field-helpers.js
+++ b/lib/forms/field-helpers.js
@@ -20,6 +20,7 @@ export function getField(el) {
 }
 
 /**
+ * DEPRECATED
  * determine if a behavior is in the first field of a form
  * note: this is used for setting the caret
  * @param  {Element}  el of the behavior

--- a/lib/forms/field.vue
+++ b/lib/forms/field.vue
@@ -37,7 +37,7 @@
 <template>
   <transition name="reveal" mode="out-in" @after-enter="onRevealResize">
     <fieldset class="kiln-field" :style="{ minHeight: minHeight }" v-if="inputName && isShown" :key="name">
-      <component :is="inputName" :name="name" :data="data" :schema="schema" :args="expandedInput" @resize="onResize"></component>
+      <component :is="inputName" :name="name" :data="data" :schema="schema" :args="expandedInput" :initialFocus="initialFocus" @resize="onResize"></component>
     </fieldset>
   </transition>
 </template>
@@ -49,7 +49,7 @@
   import { expand } from './inputs';
 
   export default {
-    props: ['name', 'data', 'schema'],
+    props: ['name', 'data', 'schema', 'initialFocus'],
     data() {
       return {
         minHeight: '0px'

--- a/lib/forms/inline.vue
+++ b/lib/forms/inline.vue
@@ -25,7 +25,7 @@
   <section class="editor-inline" @click.stop="unsetInvalidDrag">
     <form @submit.prevent="save">
       <div class="input-container">
-        <field class="first-field" :name="path" :data="data" :schema="schema"></field>
+        <field class="first-field" :name="path" :data="data" :schema="schema" :initialFocus="initialFocus"></field>
       </div>
       <button type="submit" class="hidden-submit" @click.stop></button>
     </form>
@@ -45,6 +45,9 @@
     computed: {
       path() {
         return _.get(store, 'state.ui.currentForm.path');
+      },
+      initialFocus() {
+        return this.path; // inline forms always have a single field, and it should be focused
       },
       data() {
         return _.get(store, `state.ui.currentForm.fields['${this.path}']`);

--- a/lib/forms/mutations.js
+++ b/lib/forms/mutations.js
@@ -2,8 +2,8 @@ import _ from 'lodash';
 import { OPEN_FORM, CLOSE_FORM, UPDATE_FORMDATA } from './mutationTypes';
 
 export default {
-  [OPEN_FORM]: (state, { uri, path, inline, fields, schema, initialOffset, appendText, pos }) => {
-    _.set(state, 'ui.currentForm', { uri, path, inline, fields, schema, initialOffset, appendText, pos });
+  [OPEN_FORM]: (state, { uri, path, inline, fields, schema, initialOffset, appendText, pos, initialFocus }) => {
+    _.set(state, 'ui.currentForm', { uri, path, inline, fields, schema, initialOffset, appendText, pos, initialFocus });
     return state;
   },
   [CLOSE_FORM]: (state) => {

--- a/lib/preloader/parse-url.js
+++ b/lib/preloader/parse-url.js
@@ -23,7 +23,8 @@ export default function parseUrl() {
       propMapping = {
         component: hashProps[0],
         instance: hashProps[1],
-        path: hashProps[2]
+        path: hashProps[2],
+        initialFocus: hashProps[3]
       };
     }
 

--- a/lib/toolbar/actions.js
+++ b/lib/toolbar/actions.js
@@ -61,7 +61,6 @@ export function closeModal({ commit, state, dispatch }) {
       // component exists and is in the body (not a head component)
       dispatch('select', componentEl);
     }
-    console.log('focus back on the form:', uri, path, field);
     return dispatch('focus', { uri, path, initialFocus: field, el });
   }
 }

--- a/lib/toolbar/actions.js
+++ b/lib/toolbar/actions.js
@@ -12,6 +12,7 @@ import {
   SHOW_SNACKBAR,
   HIDE_SNACKBAR
 } from './mutationTypes';
+import { getFieldEl, getComponentEl } from '../utils/component-elements';
 
 /**
  * @module toolbar
@@ -42,8 +43,27 @@ export function openModal({ commit, dispatch }, config) {
   return dispatch('unfocus').then(() => commit(OPEN_MODAL, config));
 }
 
-export function closeModal({ commit }) {
+export function closeModal({ commit, state, dispatch }) {
+  const redirectTo = _.get(state, 'ui.currentModal.redirectTo');
+
   commit(CLOSE_MODAL);
+
+  // if `redirectTo` was configured when opening the modal, re-open a specific form
+  // after closing this modal
+  if (redirectTo) {
+    const uri = redirectTo.uri,
+      path = redirectTo.path, // field or group to open the form at
+      field = redirectTo.field, // field to focus on after opening the form
+      el = getFieldEl(uri, path),
+      componentEl = el && getComponentEl(el);
+
+    if (componentEl) {
+      // component exists and is in the body (not a head component)
+      dispatch('select', componentEl);
+    }
+    console.log('focus back on the form:', uri, path, field);
+    return dispatch('focus', { uri, path, initialFocus: field, el });
+  }
 }
 
 // open and close confirmation modals

--- a/lib/utils/path-from-field.js
+++ b/lib/utils/path-from-field.js
@@ -4,10 +4,13 @@ import { groupsProp } from './references';
 
 function getGroupPath(field, schema) {
   // find the field in a group
-  // note: this will find it in a manually-specified settings group
-  // if the field doesn't itself have _display: settings
   if (schema && schema[groupsProp]) {
-    return _.findKey(schema[groupsProp], (group) => _.includes(group.fields, field));
+    return _.findKey(schema[groupsProp], (group) => {
+      // remove site specificity before matching against fields
+      const bareFields = _.map(group.fields, (f) => f.replace(/\s?\(.*?\)\s?/, ''));
+
+      return _.includes(bareFields, field);
+    });
   }
 }
 
@@ -22,8 +25,7 @@ function getGroupPath(field, schema) {
 export default function getPathFromField(uri, field) {
   const schema = getSchema(uri);
 
-  // if it's a field in settings, return settings (easiest check)
-  // otherwise see if it's in a group
+  // if the field is inside a group (including `settings`), return the group
   // otherwise return the field itself
   return getGroupPath(field, schema) || field;
 }


### PR DESCRIPTION
* fixes #1272 
* fixes #1266 

**FEATURE:** Add individual field focus to the deep linking system

This allows deep-linking to individual fields, rather than just linking to forms. When a form is opened, the relevant field will be focused (and the section its in will be switched to, when applicable). This is backwards compatible with our current deep-linking, and fixes a number of issues with field autofocus (if you aren't explicitly focusing a field, the first field in the form will now be focused, which also works with complex-lists).

Deep links with focus look like this (note: this is linking to a specific item inside a complex-list):

```
#image~cjjess29h00133i64jmqkhf08~settings~content.1.imageUrl
```

One side effect of this is that clicking validation issues will now go to the correct section tab and focus on the relevant field, rather than making the end-user click around a complex form looking for it.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/3L1n3h0N0w0z1T250i2p/Screen%20Recording%202018-07-09%20at%2005.21%20PM.gif)

Also fixed a bug where site-specific fields weren't opening the full form (they were opening small forms with only that specific field in them) from validation issues.

**FEATURE:** Allow redirecting to forms after closing simple modals

When calling `store.dispatch('openModal', config)` you may now specify a `config.redirectTo` object with `{ uri, path, field }` which will trigger a specific form to open when the modal closes. The `uri` and `path` are for the form, and the `field` is the specific field that should be focused. This is great for pickers and other attached buttons in complex-list items, as you can see below:

![](https://d3vv6lp55qjaqc.cloudfront.net/items/2i0q2U183o0l2d3J0I1s/Screen%20Recording%202018-07-09%20at%2005.48%20PM.gif)

Dev / Modder Notes:

Individual `inputs` now get an `initialFocus` prop (along with `name`, `data`, `schema`, and `args`) which will be the path for the field that should be focused. If your input can be focused (text, buttons, etc), please do a quick check on `$mount` against the `name` prop to see if your `input` should focus itself. Because inputs are varied (and may be complicated), this is left to individual inputs to deal with.

* [simple example - text](https://github.com/clay/clay-kiln/blob/cab0c2fa1eb3d7b557c2ec9e323967a2338433b3/inputs/text.vue#L136)
* [using 3rd party libraries - codemirror](https://github.com/clay/clay-kiln/blob/cab0c2fa1eb3d7b557c2ec9e323967a2338433b3/inputs/codemirror.vue#L182)
* [complex logic - wysiwyg](https://github.com/clay/clay-kiln/blob/cab0c2fa1eb3d7b557c2ec9e323967a2338433b3/inputs/wysiwyg.vue#L741)
* [passing prop to child component - simple-list](https://github.com/clay/clay-kiln/blob/cab0c2fa1eb3d7b557c2ec9e323967a2338433b3/inputs/simple-list.vue#L112)