### PR TITLE
add field helpers to api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -79,6 +79,7 @@ Property | Description
 `getAvailableComponents()` | function to determine which components are allowed in a list
 `local` | methods to get/set localstorage
 `validationHelpers` | methods to help with pre-publish validation
+`fieldHelpers` | methods to help with custom inputs
 `logger()` | function to create a new logger for a file (pass in the `__filename` when calling this)
 `version` | current Kiln version
 `components` | Vue.js components, exported by Kiln

--- a/lib/utils/api.js
+++ b/lib/utils/api.js
@@ -10,6 +10,7 @@ import * as urls from './urls';
 import getAvailableComponents from './available-components';
 import * as local from './local';
 import * as validationHelpers from '../validators/helpers';
+import * as fieldHelpers from '../forms/field-helpers';
 import logger from './log';
 // we also expose some vue components, which is useful for plugins that want to mimic our look and feel
 import avatar from './avatar.vue';
@@ -53,6 +54,7 @@ const api = {
   getAvailableComponents,
   local,
   validationHelpers,
+  fieldHelpers,
   logger, // plugin authors, please instantiate a logger from this (passing in the filename / plugin used, e.g. `const log = logger(__filename)`)
   version: process.env.KILN_VERSION,
   components: {


### PR DESCRIPTION
adds `window.kiln.utils.fieldHelpers` to the client-side api, allowing custom inputs to use them. closes #1318