### PR TITLE
Clay kiln 904 migrate from dragula to sortable

### DIFF
--- a/lib/decorators/complex-list.js
+++ b/lib/decorators/complex-list.js
@@ -5,6 +5,7 @@ import { getData, getSchema } from '../core-data/components';
 import { getComponentEl } from '../utils/component-elements';
 import store from '../core-data/store';
 import logger from '../utils/log';
+import { getDragDelay } from './helpers';
 
 const log = logger(__filename);
 
@@ -67,14 +68,6 @@ function isDraggable(handle, container) {
 }
 
 function addSortable(el) {
-  let dragDelay = 0;
-
-  if (window.matchMedia && window.matchMedia('(hover: none)').matches) {
-    // for devices that don't support hover, add a drag delay.  this requires a tap and hold before you can drag which means you can scroll
-    // on mobile without triggering drags every time your finger touches a draggable element
-    dragDelay = 200;
-  }
-
   const trash = document.createElement('div'),
     trashIcon = document.createElement('span');
 
@@ -88,9 +81,10 @@ function addSortable(el) {
   sortable.create( trash, {
     group: 'complexList'
   });
+
   sortable.create(el, {
     group: 'complexList',
-    delay: dragDelay,
+    delay: getDragDelay(),
     scroll: true,
     scrollSensitivity: 40,
     onStart(evt) {

--- a/lib/decorators/complex-list.js
+++ b/lib/decorators/complex-list.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import dragula from 'dragula';
+import sortable from 'sortablejs';
 import { getComponentName, reorderAttr, reorderItemAttr, dropAreaClass, dragItemClass, dragItemUnsavedClass, refAttr } from '../utils/references';
 import { getData, getSchema } from '../core-data/components';
 import { getComponentEl } from '../utils/component-elements';
@@ -66,28 +66,17 @@ function isDraggable(handle, container) {
     || !handle.hasAttribute(reorderItemAttr) && getItemDepth(handle, container) === 1;
 }
 
-function addDragula(el) {
+function addSortable(el) {
+  let dragDelay = 0;
+
+  if (window.matchMedia && window.matchMedia('(hover: none)').matches) {
+    // for devices that don't support hover, add a drag delay.  this requires a tap and hold before you can drag which means you can scroll
+    // on mobile without triggering drags every time your finger touches a draggable element
+    dragDelay = 200;
+  }
+
   const trash = document.createElement('div'),
-    trashIcon = document.createElement('span'),
-    drag = dragula([el, trash], {
-      deadzone: 50,
-      ignoreInputTextSelection: false,
-      moves(selectedItem, container, handle) {
-        return isDraggable(handle, container);
-      },
-      invalid(selectedItem) {
-        const isInsideField = selectedItem.classList.contains('kiln-field');
-
-        if (isInsideField) {
-          // set isInvalidDrag if user is selecting text inside form fields.
-          // it's unset when they either click another thing in the form
-          // OR if the document click event fires (when they mouseup outside of the form)
-          window.kiln.isInvalidDrag = true;
-        }
-
-        return isInsideField;
-      }
-    });
+    trashIcon = document.createElement('span');
 
   trash.classList.add('complex-list-trash');
   trashIcon.classList.add('material-icons', 'delete');
@@ -95,47 +84,44 @@ function addDragula(el) {
   trash.appendChild(trashIcon);
   el.parentElement.appendChild(trash);
 
-  // add event listeners to reorder components
-  // auto-scroll when you drag to the edge of the window
-  drag.on('cloned', function (mirror) {
-    const buffer = 40;
+  // To move items between SortableJS lists, they need to share the same group name
+  sortable.create( trash, {
+    group: 'complexList'
+  });
+  sortable.create(el, {
+    group: 'complexList',
+    delay: dragDelay,
+    scroll: true,
+    scrollSensitivity: 40,
+    onStart(evt) {
+      evt.item.classList.add(dragItemClass);
+      evt.srcElement.classList.add(dropAreaClass);
+      trash.classList.add(dropAreaClass);
+    },
+    onMove(evt) {
+      const isInsideField = evt.dragged.classList.contains('kiln-field');
 
-    let dragging = window.setInterval(() => {
-      const rect = mirror.getBoundingClientRect();
+      if (isInsideField) {
+        // set isInvalidDrag if user is selecting text inside form fields.
+        // it's unset when they either click another thing in the form
+        // OR if the document click event fires (when they mouseup outside of the form)
+        window.kiln.isInvalidDrag = true;
 
-      if (!drag.dragging) {
-        window.clearInterval(dragging);
-      } else if (rect.top < buffer) {
-        window.scrollBy(0, -buffer * 2);
-      } else if (window.innerHeight - rect.bottom < buffer) {
-        window.scrollBy(0, buffer * 2);
+        // returning false reverts to the original order
+        return false;
       }
-    }, 250);
-  });
 
-  // add classes when you start dragging
-  drag.on('drag', function (selectedItem, container) {
-    selectedItem.classList.add(dragItemClass);
-    container.classList.add(dropAreaClass);
-    trash.classList.add(dropAreaClass);
-  });
+      return isDraggable(evt.dragged, evt.from);
+    },
+    onEnd(evt) {
+      evt.item.classList.remove(dragItemClass);
+      evt.from.classList.remove(dropAreaClass);
+      trash.classList.remove(dropAreaClass);
 
-  // remove classes when you cancel dragging
-  drag.on('cancel', function (selectedItem, container) {
-    selectedItem.classList.remove(dragItemClass);
-    container.classList.remove(dropAreaClass);
-    trash.classList.remove('visible');
-  });
-
-  // handle reordering
-  drag.on('drop', function (selectedItem, container) {
-    // selectedItem.classList.add(dragItemUnsavedClass);
-    selectedItem.classList.remove(dragItemClass);
-    container.classList.remove(dropAreaClass);
-    trash.classList.remove('visible');
-    updateOrder(el).then(() => {
-      selectedItem.classList.remove(dragItemUnsavedClass);
-    });
+      updateOrder(el).then(() => {
+        evt.item.classList.remove(dragItemUnsavedClass);
+      });
+    }
   });
 }
 
@@ -160,6 +146,6 @@ export default function handler(uri, el) {
     schema = getSchema(uri, path);
 
   if (validChildElements(el, uri, path) && _.get(schema, '_has.input') === 'complex-list') {
-    addDragula(el);
+    addSortable(el);
   }
 }

--- a/lib/decorators/component-list.js
+++ b/lib/decorators/component-list.js
@@ -6,6 +6,7 @@ import { getData, getSchema } from '../core-data/components';
 import { getComponentEl, isComponentInPage } from '../utils/component-elements';
 import store from '../core-data/store';
 import logger from '../utils/log';
+import { getDragDelay } from './helpers';
 
 const log = logger(__filename);
 
@@ -91,16 +92,9 @@ function addSortableJS(el) {
     // no need to create Sortable for kiln-
     return false;
   }
-  let dragDelay = 0;
-
-  if (window.matchMedia && window.matchMedia('(hover: none)').matches) {
-    // for devices that don't support hover, add a drag delay.  this requires a tap and hold before you can drag which means you can scroll
-    // on mobile without triggering drags every time your finger touches a draggable element
-    dragDelay = 200;
-  }
 
   sortable.create(el, {
-    delay: dragDelay,
+    delay: getDragDelay(),
     scroll: true,
     scrollSensitivity: 40,
     removeCloneOnHide: true,

--- a/lib/decorators/component-list.js
+++ b/lib/decorators/component-list.js
@@ -88,6 +88,7 @@ function isDraggable(handle, container) {
 
 function addSortableJS(el) {
   if ( el.classList.contains('kiln-internals')) {
+    // no need to create Sortable for kiln-
     return false;
   }
   let dragDelay = 0;
@@ -140,7 +141,6 @@ function addSortableJS(el) {
       return isActive && isDraggable(evt.dragged, evt.from) && !evt.dragged.hasAttribute(reorderItemAttr);
     },
     onEnd(evt) {
-      console.log(evt);
       evt.item.classList.remove(dragItemClass);
       evt.from.classList.remove(dropAreaClass);
       if ( evt.from !== evt.to || evt.newIndex !== evt.oldIndex ) {

--- a/lib/decorators/component-list.js
+++ b/lib/decorators/component-list.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import dragula from 'dragula';
+import sortable from 'sortablejs';
 import { isPage } from 'clayutils';
 import { getComponentName, layoutAttr, editAttr, componentListProp, pageAreaClass, collapsibleListClass, dropAreaClass, dragItemClass, dragItemUnsavedClass, refAttr, refProp, reorderItemAttr } from '../utils/references';
 import { getData, getSchema } from '../core-data/components';
@@ -36,12 +36,13 @@ function updateOrder(el) {
       // save an open child component's form before saving the parent component
       return store.dispatch('unfocus').then(() => store.dispatch('saveComponent', { uri, data: { [path]: newList } }));
     } else {
+
       return store.dispatch('saveComponent', { uri, data: { [path]: newList } });
     }
   } else {
+
     // data is in a page area
     newList = _.map(childEls, (childEl) => childEl.getAttribute(refAttr));
-
     if (_.get(store, 'state.ui.currentFocus')) {
       // save an open child component's form before saving the page
       return store.dispatch('unfocus').then(() => store.dispatch('savePage', { [path]: newList }));
@@ -85,13 +86,29 @@ function isDraggable(handle, container) {
     || !handle.hasAttribute(refAttr) && getComponentDepth(handle, container) === 1;
 }
 
-function addDragula(el) {
-  const drag = dragula([el], {
-    deadzone: 50,
-    ignoreInputTextSelection: false, // we're handling this in the `invalid` function below
-    moves(selectedItem, container, handle) {
-      const uri = selectedItem.hasAttribute(refAttr) && selectedItem.getAttribute(refAttr),
-        isPageEditMode = _.get(store, 'state.editMode') === 'page';
+function addSortableJS(el) {
+  let dragDelay = 0;
+
+  if (window.matchMedia && window.matchMedia('(hover: none)').matches) {
+    // for devices that don't support hover, add a drag delay.  this requires a tap and hold before you can drag which means you can scroll
+    // on mobile without triggering drags every time your finger touches a draggable element
+    dragDelay = 200;
+  }
+
+  sortable.create(el, {
+    delay: dragDelay,
+    scroll: true,
+    scrollSensitivity: 40,
+    dragClass: dragItemClass,
+    removeCloneOnHide: true,
+    onStart(evt) {
+      evt.item.classList.add(dragItemClass);
+      evt.srcElement.classList.add(dropAreaClass);
+    },
+    onMove(evt) {
+      const uri = evt.dragged.hasAttribute(refAttr) && evt.dragged.getAttribute(refAttr),
+        isPageEditMode = _.get(store, 'state.editMode') === 'page',
+        isInsideField = evt.dragged.classList.contains('kiln-field');
 
       let isPageComponent, isActive;
 
@@ -103,61 +120,41 @@ function addDragula(el) {
       isPageComponent = isComponentInPage(uri);
       isActive = isPageEditMode && isPageComponent || !isPageEditMode && !isPageComponent;
 
-      // only allow direct child components of a list to be dragged
-      // this allows for nested component lists + dragdrop
-      // note: also only allow active (in the edit mode you're currently in) components to be dragged
-      return isActive && isDraggable(handle, container);
-    },
-    invalid(selectedItem) {
-      const isInsideField = selectedItem.classList.contains('kiln-field');
-
       if (isInsideField) {
         // set isInvalidDrag if user is selecting text inside form fields.
         // it's unset when they either click another thing in the form
         // OR if the document click event fires (when they mouseup outside of the form)
         window.kiln.isInvalidDrag = true;
+
+        // returning false reverts to the original order
+        return false;
       }
 
+      // only allow direct child components of a list to be dragged
+      // this allows for nested component lists + dragdrop
+      // note: also only allow active (in the edit mode you're currently in) components to be dragged
       // don't drag parent if the target is a draggable complex-list item
-      return isInsideField || selectedItem.hasAttribute(reorderItemAttr);
-    }
-  });
+      // if any of these are false, the drop will revert to the original order
+      return isActive && isDraggable(evt.dragged, evt.from) && evt.dragged.hasAttribute(reorderItemAttr);
+    },
+    onEnd(evt) {
+      evt.item.classList.remove(dragItemClass);
+      evt.from.classList.remove(dropAreaClass);
+      if ( evt.from !== evt.to || evt.newIndex !== evt.oldIndex ) {
+        updateOrder(el).then(() => {
+          evt.item.classList.remove(dragItemUnsavedClass);
+        });
+      } else {
+        // The keen-ui-ripple-ink component relies on mouseup to trigger the removal of its styles.
+        // When you start to drag an element, but end up dropping it in the same spot you started from,
+        // keen-ui isn't registering the mouseup event so we're manually triggering a mouseup that it will react to.
+        const mouseUpEvent = document.createEvent('MouseEvents');
 
-  // add event listeners to reorder components
-  // auto-scroll when you drag to the edge of the window
-  drag.on('cloned', function (mirror) {
-    const buffer = 40;
-
-    let dragging = window.setInterval(() => {
-      const rect = mirror.getBoundingClientRect();
-
-      if (!drag.dragging) {
-        window.clearInterval(dragging);
-      } else if (rect.top < buffer) {
-        window.scrollBy(0, -buffer * 2);
-      } else if (window.innerHeight - rect.bottom < buffer) {
-        window.scrollBy(0, buffer * 2);
+        mouseUpEvent.initEvent('mouseup', true, true);
+        document.dispatchEvent(mouseUpEvent);
+        evt.item.classList.remove(dragItemUnsavedClass);
       }
-    }, 250);
-  });
-  // add classes when you start dragging
-  drag.on('drag', function (selectedItem, container) {
-    selectedItem.classList.add(dragItemClass);
-    container.classList.add(dropAreaClass);
-  });
-  // remove classes when you cancel dragging
-  drag.on('cancel', function (selectedItem, container) {
-    selectedItem.classList.remove(dragItemClass);
-    container.classList.remove(dropAreaClass);
-  });
-  // handle reordering
-  drag.on('drop', function (selectedItem, container) {
-    // selectedItem.classList.add(dragItemUnsavedClass);
-    selectedItem.classList.remove(dragItemClass);
-    container.classList.remove(dropAreaClass);
-    updateOrder(el).then(() => {
-      selectedItem.classList.remove(dragItemUnsavedClass);
-    });
+    }
   });
 }
 
@@ -208,8 +205,8 @@ function addComponentList(el, componentList) {
     el.classList.add(collapsibleListClass);
   }
 
-  // enable dragula
-  addDragula(el);
+  // enable sortableJS
+  addSortableJS(el);
 }
 
 /**

--- a/lib/decorators/component-list.js
+++ b/lib/decorators/component-list.js
@@ -135,7 +135,7 @@ function addSortableJS(el) {
       // note: also only allow active (in the edit mode you're currently in) components to be dragged
       // don't drag parent if the target is a draggable complex-list item
       // if any of these are false, the drop will revert to the original order
-      return isActive && isDraggable(evt.dragged, evt.from) && evt.dragged.hasAttribute(reorderItemAttr);
+      return isActive && isDraggable(evt.dragged, evt.from) && !evt.dragged.hasAttribute(reorderItemAttr);
     },
     onEnd(evt) {
       evt.item.classList.remove(dragItemClass);

--- a/lib/decorators/component-list.js
+++ b/lib/decorators/component-list.js
@@ -87,6 +87,9 @@ function isDraggable(handle, container) {
 }
 
 function addSortableJS(el) {
+  if ( el.classList.contains('kiln-internals')) {
+    return false;
+  }
   let dragDelay = 0;
 
   if (window.matchMedia && window.matchMedia('(hover: none)').matches) {
@@ -99,7 +102,6 @@ function addSortableJS(el) {
     delay: dragDelay,
     scroll: true,
     scrollSensitivity: 40,
-    dragClass: dragItemClass,
     removeCloneOnHide: true,
     onStart(evt) {
       evt.item.classList.add(dragItemClass);
@@ -138,6 +140,7 @@ function addSortableJS(el) {
       return isActive && isDraggable(evt.dragged, evt.from) && !evt.dragged.hasAttribute(reorderItemAttr);
     },
     onEnd(evt) {
+      console.log(evt);
       evt.item.classList.remove(dragItemClass);
       evt.from.classList.remove(dropAreaClass);
       if ( evt.from !== evt.to || evt.newIndex !== evt.oldIndex ) {

--- a/lib/decorators/helpers.js
+++ b/lib/decorators/helpers.js
@@ -1,0 +1,16 @@
+const getDragDelay = () => {
+  // Elements that use SortableJS have a dragDelay property which is the ms
+  // the user must hold the element before they can drag it.  On desktop this
+  // should be 0.
+  let dragDelay = 0;
+
+  if (window.matchMedia && window.matchMedia('(hover: none)').matches) {
+    // for devices that don't support hover (i.e. mobile devices), dragDelay is set to 200 so users
+    //  can scroll without triggering drags every time their finger touches a draggable element
+    dragDelay = 200;
+  }
+
+  return dragDelay;
+};
+
+export { getDragDelay };

--- a/lib/decorators/helpers.js
+++ b/lib/decorators/helpers.js
@@ -4,7 +4,7 @@ const getDragDelay = () => {
   // should be 0.
   let dragDelay = 0;
 
-  if ((window.matchMedia && window.matchMedia('(hover: none)').matches) || ('ontouchstart' in document.documentElement)) {
+  if (window.matchMedia && window.matchMedia('(hover: none)').matches || 'ontouchstart' in document.documentElement) {
     // for devices that don't support hover (i.e. mobile devices), dragDelay is set to 200 so users
     //  can scroll without triggering drags every time their finger touches a draggable element
     dragDelay = 200;

--- a/lib/decorators/helpers.js
+++ b/lib/decorators/helpers.js
@@ -4,7 +4,7 @@ const getDragDelay = () => {
   // should be 0.
   let dragDelay = 0;
 
-  if (window.matchMedia && window.matchMedia('(hover: none)').matches) {
+  if ((window.matchMedia && window.matchMedia('(hover: none)').matches) || ('ontouchstart' in document.documentElement)) {
     // for devices that don't support hover (i.e. mobile devices), dragDelay is set to 200 so users
     //  can scroll without triggering drags every time their finger touches a draggable element
     dragDelay = 200;

--- a/lib/utils/filterable-list.vue
+++ b/lib/utils/filterable-list.vue
@@ -130,6 +130,7 @@
   import listItem from './filterable-list-item.vue';
   import UiTextbox from 'keen/UiTextbox';
   import UiButton from 'keen/UiButton';
+  import { getDragDelay } from '../decorators/helpers';
 
   /**
    * Add SortableJS functionality
@@ -139,6 +140,7 @@
    */
   function addSortableJS(el, reorder) {
     sortable.create(el, {
+      delay: getDragDelay(),
       direction: 'vertical',
       handle: '.drag_handle',
       onEnd(evt) {

--- a/lib/utils/filterable-list.vue
+++ b/lib/utils/filterable-list.vue
@@ -125,48 +125,27 @@
 <script>
   import _ from 'lodash';
   import { find } from '@nymag/dom';
-  import dragula from 'dragula';
+  import sortable from 'sortablejs';
   import { requestTimeout } from './events';
   import listItem from './filterable-list-item.vue';
   import UiTextbox from 'keen/UiTextbox';
   import UiButton from 'keen/UiButton';
 
-  // Placeholder for Dragula instance
-  var drag;
+  let sortableList;
 
   /**
-   * get index of a child element in a container
-   * @param {Element} el
-   * @param {Element} container
-   * @returns {number}
-   */
-  function getIndex(el, container) {
-    return _.findIndex(container.children, (child) => child === el);
-  }
-
-  /**
-   * Add Dragula functionality
+   * Add SortableJS functionality
    *
    * @param {Element} el
    * @param {Function} reorder
    */
-  function addDragula(el, reorder) {
-    var oldIndex;
-
-    drag = dragula([el], {
-      direction: 'vertical'
-    });
-
-    drag.on('drag', function (selectedItem, container) {
-      oldIndex = getIndex(selectedItem, container);
-    });
-
-    drag.on('cancel', function () {
-      oldIndex = null;
-    });
-
-    drag.on('drop', function (selectedItem, container) {
-      reorder(selectedItem.getAttribute('data-item-id'), getIndex(selectedItem, container), oldIndex, selectedItem);
+  function addSortableJS(el, reorder) {
+    sortableList =  sortable.create(el, {
+      direction: 'vertical',
+      handle: '.drag_handle',
+      onEnd(evt) {
+        reorder(evt.item.getAttribute('data-item-id'), evt.newIndex, evt.oldIndex, evt.item);
+      }
     });
   }
 
@@ -302,9 +281,9 @@
       // set initial list data
       this.matches = this.fullContent;
 
-      // Add dragula
+      // Add Sortable
       if (this.hasReorder) {
-        addDragula(this.$refs.list, this.onReorder);
+        addSortableJS(this.$refs.list, this.onReorder);
       }
 
       this.$nextTick(() => {
@@ -315,9 +294,9 @@
       });
     },
     beforeDestroy() {
-      // Clean up any Dragula event handlers
-      if (drag) {
-        drag.destroy();
+      // Clean up any Sortable event handlers
+      if (sortableList) {
+        sortableList.destroy();
       }
     },
     methods: {

--- a/lib/utils/filterable-list.vue
+++ b/lib/utils/filterable-list.vue
@@ -131,8 +131,6 @@
   import UiTextbox from 'keen/UiTextbox';
   import UiButton from 'keen/UiButton';
 
-  let sortableList;
-
   /**
    * Add SortableJS functionality
    *
@@ -140,7 +138,7 @@
    * @param {Function} reorder
    */
   function addSortableJS(el, reorder) {
-    sortableList =  sortable.create(el, {
+    sortable.create(el, {
       direction: 'vertical',
       handle: '.drag_handle',
       onEnd(evt) {
@@ -292,12 +290,6 @@
         // focus on the input if it wasn't focused before
         input && input.focus();
       });
-    },
-    beforeDestroy() {
-      // Clean up any Sortable event handlers
-      if (sortableList) {
-        sortableList.destroy();
-      }
     },
     methods: {
       focusOnIndex(index, childIndex) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "8.3.4-0",
+  "version": "8.3.4-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12272,7 +12272,8 @@
     "sortablejs": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.8.1.tgz",
-      "integrity": "sha512-r0bKxZYGUFgv/6DQSWW8TVJBBtupUn6TPnDABd4rlqNq+u94ct5+barZmYauPAQNCKwy56C1kg9Y9msAN7UPag=="
+      "integrity": "sha512-r0bKxZYGUFgv/6DQSWW8TVJBBtupUn6TPnDABd4rlqNq+u94ct5+barZmYauPAQNCKwy56C1kg9Y9msAN7UPag==",
+      "dev": true
     },
     "source-list-map": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12309,6 +12309,11 @@
         "is-plain-obj": "^1.0.0"
       }
     },
+    "sortablejs": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.8.1.tgz",
+      "integrity": "sha512-r0bKxZYGUFgv/6DQSWW8TVJBBtupUn6TPnDABd4rlqNq+u94ct5+barZmYauPAQNCKwy56C1kg9Y9msAN7UPag=="
+    },
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "8.3.3",
+  "version": "8.3.4-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -389,12 +389,6 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "atoa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz",
-      "integrity": "sha1-DMDpGkgOc4+SPrwQNnZHF3mzSkk=",
-      "dev": true
-    },
     "atob": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
@@ -2165,16 +2159,6 @@
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
-    "contra": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.1.tgz",
-      "integrity": "sha1-YOSYJ0s9LTMoltYPgpAK76LsrIw=",
-      "dev": true,
-      "requires": {
-        "atoa": "1.0.0",
-        "ticky": "1.0.0"
-      }
-    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
@@ -2289,15 +2273,6 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      }
-    },
-    "crossvent": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.4.tgz",
-      "integrity": "sha1-2ixPj0DJR4JRe/K+7BBEFIGUq5I=",
-      "dev": true,
-      "requires": {
-        "custom-event": "1.0.0"
       }
     },
     "crypto-browserify": {
@@ -2655,12 +2630,6 @@
         "array-find-index": "^1.0.1"
       }
     },
-    "custom-event": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz",
-      "integrity": "sha1-LkYovhncSyFLXAJjDFlx6BFhgGI=",
-      "dev": true
-    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -3008,15 +2977,6 @@
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
-      }
-    },
-    "dragula": {
-      "version": "github:gitterhq/dragula#ccda30b674e3b2098d26caed3e2f09f127f04c3b",
-      "from": "github:gitterhq/dragula#feature/deadzone",
-      "dev": true,
-      "requires": {
-        "contra": "1.9.1",
-        "crossvent": "1.5.4"
       }
     },
     "ecc-jsbn": {
@@ -12906,12 +12866,6 @@
         "readable-stream": "^2.1.5",
         "xtend": "~4.0.1"
       }
-    },
-    "ticky": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.0.tgz",
-      "integrity": "sha1-6H847gSR6jL2Lo8FZ7qWOLKfBJw=",
-      "dev": true
     },
     "timers-browserify": {
       "version": "2.0.10",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "sass-loader": "^6.0.6",
     "set-dom": "^7.4.5",
     "snarkdown": "^1.2.2",
+    "sortablejs": "^1.8.1",
     "speakingurl": "^14.0.1",
     "striptags": "^3.1.0",
     "style-loader": "^0.19.0",
@@ -160,8 +161,5 @@
   },
   "peerDependencies": {
     "amphora-search": "^6.2.0"
-  },
-  "dependencies": {
-    "sortablejs": "^1.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "8.3.3",
+  "version": "8.3.4-0",
   "description": "Editor tools for Clay",
   "template": "template.handlebars",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "cuid": "^1.3.8",
     "date-fns": "^1.29.0",
     "delegate": "^3.1.2",
-    "dragula": "github:gitterhq/dragula#feature/deadzone",
     "element-client-rect": "^1.0.4",
     "eslint": "~4.10.0",
     "eslint-plugin-html": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "8.3.4-0",
+  "version": "8.3.4-1",
   "description": "Editor tools for Clay",
   "template": "template.handlebars",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -162,5 +162,7 @@
   "peerDependencies": {
     "amphora-search": "^6.2.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "sortablejs": "^1.8.1"
+  }
 }

--- a/styleguide/component-list-drag.scss
+++ b/styleguide/component-list-drag.scss
@@ -68,6 +68,7 @@
   width: 300px;
   z-index: 9998;
   li {
+    /* hide item to be deleted while it's on the trash item */
     display: none;
   }
 }

--- a/styleguide/component-list-drag.scss
+++ b/styleguide/component-list-drag.scss
@@ -67,6 +67,9 @@
   position: fixed;
   width: 300px;
   z-index: 9998;
+  li {
+    display: none;
+  }
 }
 
 .complex-list-trash .material-icons {


### PR DESCRIPTION
Switched out the dragula drag and drop library for the sortablejs drag and drop library.  This allows for much smoother scrolling on mobile because you now tap and hold on draggable elements to move them on mobile. 

https://app.zenhub.com/workspaces/clay-repos-596524da4a8a0769f2f03175/issues/clay/clay-kiln/904

