### PR TITLE
Allow inline reordering on complex-lists

### DIFF
--- a/lib/decorators/complex-list.js
+++ b/lib/decorators/complex-list.js
@@ -1,9 +1,8 @@
 import _ from 'lodash';
 import dragula from 'dragula';
-import { isPage } from 'clayutils';
-import { getComponentName, layoutAttr, editAttr, reorderAttr, reorderItemAttr, componentListProp, pageAreaClass, collapsibleListClass, dropAreaClass, dragItemClass, dragItemUnsavedClass, refAttr, refProp } from '../utils/references';
+import { getComponentName, reorderAttr, reorderItemAttr, dropAreaClass, dragItemClass, dragItemUnsavedClass, refAttr } from '../utils/references';
 import { getData, getSchema } from '../core-data/components';
-import { getComponentEl, isComponentInPage } from '../utils/component-elements';
+import { getComponentEl } from '../utils/component-elements';
 import store from '../core-data/store';
 import logger from '../utils/log';
 
@@ -71,26 +70,24 @@ function addDragula(el) {
   const trash = document.createElement('div'),
     trashIcon = document.createElement('span'),
     drag = dragula([el, trash], {
-    deadzone: 50,
-    ignoreInputTextSelection: false,
-    moves(selectedItem, container, handle) {
-      const itemKey = selectedItem.hasAttribute(reorderItemAttr) && selectedItem.getAttribute(reorderItemAttr);
+      deadzone: 50,
+      ignoreInputTextSelection: false,
+      moves(selectedItem, container, handle) {
+        return isDraggable(handle, container);
+      },
+      invalid(selectedItem) {
+        const isInsideField = selectedItem.classList.contains('kiln-field');
 
-      return isDraggable(handle, container);
-    },
-    invalid(selectedItem) {
-      const isInsideField = selectedItem.classList.contains('kiln-field');
+        if (isInsideField) {
+          // set isInvalidDrag if user is selecting text inside form fields.
+          // it's unset when they either click another thing in the form
+          // OR if the document click event fires (when they mouseup outside of the form)
+          window.kiln.isInvalidDrag = true;
+        }
 
-      if (isInsideField) {
-        // set isInvalidDrag if user is selecting text inside form fields.
-        // it's unset when they either click another thing in the form
-        // OR if the document click event fires (when they mouseup outside of the form)
-        window.kiln.isInvalidDrag = true;
+        return isInsideField;
       }
-
-      return isInsideField;
-    }
-  });
+    });
 
   trash.classList.add('complex-list-trash');
   trashIcon.classList.add('material-icons', 'delete');
