### PR TITLE
updating keenu-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6670,9 +6670,9 @@
       "dev": true
     },
     "keen-ui": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/keen-ui/-/keen-ui-1.0.1.tgz",
-      "integrity": "sha512-C4E4fGQk6V/WiqvSNgpQbnbRN48fi1eV3lMNjJLWlMuqlYl8wpboa0q8aq4Poxk/Ktd9q5jJyYtJFoa3bMJu7g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/keen-ui/-/keen-ui-1.0.2.tgz",
+      "integrity": "sha512-E8EZ3r+JWpzW6HSdGiw6BLki1wONVZlc5BSp+tWe/KF4Ea63HWdTRktABrcDlcTkXikJ4rka2zjV/vJRjH1oWA==",
       "dev": true,
       "requires": {
         "autosize": "^3.0.20",
@@ -12844,9 +12844,9 @@
       }
     },
     "tether": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.4.tgz",
-      "integrity": "sha512-bagKeRRo3vEynHnO3GB7/jB3Q4YIf0mN7gXM/nR0wZvNHkPrwmZemg1w0C32JZP0prHZUwxGwoX5CdA7tuIDEw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.5.tgz",
+      "integrity": "sha512-fysT1Gug2wbRi7a6waeu39yVDwiNtvwj5m9eRD+qZDSHKNghLo6KqP/U3yM2ap6TNUL2skjXGJaJJTJqoC31vw==",
       "dev": true
     },
     "tether-drop": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "jest": "^23.1.0",
     "jest-serializer-vue": "^2.0.0",
     "jsdoc-to-markdown": "^3.0.1",
-    "keen-ui": "^1.0.1",
+    "keen-ui": "^1.0.2",
     "keycode": "^2.1.8",
     "localforage": "^1.5.3",
     "lodash": "^4.17.4",


### PR DESCRIPTION
https://app.zenhub.com/workspaces/clay-repos-596524da4a8a0769f2f03175/issues/clay/clay-kiln/1373

https://github.com/clay/clay-kiln/issues/1373

Updating version of keen-ui to eliminate the error that was happening when you were on the last day of the month and clicked the next month arrow and the datepicker skipped a month.