### PR TITLE
open 1180px wide window for desktop page preview

### DIFF
--- a/lib/drawers/preview.vue
+++ b/lib/drawers/preview.vue
@@ -87,7 +87,7 @@
     previewSizes = {
       small: { w: 375, h: 660 },
       medium: { w: 768, h: 1024 },
-      large: { w: 1024, h: 768 }
+      large: { w: 1180, h: 768 }
     };
 
   export default {


### PR DESCRIPTION
because the new min-width breakpoint for desktop screens is 1180px, the current 1024px desktop preview window shows a page styled for tablet. We need to ensure that a desktop page is displayed when previewing a page for desktop.