### PR TITLE
only display time parsing error when timepicker has data

### DIFF
--- a/lib/utils/timepicker.vue
+++ b/lib/utils/timepicker.vue
@@ -20,6 +20,7 @@
   import dateFormat from 'date-fns/format';
   import { parseDate as parseNaturalDate } from 'chrono-node';
   import { shouldBeRequired, getValidationError } from '../forms/field-helpers';
+  import { isEmpty } from '../utils/comparators';
   import UiTextbox from 'keen/UiTextbox';
   import attachedButton from '../../inputs/attached-button.vue';
 
@@ -42,7 +43,8 @@
 
           if (validationError) {
             return validationError;
-          } else if (!parsed) {
+          } else if (!parsed && !isEmpty(this.timeValue)) {
+            // only display the time parsing error if the timepicker has data in it
             return `${this.help} (Please enter a valid time)`;
           }
         }


### PR DESCRIPTION
* fixes #1342
* since a timepicker without data can't actually be parsed as a date value, we shouldn't display the "hey I can't parse this as a date value" error message for empty timepickers