### PR TITLE
fix #1307, update modal top height

### DIFF
--- a/lib/forms/overlay.vue
+++ b/lib/forms/overlay.vue
@@ -325,16 +325,19 @@
             halfFinalHeight = finalHeight / 2;
 
           if (path === 'settings' || !posY) {
+            const formTop = docHeight / 3 - halfFinalHeight;
+
             // set top position of form once we know how tall it should be,
             // to prevent overflowing the top/bottom of the viewport
-            this.formTop = `${docHeight / 2 - halfFinalHeight}px`;
+            this.formTop = `${Math.abs(formTop)}px`;
           } else {
             const heightPlusMargin = finalHeight / 2 + 20,
-              isInsideViewport = posY > heightPlusMargin && posY < docHeight - heightPlusMargin - 500;
+              isInsideViewport = posY > heightPlusMargin && posY < docHeight - heightPlusMargin - 500,
               // give the bottom calculation about 500px more room, so complex-list items
               // don't overflow the bottom of the viewport (if they're opened when they don't have any items yet)
+              formTop = docHeight / 3 - halfFinalHeight;
 
-            this.formTop = isInsideViewport ? `${posY - halfFinalHeight}px` : `${docHeight / 2 - halfFinalHeight}px`;
+            this.formTop = isInsideViewport ? `${posY - halfFinalHeight}px` : `${Math.abs(formTop)}px`;
           }
           el.style.height = '100px'; // animate from 100px to auto height (auto)
           el.style.width = '100px'; // animate from 100px to auto width (600px)

--- a/lib/forms/overlay.vue
+++ b/lib/forms/overlay.vue
@@ -322,22 +322,20 @@
           const headerEl = find(el, '.form-header'),
             innerEl = find(el, '.form-contents'),
             finalHeight = el.clientHeight,
-            halfFinalHeight = finalHeight / 2;
+            halfFinalHeight = finalHeight / 2,
+            defaultFormTop = Math.abs(docHeight / 3 - halfFinalHeight);
 
           if (path === 'settings' || !posY) {
-            const formTop = docHeight / 3 - halfFinalHeight;
-
             // set top position of form once we know how tall it should be,
             // to prevent overflowing the top/bottom of the viewport
-            this.formTop = `${Math.abs(formTop)}px`;
+            this.formTop = `${defaultFormTop}px`;
           } else {
             const heightPlusMargin = finalHeight / 2 + 20,
-              isInsideViewport = posY > heightPlusMargin && posY < docHeight - heightPlusMargin - 500,
+              isInsideViewport = posY > heightPlusMargin && posY < docHeight - heightPlusMargin - 500;
               // give the bottom calculation about 500px more room, so complex-list items
               // don't overflow the bottom of the viewport (if they're opened when they don't have any items yet)
-              formTop = docHeight / 3 - halfFinalHeight;
 
-            this.formTop = isInsideViewport ? `${posY - halfFinalHeight}px` : `${Math.abs(formTop)}px`;
+            this.formTop = isInsideViewport ? `${posY - halfFinalHeight}px` : `${defaultFormTop}px`;
           }
           el.style.height = '100px'; // animate from 100px to auto height (auto)
           el.style.width = '100px'; // animate from 100px to auto width (600px)


### PR DESCRIPTION
Updates the form fallbacks so they appear higher on the page. Note: it overlays the header because it is in front of it (per material design guidelines)

Big screen:

![](https://d3vv6lp55qjaqc.cloudfront.net/items/3w060j423i1j192A0e21/Screen%20Shot%202018-08-30%20at%203.39.01%20PM.png?X-CloudApp-Visitor-Id=100841)

Little screen:

![](https://d3vv6lp55qjaqc.cloudfront.net/items/0o1W1r0v153F0h0W2Q1I/Screen%20Shot%202018-08-30%20at%203.39.59%20PM.png?X-CloudApp-Visitor-Id=100841)