### PR TITLE
adding a couple of explicit box-sizing styles to kiln elements

### DIFF
--- a/lib/decorators/placeholder.vue
+++ b/lib/decorators/placeholder.vue
@@ -37,6 +37,11 @@
   .kiln-inactive-placeholder {
     align-items: center;
     border-radius: 2px;
+
+    // explicitly setting box-sizing because Kiln placeholders rely on this property being set to border-box for proper styling,
+    // while the site using Kiln might have box-sizing set to something else, not set at all
+    box-sizing: border-box;
+
     cursor: pointer;
     display: flex;
     height: 100%;

--- a/styleguide/_toolbar.scss
+++ b/styleguide/_toolbar.scss
@@ -6,6 +6,10 @@ $height: 56px;
 @mixin toolbar-wrapper {
   @include toolbar-layer();
 
+  //explicitly setting box-sizing because Kiln toolbars rely on this property being set to border-box for proper styling,
+  //while the site using Kiln might have box-sizing set to something else, not set at all
+  box-sizing: border-box;
+
   left: 0;
   position: fixed;
   top: 0;


### PR DESCRIPTION
Adding box-sizing: border-box to Kiln toolbar and placeholder because these elements rely on that property for proper styling.  nymag sites set this property globally on the html tag, but not all sites using kiln will have this property set or set to border-box.  This will preserve the proper styling in those cases where it's not set globally or set to a different value.

https://app.zenhub.com/workspaces/clay-repos-596524da4a8a0769f2f03175/issues/clay/clay-kiln/1183