### PR TITLE
use asset host to fetch styles for newly-created components

### DIFF
--- a/lib/component-data/create.js
+++ b/lib/component-data/create.js
@@ -94,7 +94,8 @@ function fetchLegacyStyles(prefix, name, slug) {
  * @param  {string} name of component
  */
 function fetchComponentStyles(name) {
-  const prefix = _.get(store, 'state.site.prefix', ''), // default to emptystring for testing
+  const assetHost = _.get(store, 'state.site.assetHost'),
+    prefix = _.get(store, 'state.site.prefix', ''), // default to emptystring for testing
     styleguide = _.get(store, 'state.site.styleguide'),
     variations = _.get(store, `state.componentVariations['${name}']`, []),
     slug = _.get(store, 'state.site.slug');
@@ -102,10 +103,10 @@ function fetchComponentStyles(name) {
   if (styleguide) {
     // site has a styleguide! attempt to load component + variation styles,
     // falling back to using the '_default' styleguide
-    fetchStyleguideStyles(uriToUrl(prefix), name, styleguide, variations);
+    fetchStyleguideStyles(assetHost || uriToUrl(prefix), name, styleguide, variations);
   } else {
     // legacy: site has no styleguide, so load <component>.css and <component>.<site>.css
-    fetchLegacyStyles(uriToUrl(prefix), name, slug);
+    fetchLegacyStyles(assetHost || uriToUrl(prefix), name, slug);
   }
 }
 


### PR DESCRIPTION
fixes #1330

when components are first created and added to the page, kiln fetches css for them. it should use the `site.assetHost` to do this, if it exists (falling back to the site prefix)