### PR TITLE
fix bug in validation when component props are null

### DIFF
--- a/lib/validators/helpers.js
+++ b/lib/validators/helpers.js
@@ -158,7 +158,7 @@ export function forEachField(state, componentData, uri, fn) {
       // component prop
       fieldObj.type = 'component-prop';
       fieldObj.path = fieldName;
-      fieldObj.value = _.get(componentData, fieldName, {})[refProp] || null;
+      fieldObj.value = _.isObject(_.get(componentData, fieldName)) ? _.get(componentData, fieldName)[refProp] : null;
       fieldObj.validate = _.get(fieldSchema, `${componentProp}.validate`);
       // child ref, or null
       fn(fieldObj);


### PR DESCRIPTION
fixes a small issue that popped up when testing other stuff. `_.get()` considers null as a value, so it doesn't add the (third arg) defaults.