@@ -146,12 +143,12 @@ function validChildElements(el, uri, path) {
   const children = Array.from(el.children);
 
   if (!_.every(children, (child) => child.getAttribute(reorderItemAttr))) {
-    log.error(`All direct children of reorderable complex lists must have a unique 'data-reorderable-item' attribute`);
+    log.error(`Template for ${getComponentName(uri)} → ${path} contains non-rearrangeable elements! All direct children of an inline-rearrangeable complex-list must have the 'data-reorderable-item' attribute.`, { action: 'containsChildComponents' });
     return false;
   }
 
   if (_.uniqBy(children, (child) => child.getAttribute(reorderItemAttr)).length < children.length) {
-    log.error(`All direct children of reorderable complex lists must have a unique 'data-reorderable-item' attribute`);
+    log.error(`Template for ${getComponentName(uri)} → ${path} contains duplicate elements! All direct children of an inline-rearrangeable complex-list must have a unique 'data-reorderable-item' attribute value.`, { action: 'containsChildComponents' });
     return false;
   }
 
@@ -162,7 +159,7 @@ export default function handler(uri, el) {
   const path = el.getAttribute(reorderAttr),
     schema = getSchema(uri, path);
 
-  if (validChildElements(el, uri, path)) {
+  if (validChildElements(el, uri, path) && _.get(schema, '_has.input') === 'complex-list') {
     addDragula(el);
   }
 }

--- a/lib/decorators/complex-list.js
+++ b/lib/decorators/complex-list.js
@@ -1,0 +1,168 @@
+import _ from 'lodash';
+import dragula from 'dragula';
+import { isPage } from 'clayutils';
+import { getComponentName, layoutAttr, editAttr, reorderAttr, reorderItemAttr, componentListProp, pageAreaClass, collapsibleListClass, dropAreaClass, dragItemClass, dragItemUnsavedClass, refAttr, refProp } from '../utils/references';
+import { getData, getSchema } from '../core-data/components';
+import { getComponentEl, isComponentInPage } from '../utils/component-elements';
+import store from '../core-data/store';
+import logger from '../utils/log';
+
+const log = logger(__filename);
+
+function updateOrder(el) {
+  const componentEl = getComponentEl(el),
+    uri = componentEl.getAttribute(refAttr),
+    path = el.getAttribute(reorderAttr),
+    list = getData(uri, path),
+    childEls = el.querySelectorAll(':scope > [' + reorderItemAttr + ']'), // only get direct children of the list;
+    listItemProp = el.getAttribute('data-reorderable-prop');
+
+  let newList = [];
+
+  if (_.isArray(list)) {
+    newList = _.map(childEls, (childEl) => {
+      return list.find((item) => item[listItemProp] === childEl.getAttribute(reorderItemAttr));
+    });
+
+    if (_.get(store, 'state.ui.currentFocus')) {
+      // save an open child component's form before saving the parent component
+      return store.dispatch('unfocus').then(() => store.dispatch('saveComponent', { uri, data: { [path]: newList } }));
+    } else {
+      return store.dispatch('saveComponent', { uri, data: { [path]: newList } });
+    }
+  }
+}
+
+/**
+ * get the number of components between the handle and container
+ * @param {Element} handle
+ * @param {Element} container
+ * @returns {number}
+ */
+function getItemDepth(handle, container) {
+  let cursor = handle,
+    depth = 0;
+
+  // note: Element#matches doesn't work on all browsers, limiting our support
+  while (cursor && !cursor.matches('html') && cursor !== container) {
+    cursor = cursor.parentNode; // iterate up through the elements
+    if (cursor.getAttribute(reorderItemAttr)) {
+      depth++; // every time you hit a component, add to the depth
+    }
+  }
+
+  return depth; // return the number of you passed through
+}
+
+/**
+ * determine if a component is draggable inside a specific container
+ * @param {Element} handle
+ * @param {Element} container
+ * @returns {boolean}
+ */
+function isDraggable(handle, container) {
+  // components are draggable if the handle is the component element and it's a direct child of the container (depth 0)
+  // OR if the handle is some OTHER element inside the direct child component (depth 1)
+  return !!handle.hasAttribute(reorderItemAttr) && getItemDepth(handle, container) === 0
+    || !handle.hasAttribute(reorderItemAttr) && getItemDepth(handle, container) === 1;
+}
+
+function addDragula(el) {
+  const trash = document.createElement('div'),
+    trashIcon = document.createElement('span'),
+    drag = dragula([el, trash], {
+    deadzone: 50,
+    ignoreInputTextSelection: false,
+    moves(selectedItem, container, handle) {
+      const itemKey = selectedItem.hasAttribute(reorderItemAttr) && selectedItem.getAttribute(reorderItemAttr);
+
+      return isDraggable(handle, container);
+    },
+    invalid(selectedItem) {
+      const isInsideField = selectedItem.classList.contains('kiln-field');
+
+      if (isInsideField) {
+        // set isInvalidDrag if user is selecting text inside form fields.
+        // it's unset when they either click another thing in the form
+        // OR if the document click event fires (when they mouseup outside of the form)
+        window.kiln.isInvalidDrag = true;
+      }
+
+      return isInsideField;
+    }
+  });
+
+  trash.classList.add('complex-list-trash');
+  trashIcon.classList.add('material-icons', 'delete');
+  trashIcon.innerHTML = 'delete';
+  trash.appendChild(trashIcon);
+  el.parentElement.appendChild(trash);
+
+  // add event listeners to reorder components
+  // auto-scroll when you drag to the edge of the window
+  drag.on('cloned', function (mirror) {
+    const buffer = 40;
+
+    let dragging = window.setInterval(() => {
+      const rect = mirror.getBoundingClientRect();
+
+      if (!drag.dragging) {
+        window.clearInterval(dragging);
+      } else if (rect.top < buffer) {
+        window.scrollBy(0, -buffer * 2);
+      } else if (window.innerHeight - rect.bottom < buffer) {
+        window.scrollBy(0, buffer * 2);
+      }
+    }, 250);
+  });
+
+  // add classes when you start dragging
+  drag.on('drag', function (selectedItem, container) {
+    selectedItem.classList.add(dragItemClass);
+    container.classList.add(dropAreaClass);
+    trash.classList.add(dropAreaClass);
+  });
+
+  // remove classes when you cancel dragging
+  drag.on('cancel', function (selectedItem, container) {
+    selectedItem.classList.remove(dragItemClass);
+    container.classList.remove(dropAreaClass);
+    trash.classList.remove('visible');
+  });
+
+  // handle reordering
+  drag.on('drop', function (selectedItem, container) {
+    // selectedItem.classList.add(dragItemUnsavedClass);
+    selectedItem.classList.remove(dragItemClass);
+    container.classList.remove(dropAreaClass);
+    trash.classList.remove('visible');
+    updateOrder(el).then(() => {
+      selectedItem.classList.remove(dragItemUnsavedClass);
+    });
+  });
+}
+
+function validChildElements(el, uri, path) {
+  const children = Array.from(el.children);
+
+  if (!_.every(children, (child) => child.getAttribute(reorderItemAttr))) {
+    log.error(`All direct children of reorderable complex lists must have a unique 'data-reorderable-item' attribute`);
+    return false;
+  }
+
+  if (_.uniqBy(children, (child) => child.getAttribute(reorderItemAttr)).length < children.length) {
+    log.error(`All direct children of reorderable complex lists must have a unique 'data-reorderable-item' attribute`);
+    return false;
+  }
+
+  return true;
+}
+
+export default function handler(uri, el) {
+  const path = el.getAttribute(reorderAttr),
+    schema = getSchema(uri, path);
+
+  if (validChildElements(el, uri, path)) {
+    addDragula(el);
+  }
+}

--- a/lib/decorators/component-list.js
+++ b/lib/decorators/component-list.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import dragula from 'dragula';
 import { isPage } from 'clayutils';
-import { getComponentName, layoutAttr, editAttr, componentListProp, pageAreaClass, collapsibleListClass, dropAreaClass, dragItemClass, dragItemUnsavedClass, refAttr, refProp } from '../utils/references';
+import { getComponentName, layoutAttr, editAttr, componentListProp, pageAreaClass, collapsibleListClass, dropAreaClass, dragItemClass, dragItemUnsavedClass, refAttr, refProp, reorderItemAttr } from '../utils/references';
 import { getData, getSchema } from '../core-data/components';
 import { getComponentEl, isComponentInPage } from '../utils/component-elements';
 import store from '../core-data/store';
@@ -118,7 +118,8 @@ function addDragula(el) {
         window.kiln.isInvalidDrag = true;
       }
 
-      return isInsideField;
+      // don't drag parent if the target is a draggable complex-list item
+      return isInsideField || selectedItem.hasAttribute(reorderItemAttr);
     }
   });
 

