### PR TITLE
check if componentModels is empty when mounting

### DIFF
--- a/lib/preloader/actions.js
+++ b/lib/preloader/actions.js
@@ -25,7 +25,7 @@ const hbs = clayHBS();
  * @return {object}
  */
 function getComponentModels() {
-  if (!_.has(window, 'kiln.componentModels') || _.isEmpty(_.get(window, 'kiln.componentModels'))) {
+  if (_.isEmpty(_.get(window, 'kiln.componentModels'))) {
     Object.keys(window.modules)
       .filter((key) => _.endsWith(key, '.model'))
       .forEach((key) => {

--- a/lib/preloader/actions.js
+++ b/lib/preloader/actions.js
@@ -25,7 +25,7 @@ const hbs = clayHBS();
  * @return {object}
  */
 function getComponentModels() {
-  if (!_.has(window, 'kiln.componentModels')) {
+  if (!_.has(window, 'kiln.componentModels') || _.isEmpty(_.get(window, 'kiln.componentModels'))) {
     Object.keys(window.modules)
       .filter((key) => _.endsWith(key, '.model'))
       .forEach((key) => {


### PR DESCRIPTION
We need to do this for claycli's compilation because kiln's template makes it an empty object if it's not mounted by the clay installation.