### PR TITLE
add deep focus support

### DIFF
--- a/lib/core-data/components.js
+++ b/lib/core-data/components.js
@@ -49,7 +49,14 @@ function isCamelCase(str) {
  * @throws {Error} if not camelCased
  */
 function assertCamelCasedProps(item, name) {
-  if (_.isString(item) && !isCamelCase(item)) {
+  if (_.isString(item) && _.includes(item, '.')) {
+    // deep path! make sure all parts of it are camelcased
+    let nonCamelCasedPart = _.find(item.split('.'), (part) => !isCamelCase(part));
+
+    if (nonCamelCasedPart) {
+      log.error(`Properties in component data must be camelCased: ${name} → ${item} (try "${_.camelCase(nonCamelCasedPart)}")`);
+    }
+  } else if (_.isString(item) && !isCamelCase(item)) {
     log.error(`Properties in component data must be camelCased: ${name} → ${item} (try "${_.camelCase(item)}")`);
   } else if (_.isObject(item)) {
     _.forOwn(item, (val, prop) => {

--- a/lib/core-data/components.js
+++ b/lib/core-data/components.js
@@ -14,7 +14,7 @@ export function getData(uri, path, testStore) {
   testStore = testStore || /* istanbul ignore next */ store;
 
   if (path) {
-    return _.get(testStore, `${prefix}['${path}']`);
+    return _.get(testStore, `${prefix}.${path}`); // path might be deep, e.g. `foo.0.bar`
   } else {
     return _.get(testStore, `${prefix}`);
   }
@@ -77,7 +77,37 @@ export function getSchema(uri, path, testStore) {
 
   testStore = testStore || /* istanbul ignore next */ store;
   schema = _.get(testStore, prefix);
-  result = path ? _.get(schema, path) : schema;
+  if (path && path.match(/\.\d+\./i)) {
+    // if the path has a digit, assume it's a complex-list item
+    let prevPathIsNumber = false;
+
+    // we need to convert a path like 'content.0.foo' into the schema path,
+    // e.g. content.props.1
+    // (and we need to be able to do this recursively for deeply-nested complex-lists)
+    result = _.get(schema, _.reduce(_.tail(path.split('.')), (schemaPath, part) => {
+      const partIsNumber = !_.isNaN(new Number(part)); // convert to a number, see if that works
+
+      if (partIsNumber) {
+        // we've hit a number! this means we need to search through the
+        // current path's props to find the index of the next part of the path
+        schemaPath += '._has.props';
+      } else if (prevPathIsNumber) {
+        // we had just hit a number before, so this 'part' is a property in a complex-list
+        // search through the complex-list's 'props' to find the index we want
+        schemaPath += `.${_.findIndex(_.get(schema, schemaPath), (prop) => prop.prop === part)}`;
+      } else {
+        schemaPath += `.${part}`;
+      }
+
+      prevPathIsNumber = partIsNumber;
+      return schemaPath;
+    }, _.head(path.split('.'))));
+  } else if (path) {
+    // _.get() works, no special logic required
+    result = _.get(schema, path);
+  } else {
+    result = schema;
+  }
 
   if (path) {
     assertCamelCasedProps(path, name);

--- a/lib/core-data/components.test.js
+++ b/lib/core-data/components.test.js
@@ -6,7 +6,18 @@ const uri = '/_components/foo',
     state: {
       components: { [uri]: ok },
       componentDefaults: { foo: ok },
-      schemas: { foo: ok },
+      schemas: { foo: {
+        bar: 'baz',
+        baz: {
+          _has: {
+            input: 'complex-list',
+            props: [{
+              prop: 'qux',
+              _has: 'text'
+            }]
+          }
+        }
+      } },
       templates: { foo: ok },
       models: { foo: ok, fooBar: ok },
       locals: ok
@@ -29,15 +40,19 @@ describe('components helper functions', () => {
   );
   test(
     'gets schema from uri',
-    () => expect(lib.getSchema(uri, null, testStore)).toEqual(ok)
+    () => expect(lib.getSchema(uri, null, testStore)).toEqual(testStore.state.schemas.foo)
   );
   test(
     'gets schema from name',
-    () => expect(lib.getSchema('foo', null, testStore)).toEqual(ok)
+    () => expect(lib.getSchema('foo', null, testStore)).toEqual(testStore.state.schemas.foo)
   );
   test(
     'gets subset of schema with path',
     () => expect(lib.getSchema(uri, 'bar', testStore)).toEqual('baz')
+  );
+  test(
+    'gets subset of schema with deep path',
+    () => expect(lib.getSchema(uri, 'baz.0.qux', testStore)).toEqual({ prop: 'qux', _has: 'text'})
   );
   test('gets template', () => expect(lib.getTemplate(uri, testStore)).toEqual(ok));
   test('gets model', () => expect(lib.getModel(uri, testStore)).toEqual(ok));

--- a/lib/core-data/groups.js
+++ b/lib/core-data/groups.js
@@ -90,14 +90,15 @@ export function get(uri, path) {
     // and the data from the page itself
     data = _.get(store, 'state.page.data');
     schema = getSchema(data.layout);
+    field = data && data[path];
+    fieldSchema = schema && schema[path];
   } else {
     // if the uri points to a component, grab both data and schema from that component
     data = getData(uri);
     schema = addVariationField(getSchema(uri), getComponentName(uri), _.get(store, 'state.componentVariations'));
+    field = data && getData(uri, path);
+    fieldSchema = schema && getSchema(uri, path);
   }
-
-  field = data && data[path];
-  fieldSchema = schema && schema[path];
 
   if (fieldSchema) {
     // get single field

--- a/lib/core-data/groups.test.js
+++ b/lib/core-data/groups.test.js
@@ -96,21 +96,38 @@ describe('groups', () => {
     const fn = lib.get;
 
     test('throws error if field not found in schema', () => {
-      components.getData.mockReturnValue({ bar });
-      components.getSchema.mockReturnValue({});
+      components.getData.mockReturnValueOnce({ bar });
+      components.getData.mockReturnValueOnce(bar);
+      components.getSchema.mockReturnValueOnce({});
+      components.getSchema.mockReturnValueOnce(undefined);
       expect(() => fn('foo', 'bar')).toThrow(Error);
     });
 
     test('returns undefined if field not found in data', () => {
-      components.getData.mockReturnValue({});
-      components.getSchema.mockReturnValue({ bar: {} });
-      expect(fn('foo', 'bar')).toEqual({ fields: { bar: undefined }, schema: {}});
+      components.getData.mockReturnValueOnce({});
+      components.getData.mockReturnValueOnce(undefined);
+      components.getSchema.mockReturnValueOnce({ bar: { _has: 'text' } });
+      components.getSchema.mockReturnValueOnce({ _has: 'text' });
+      expect(fn('foo', 'bar')).toEqual({ fields: { bar: undefined }, schema: { _has: 'text' }});
     });
 
     test('returns a single field', () => {
-      components.getData.mockReturnValue({ bar });
-      components.getSchema.mockReturnValue({ bar: { _has: 'text' } });
+      components.getData.mockReturnValueOnce({ bar });
+      components.getData.mockReturnValueOnce(bar);
+      components.getSchema.mockReturnValueOnce({ bar: { _has: 'text' } });
+      components.getSchema.mockReturnValueOnce({ _has: 'text' });
       expect(fn('foo', 'bar')).toEqual({ fields: { bar }, schema: { _has: 'text' }});
+    });
+
+    test('returns a deep field inside a complex-list', () => {
+      components.getData.mockReturnValueOnce({ content: [{ bar: 'bar' }] });
+      components.getData.mockReturnValueOnce('bar');
+      components.getSchema.mockReturnValueOnce({ content: { _has: { props: [{ prop: 'bar', _has: 'text' }]} } });
+      components.getSchema.mockReturnValueOnce({
+        prop: 'bar',
+        _has: 'text'
+      });
+      expect(fn('foo', 'content.0.bar')).toEqual({ fields: { 'content.0.bar': 'bar' }, schema: { prop: 'bar', _has: 'text' }});
     });
 
     test('returns fields for a group', () => {
@@ -120,14 +137,16 @@ describe('groups', () => {
         _label: 'Baz'
       };
 
-      components.getData.mockReturnValue({ foo, bar });
-      components.getSchema.mockReturnValue({
+      components.getData.mockReturnValueOnce({ foo, bar });
+      components.getData.mockReturnValueOnce(undefined);
+      components.getSchema.mockReturnValueOnce({
         foo: {},
         bar: {},
         _groups: {
           baz
         }
       });
+      components.getSchema.mockReturnValueOnce(undefined);
       expect(fn('foo', 'baz')).toEqual({ fields: { foo, bar }, schema: baz });
     });
 
@@ -138,14 +157,16 @@ describe('groups', () => {
         _placeholder: true // this should be merged into the resulting schema
       };
 
-      components.getData.mockReturnValue({ foo, bar });
-      components.getSchema.mockReturnValue({
+      components.getData.mockReturnValueOnce({ foo, bar });
+      components.getData.mockReturnValueOnce(undefined);
+      components.getSchema.mockReturnValueOnce({
         foo: {},
         bar: {},
         _groups: {
           settings: baz
         }
       });
+      components.getSchema.mockReturnValueOnce(undefined);
       expect(fn('/_components/foo', 'settings')).toEqual({ fields: {foo, bar}, schema: {
         fields: ['foo', 'bar'],
         sections: [general(['foo', 'bar'])],
@@ -159,8 +180,10 @@ describe('groups', () => {
     const fn = lib.has;
 
     test('returns false if field not found in schema', () => {
-      components.getData.mockReturnValue({ bar });
-      components.getSchema.mockReturnValue({});
+      components.getData.mockReturnValueOnce({ bar });
+      components.getData.mockReturnValueOnce(bar);
+      components.getSchema.mockReturnValueOnce({});
+      components.getData.mockReturnValueOnce(undefined);
       expect(fn('foo', 'bar')).toBe(false);
     });
 

--- a/lib/forms/mutations.js
+++ b/lib/forms/mutations.js
@@ -11,7 +11,23 @@ export default {
     return state;
   },
   [UPDATE_FORMDATA]: (state, { path, data }) => {
-    _.set(state, `ui.currentForm.fields.${path}`, data);
+    const pathArr = path.split('.'),
+      fields = _.get(state, 'ui.currentForm.fields'),
+      uri = _.get(state, 'ui.currentForm.uri');
+
+    _.forEach(pathArr, (part, index) => {
+      const currentPath = _.take(pathArr, index + 1).join('.');
+
+      if (typeof _.get(fields, currentPath) === 'undefined') {
+        // before updating the data in the current form, we should check if that data exists
+        // in the current form. this prevents us from getting into weird situations when
+        // setting individual indices on otherwise undefined arrays
+        // (we merge in the current component data for those, THEN set the form data)
+        _.set(fields, currentPath, _.get(state, `components['${uri}'].${currentPath}`));
+      }
+    });
+
+    _.set(fields, `${path.replace(/\.(\d+)(\.)?/ig, '[$1]$2')}`, data);
     return state;
   }
 };

--- a/lib/forms/overlay.vue
+++ b/lib/forms/overlay.vue
@@ -132,7 +132,7 @@
         </ui-tabs>
         <div v-else class="input-container-wrapper" :style="{ 'max-height': `calc(100vh - ${formTop} - 56px)`}">
           <div class="input-container">
-            <field v-for="(field, fieldIndex) in sections[0].fields" :key="fieldIndex" :name="field" :data="fields[field]" :schema="schema[field]" :initialFocus="initialFocus"></field>
+            <field v-for="(field, fieldIndex) in sections[0].fields" :key="fieldIndex" :name="field" :data="fields[field]" :schema="schema[field] || getFieldSchema(field)" :initialFocus="initialFocus"></field>
             <div v-if="hasRequiredFields" class="required-footer">* Required fields</div>
           </div>
         </div>
@@ -168,6 +168,7 @@
     },
     computed: mapState({
       hasCurrentOverlayForm: (state) => !_.isNull(state.ui.currentForm) && !state.ui.currentForm.inline,
+      uri: (state) => state.ui.currentForm.uri,
       formKey: (state) => state.ui.currentForm.uri + state.ui.currentForm.path,
       formLeft: (state) => {
         const path = state.ui.currentForm.path,
@@ -309,6 +310,9 @@
       }
     }),
     methods: {
+      getFieldSchema(field) {
+        return getSchema(this.uri, field);
+      },
       enter(el, done) {
         const path = _.get(this.$store, 'state.ui.currentForm.path'),
           posY = _.get(this.$store, 'state.ui.currentForm.pos.y'),


### PR DESCRIPTION
fixes #1295

Allows `data-editable` to point to deeply-nested fields (i.e. fields inside of `complex-list` inputs)