--- a/lib/decorators/index.js
+++ b/lib/decorators/index.js
@@ -13,6 +13,7 @@ import { addSelector } from './select';
 import addPlaceholder from './placeholders';
 import addComponentList from './component-list';
 import addComponentProp from './component-prop';
+import addReorderability from './complex-list';
 import addFocus from './focus';
 import logger from '../utils/log';
 
@@ -72,7 +73,8 @@ function addLinkKiller(uri) {
  */
 function addFieldDecorators(uri, el) {
   const editableNodes = getComponentNodes(el, 'editable'),
-    placeholderNodes = getComponentNodes(el, 'placeholder');
+    placeholderNodes = getComponentNodes(el, 'placeholder'),
+    reorderableNodes = getComponentNodes(el, 'reorderable');
 
   // add placeholders
   _.each(editableNodes, addPlaceholder.bind(null, uri));
@@ -84,6 +86,8 @@ function addFieldDecorators(uri, el) {
 
   // add focus handler
   _.each(editableNodes, addFocus.bind(null, uri));
+
+  _.each(reorderableNodes, addReorderability.bind(null, uri));
 }
 
 /**

--- a/lib/utils/references.js
+++ b/lib/utils/references.js
@@ -69,6 +69,8 @@ export const editAttr = 'data-editable'; // indicates el is editable when clicke
 export const placeholderAttr = 'data-placeholder'; // indicates el should have placeholder, but is NOT editable when clicked
 export const layoutAttr = 'data-layout-uri'; // set on <html> element, points to the layout when data-uri points to the page
 export const hiddenAttr = 'data-kiln-hidden';
+export const reorderAttr = 'data-reorderable';
+export const reorderItemAttr = 'data-reorderable-item';
 // properties
 export const refProp = '_ref';
 export const fieldProp = '_has'; // used to determine if a node (in the schema) is a field

--- a/lib/utils/walker.js
+++ b/lib/utils/walker.js
@@ -1,4 +1,4 @@
-import { refAttr, editAttr, placeholderAttr } from './references';
+import { refAttr, editAttr, placeholderAttr, reorderAttr } from './references';
 
 /**
  * create a tree walker that only returns nodes in the current component
@@ -25,7 +25,8 @@ export function getComponentNodes(el, type) {
   const walker = createWalker(el),
     attrs = {
       editable: editAttr,
-      placeholder: placeholderAttr
+      placeholder: placeholderAttr,
+      reorderable: reorderAttr
     },
     attr = attrs[type];
 

--- a/styleguide/component-list-drag.scss
+++ b/styleguide/component-list-drag.scss
@@ -54,3 +54,42 @@
   top: 0;
   width: 100%;
 }
+
+.complex-list-trash {
+  align-items: center;
+  background: $permanent-placeholder-bg-color;
+  bottom: 50px;
+  color: $permanent-placeholder-color;
+  display: none;
+  height: 300px;
+  justify-content: center;
+  left: 50px;
+  position: fixed;
+  width: 300px;
+  z-index: 9998;
+}
+
+.complex-list-trash .material-icons {
+  content: 'delete';
+  font-size: 150px;
+}
+
+.complex-list-trash.dragula-drop-area .material-icons:not(:only-child) {
+  background: $placeholder-error-bg-color;
+  color: $placeholder-error-color;
+  font-size: 300px;
+  height: 100%;
+  width: 100%;
+}
+
+.complex-list-trash.dragula-drop-area {
+  display: flex;
+}
+
+.complex-list-trash > .gu-transit {
+  display: block;
+  max-width: 200px;
+  opacity: 0.7;
+  filter: alpha(opacity=70);
+  position: absolute;
+}


### PR DESCRIPTION
reorderable complex-lists must have a specific markup to allow this functionality:

```
<ul data-reorderable="complexListName" data-reorderable-prop="id">
  <li data-reorderable-item="{{item.index.id}}">...</li>
</ul>
```
where `data-reorderable` is the name of the complex list field, `data-reorderable-prop` is the property on all complex list items that is unique across all items, used to track changes and update the data, and `data-reorderable-item` is the value of the item's unique reorderable property. All `data-reorderable-item`s must be the direct child of the `data-reorderable` parent and the parent must only contain `data-reorderable-item` elements.