### PR TITLE
Clone embedded component data when creating new components

### DIFF
--- a/lib/component-data/create.js
+++ b/lib/component-data/create.js
@@ -223,7 +223,7 @@ function addChildrenToParent(children, uri, data) {
 
     if (!isDefaultComponent(childURI)) {
       // clone the already-existing data, rather than fetching the default data
-      dataPromise = getData(childURI) ? Promise.resolve(_.toPlainObject(getData(childURI))) : getObject(childURI).then((data) => _.toPlainObject(data));
+      dataPromise = getData(childURI) ? Promise.resolve(_.toPlainObject(getData(childURI))) : getObject(childURI).then((data) => _.toPlainObject(data)).catch(() => resolveDefaultData(childName));
     } else {
       dataPromise = resolveDefaultData(childName);
     }

--- a/lib/component-data/create.js
+++ b/lib/component-data/create.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import cuid from 'cuid';
+import { isDefaultComponent } from 'clayutils';
 import { create as createElement } from '@nymag/dom';
 import store from '../core-data/store';
 import { UPDATE_COMPONENT, ADD_DEFAULT_DATA, ADD_SCHEMA } from './mutationTypes';
@@ -220,9 +221,9 @@ function addChildrenToParent(children, uri, data) {
 
     let dataPromise;
 
-    if (getData(childURI)) {
+    if (!isDefaultComponent(childURI)) {
       // clone the already-existing data, rather than fetching the default data
-      dataPromise = Promise.resolve(_.toPlainObject(getData(childURI)));
+      dataPromise = getData(childURI) ? Promise.resolve(_.toPlainObject(getData(childURI))) : getObject(childURI).then((data) => _.toPlainObject(data));
     } else {
       dataPromise = resolveDefaultData(childName);
     }


### PR DESCRIPTION
previously, kiln would only use an instance's data as the default for a duplicated child instance IF that instance's data was already loaded into the store. This makes very little sense for scenarios where you're adding a component to a page that did not already have this component. This change first checks the store for the referenced data, and if it doesn't find it there, makes a call to the referenced URI, and if that doesn't resolve, it will use the default component data. fixes https://github.com/clay/clay-kiln/issues/1305

LMK if you don't get it