### PR TITLE
add module mounting for claycli compilation

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -114,6 +114,11 @@ document.addEventListener('DOMContentLoaded', function () {
   // instantiate toolbar on DOMContentLoaded, so custom buttons and modals can be
   // added as child components to the toolbar and simple-modal
 
+  // init custom kiln plugins after utils is set (if they exist)
+  if (_.has(window, 'modules["index.kilnplugin"]')) {
+    window.require('index.kilnplugin');
+  }
+
   Vue.component('edit-toolbar', toolbar);
 
   new Vue({

--- a/edit.js
+++ b/edit.js
@@ -110,7 +110,16 @@ function isStuffOpen(store) {
 // note: preloaded data, external inputs, decorators, and validation rules should already be added
 // when this event fires
 document.addEventListener('DOMContentLoaded', function () {
-  const toolbar = require('./lib/toolbar/edit-toolbar.vue');
+  let toolbar;
+
+  // init custom kiln plugins after utils is set (if they exist)
+  if (_.has(window, 'modules["kiln_index.kilnplugin"]')) {
+    const pluginInitializer = window.require('kiln_index.kilnplugin');
+
+    pluginInitializer();
+  }
+
+  toolbar = require('./lib/toolbar/edit-toolbar.vue');
   // instantiate toolbar on DOMContentLoaded, so custom buttons and modals can be
   // added as child components to the toolbar and simple-modal
 
@@ -129,13 +138,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // page load indicator. will be finished by the preloader
   store.dispatch('startProgress', 'offline');
-
-  // init custom kiln plugins after utils is set (if they exist)
-  console.log('attempt to load plugins 2');
-  if (_.has(window, 'modules["index.kilnplugin"]')) {
-    console.log('init kiln plugins');
-    // window.require('index.kilnplugin');
-  }
 
   // add external plugins
   _.forOwn(window.kiln.plugins || {}, (plugin) => plugin(store));

--- a/edit.js
+++ b/edit.js
@@ -114,11 +114,6 @@ document.addEventListener('DOMContentLoaded', function () {
   // instantiate toolbar on DOMContentLoaded, so custom buttons and modals can be
   // added as child components to the toolbar and simple-modal
 
-  // init custom kiln plugins after utils is set (if they exist)
-  if (_.has(window, 'modules["index.kilnplugin"]')) {
-    window.require('index.kilnplugin');
-  }
-
   Vue.component('edit-toolbar', toolbar);
 
   new Vue({
@@ -134,6 +129,13 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // page load indicator. will be finished by the preloader
   store.dispatch('startProgress', 'offline');
+
+  // init custom kiln plugins after utils is set (if they exist)
+  console.log('attempt to load plugins 2');
+  if (_.has(window, 'modules["index.kilnplugin"]')) {
+    console.log('init kiln plugins');
+    // window.require('index.kilnplugin');
+  }
 
   // add external plugins
   _.forOwn(window.kiln.plugins || {}, (plugin) => plugin(store));

--- a/lib/preloader/actions.js
+++ b/lib/preloader/actions.js
@@ -20,6 +20,25 @@ import { getItem } from '../utils/local';
 const hbs = clayHBS();
 
 /**
+ * get component models so we can mount them on window.kiln.componentModels
+ * @param  {object} modules
+ * @return {object}
+ */
+function getComponentModels(modules) {
+  let componentModels = Object.keys(modules)
+    .filter(function (key) {
+      return key.slice(-6) === '.model';
+    })
+    .reduce(function (acc, key) {
+      acc[key.replace('.model','')] = window.require(key);
+      return acc;
+    }, {});
+
+  _.set(window, 'kiln.componentModels', componentModels);
+  return componentModels;
+}
+
+/**
  * get schema for a layout
  * @param  {object} schemas
  * @param  {string} layoutRef
@@ -107,7 +126,7 @@ export default function preload({ commit, dispatch }) {
   const data = _.get(window, 'kiln.preloadData'),
     schemas = _.get(window, 'kiln.preloadSchemas'),
     locals = _.get(window, 'kiln.locals'),
-    models = _.get(window, 'kiln.componentModels'),
+    models = getComponentModels(window.modules),
     templates = _.get(window, 'kiln.componentTemplates'),
     user = locals && locals.user,
     site = locals && normalizeSiteData(locals.site),

--- a/lib/preloader/actions.js
+++ b/lib/preloader/actions.js
@@ -21,15 +21,17 @@ const hbs = clayHBS();
 
 /**
  * get component models so we can mount them on window.kiln.componentModels
- * @param  {object} modules
+ * if they aren't already mounted (backwards-compatability)
  * @return {object}
  */
-function getComponentModels(modules) {
-  Object.keys(modules)
-    .filter((key) => _.endsWith(key, '.model'))
-    .forEach((key) => {
-      window.kiln.componentModels[key.replace('.model', '')] = window.require(key);
-    });
+function getComponentModels() {
+  if (!_.has(window, 'kiln.componentModels')) {
+    Object.keys(window.modules)
+      .filter((key) => _.endsWith(key, '.model'))
+      .forEach((key) => {
+        window.kiln.componentModels[key.replace('.model', '')] = window.require(key);
+      });
+  }
 
   return window.kiln.componentModels;
 }
@@ -122,7 +124,7 @@ export default function preload({ commit, dispatch }) {
   const data = _.get(window, 'kiln.preloadData'),
     schemas = _.get(window, 'kiln.preloadSchemas'),
     locals = _.get(window, 'kiln.locals'),
-    models = getComponentModels(window.modules),
+    models = getComponentModels(),
     templates = _.get(window, 'kiln.componentTemplates'),
     user = locals && locals.user,
     site = locals && normalizeSiteData(locals.site),

--- a/lib/preloader/actions.js
+++ b/lib/preloader/actions.js
@@ -25,17 +25,13 @@ const hbs = clayHBS();
  * @return {object}
  */
 function getComponentModels(modules) {
-  let componentModels = Object.keys(modules)
-    .filter(function (key) {
-      return key.slice(-6) === '.model';
-    })
-    .reduce(function (acc, key) {
-      acc[key.replace('.model','')] = window.require(key);
-      return acc;
-    }, {});
+  Object.keys(modules)
+    .filter((key) => _.endsWith(key, '.model'))
+    .forEach((key) => {
+      window.kiln.componentModels[key.replace('.model', '')] = window.require(key);
+    });
 
-  _.set(window, 'kiln.componentModels', componentModels);
-  return componentModels;
+  return window.kiln.componentModels;
 }
 
 /**


### PR DESCRIPTION
* FEATURE: mount `model.js` files in kiln preloading step, if they don't already exist (backwards-compatible)
* FEATURE: mount `_kiln-plugins.js` if they exist (backwards-compatible)

This allows kiln itself to mount any component models and kiln plugins, using the syntax specified by `claycli compile`. It's backwards compatible with older (gulp-based) compilation pipelines that have been used in Clay installations.