### PR TITLE
preload component data that hasn't been mutated by handlebars

### DIFF
--- a/lib/preloader/actions.js
+++ b/lib/preloader/actions.js
@@ -113,7 +113,7 @@ export default function preload({ commit, dispatch }) {
     site = locals && normalizeSiteData(locals.site),
     layoutSchema = _.get(window, 'kiln.layout.schema'),
     tabulaRasa = _.assign({}, defaultState),
-    components = _.reduce(data, reduceComponents, {}),
+    components = _.reduce(data._componentData || data, reduceComponents, {}),
     urlProps = parseUrl();
 
   commit(PRELOAD_PENDING);


### PR DESCRIPTION
...if it's available from amphora-html. See https://github.com/clay/amphora-html/pull/56

part of the fix for https://github.com/clay/clay-kiln/issues/1363