### PR TITLE
Deep linking

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,6 @@
       "templateStrings": true,
       "generators": true,
       "modules": true,
-      "spread": true,
       "experimentalObjectRestSpread": true
     }
   },

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,9 @@
       "binaryLiterals": true,
       "templateStrings": true,
       "generators": true,
-      "modules": true
+      "modules": true,
+      "spread": true,
+      "experimentalObjectRestSpread": true
     }
   },
   "plugins": ["html"],

--- a/docs/api.md
+++ b/docs/api.md
@@ -187,9 +187,7 @@ The Vuex state looks similar to this:
     currentAddComponentModal: { currentURI, parentURI, path, available }, // current "add component" modal
     currentModal: { title, type, size, data }, // current "simple" modal
     currentConfirm: { title, text, button, onConfirm }, // current "confirmation" modal
-    currentDrawer: null, // current right-hand drawer
-    currentNav: null, // current left-hand nav
-    currentNavConfig: null, // used to deep-link into the nav
+    currentDrawer: null, // current drawer menu, both left and right drawers
     currentSelection: null, // currently selected component, gets uri
     currentFocus: { uri, path }, // currently focused field/group
     currentProgress: 0, // progress bar, gets random number (to prevent flashes)

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,7 +51,7 @@ Property | Description
 
 You may add options to the Clay menu to be displayed between `New Page` and `Sign Out` options. The trigger buttons should extend the `navMenuButton` component included in `window.kiln.components` and should be added to `window.kiln.navButtons.`
 
-Custom nav buttons should dispatch the `openNav` action with the same id used to name the nav button and nav content in the global `kiln` object.
+Custom nav buttons should dispatch the `openDrawer` action with the same id used to name the nav button and nav content in the global `kiln` object.
 
 The body of the nav option should be added to `window.kiln.navContent` using the same object key that was used to add the corresponding nav button.
 

--- a/docs/vuex-actions.md
+++ b/docs/vuex-actions.md
@@ -56,7 +56,7 @@
 ### component-data.saveComponent(store, uri, data, [eventID], [snapshot], [prevData]) ⇒ <code>Promise</code>
 save a component's data and re-render
 
-**Kind**: static method of [<code>component-data</code>](#module_component-data)
+**Kind**: static method of [<code>component-data</code>](#module_component-data)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -73,7 +73,7 @@ save a component's data and re-render
 remove a component from its parent
 note: removes from parent component OR page
 
-**Kind**: static method of [<code>component-data</code>](#module_component-data)
+**Kind**: static method of [<code>component-data</code>](#module_component-data)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -85,7 +85,7 @@ note: removes from parent component OR page
 ### component-data.removeHeadComponent(store, startNode) ⇒ <code>Promise</code>
 remove head components (from page or layout)
 
-**Kind**: static method of [<code>component-data</code>](#module_component-data)
+**Kind**: static method of [<code>component-data</code>](#module_component-data)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -101,8 +101,8 @@ note: always creates new instances of the components you're adding
 note: allows you to replace a specific uri, or add components after it
 note: if no currentURI passed in, it will add new components to the end (and won't replace anything)
 
-**Kind**: static method of [<code>component-data</code>](#module_component-data)
-**Returns**: <code>Promise</code> - with the last added component's el
+**Kind**: static method of [<code>component-data</code>](#module_component-data)  
+**Returns**: <code>Promise</code> - with the last added component's el  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -118,7 +118,7 @@ note: if no currentURI passed in, it will add new components to the end (and won
 ### component-data.openAddComponent(store, [currentURI], parentURI, path) ⇒ <code>Promise</code>
 open the add components pane, or add a new components
 
-**Kind**: static method of [<code>component-data</code>](#module_component-data)
+**Kind**: static method of [<code>component-data</code>](#module_component-data)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -132,31 +132,31 @@ open the add components pane, or add a new components
 ### component-data~logSaveError(uri, e, data, [eventID], [snapshot], store)
 log errors when components save and display them to the user
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
 
 | Param | Type |
 | --- | --- |
-| uri | <code>string</code> |
-| e | <code>Error</code> |
-| data | <code>object</code> |
-| [eventID] | <code>string</code> |
-| [snapshot] | <code>boolean</code> |
-| store | <code>object</code> |
+| uri | <code>string</code> | 
+| e | <code>Error</code> | 
+| data | <code>object</code> | 
+| [eventID] | <code>string</code> | 
+| [snapshot] | <code>boolean</code> | 
+| store | <code>object</code> | 
 
 <a name="module_component-data..revertReject"></a>
 
 ### component-data~revertReject(uri, data, [snapshot], paths, store) ⇒ <code>Promise</code>
 re-render (reverting) a component and stop the saving promise chain
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
 
 | Param | Type |
 | --- | --- |
-| uri | <code>string</code> |
-| data | <code>object</code> |
-| [snapshot] | <code>boolean</code> |
-| paths | <code>array</code> |
-| store | <code>object</code> |
+| uri | <code>string</code> | 
+| data | <code>object</code> | 
+| [snapshot] | <code>boolean</code> | 
+| paths | <code>array</code> | 
+| store | <code>object</code> | 
 
 <a name="module_component-data..clientSave"></a>
 
@@ -165,7 +165,7 @@ save data client-side and queue up api call for the server
 note: this uses the components' model.js (if it exists) and handlebars template
 note: server-side saving and/or re-rendering has been removed in kiln v4.x
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -183,19 +183,19 @@ note: server-side saving and/or re-rendering has been removed in kiln v4.x
 find the index of a uri in a list
 this is broken out into a separate function so we don't assume an index of 0 is falsy
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
 
 | Param | Type |
 | --- | --- |
-| data | <code>array</code> |
-| [uri] | <code>string</code> |
+| data | <code>array</code> | 
+| [uri] | <code>string</code> | 
 
 <a name="module_component-data..addComponentsToComponentList"></a>
 
 ### component-data~addComponentsToComponentList(store, data, [currentURI], parentURI, path, [replace], components) ⇒ <code>Promise</code>
 add one or more components to a component list
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -212,7 +212,7 @@ add one or more components to a component list
 ### component-data~addComponentsToComponentProp(store, data, parentURI, path, components) ⇒ <code>Promise</code>
 replace a single component in another component's property
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -227,15 +227,15 @@ replace a single component in another component's property
 ### component-data~addComponentsToPageArea(store, currentURI, path, replace, components) ⇒ <code>Promise</code>
 add one or more components to a page area
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| currentURI | <code>string</code> |
-| path | <code>string</code> |
-| replace | <code>boolean</code> |
-| components | <code>array</code> |
+| store | <code>object</code> | 
+| currentURI | <code>string</code> | 
+| path | <code>string</code> | 
+| replace | <code>boolean</code> | 
+| components | <code>array</code> | 
 
 <a name="module_decorators"></a>
 
@@ -253,42 +253,42 @@ add one or more components to a page area
 ### decorators.unselect(store)
 unselect currently-selected component
 
-**Kind**: static method of [<code>decorators</code>](#module_decorators)
+**Kind**: static method of [<code>decorators</code>](#module_decorators)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
+| store | <code>object</code> | 
 
 <a name="module_decorators.select"></a>
 
 ### decorators.select(store, el)
 select a component
 
-**Kind**: static method of [<code>decorators</code>](#module_decorators)
+**Kind**: static method of [<code>decorators</code>](#module_decorators)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| el | <code>element</code> |
+| store | <code>object</code> | 
+| el | <code>element</code> | 
 
 <a name="module_decorators.scrollToComponent"></a>
 
 ### decorators.scrollToComponent(store, el)
 Scroll user to the component. "Weeee!" or "What the?"
 
-**Kind**: static method of [<code>decorators</code>](#module_decorators)
+**Kind**: static method of [<code>decorators</code>](#module_decorators)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| el | <code>Element</code> |
+| store | <code>object</code> | 
+| el | <code>Element</code> | 
 
 <a name="module_decorators.navigateComponents"></a>
 
 ### decorators.navigateComponents(store, direction) ⇒ <code>Promise</code>
 navigate to the previous or next component
 
-**Kind**: static method of [<code>decorators</code>](#module_decorators)
+**Kind**: static method of [<code>decorators</code>](#module_decorators)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -300,11 +300,11 @@ navigate to the previous or next component
 ### decorators.unfocus(store) ⇒ <code>Promise</code>
 unfocus currently-focused field/group
 
-**Kind**: static method of [<code>decorators</code>](#module_decorators)
+**Kind**: static method of [<code>decorators</code>](#module_decorators)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
+| store | <code>object</code> | 
 
 <a name="module_deep-linking"></a>
 
@@ -320,72 +320,68 @@ unfocus currently-focused field/group
 ### deep-linking.parseURLHash(store) ⇒ <code>Promise</code>
 parse url hash, opening form or clay menu as necessary
 
-**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)
+**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
+| store | <code>object</code> | 
 
 <a name="module_deep-linking.setHash"></a>
 
 ### deep-linking.setHash(commit, [uri], [path], [initialFocus], [menu])
 set hash in window and store
 
-**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)
+**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)  
 
 | Param | Type |
 | --- | --- |
-| commit | <code>function</code> |
-| [uri] | <code>string</code> |
-| [path] | <code>string</code> |
-| [initialFocus] | <code>string</code> |
-| [menu] | <code>object</code> |
+| commit | <code>function</code> | 
+| [uri] | <code>string</code> | 
+| [path] | <code>string</code> | 
+| [initialFocus] | <code>string</code> | 
+| [menu] | <code>object</code> | 
 
 <a name="module_deep-linking.clearHash"></a>
 
 ### deep-linking.clearHash(commit)
 clear hash in window and store
 
-**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)
+**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)  
 
 | Param | Type |
 | --- | --- |
-| commit | <code>function</code> |
+| commit | <code>function</code> | 
 
 <a name="module_drawers"></a>
 
 ## drawers
+
+* [drawers](#module_drawers)
+    * [.closeDrawer(store)](#module_drawers.closeDrawer)
+    * [.openDrawer(store, nameOrConfig)](#module_drawers.openDrawer)
+
 <a name="module_drawers.closeDrawer"></a>
 
 ### drawers.closeDrawer(store)
-close drawer without toggling a new drawer, calls <a href="#module_deep-linking">clearHash</a>
+close drawer without toggling a new drawer
 
-**Kind**: static method of [<code>drawers</code>](#module_drawers)
+**Kind**: static method of [<code>drawers</code>](#module_drawers)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>Object</code> |
+| store | <code>Object</code> | 
+
+<a name="module_drawers.openDrawer"></a>
 
 ### drawers.openDrawer(store, nameOrConfig)
-open Drawer, will close any other open drawer, calls <a href="#module_deep-linking">setHash</a> so drawer is automatically deep-linked to
+open drawer
 
-**Kind**: static method of [<code>drawer</code>](#module_nav)
-
-| Param | Type | Description |
-| --- | --- | --- |
-| store | <code>object</code> |  |
-| nameOrConfig | <code>string</code> \| <code>object</code> | tab name, or clay menu config |
-
-### drawers.toggleDrawer(store, nameOrConfig)
-open or close Drawer passed to it, depending upon its current state. i.e. if it's closed, it will be opened, if it's closed, it will be opened.
-
-**Kind**: static method of [<code>drawer</code>](#module_nav)
+**Kind**: static method of [<code>drawers</code>](#module_drawers)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| store | <code>object</code> |  |
-| nameOrConfig | <code>string</code> \| <code>object</code> | tab name, or clay menu config |
-
+| store | <code>Object</code> |  |
+| nameOrConfig | <code>string</code> \| <code>object</code> | either just the tab name or a json object for deeper linking |
 
 <a name="module_forms"></a>
 
@@ -402,7 +398,7 @@ open or close Drawer passed to it, depending upon its current state. i.e. if it'
 ### forms.openForm(store, uri, path, [el], [offset], [appendText], [initialFocus], pos)
 open form
 
-**Kind**: static method of [<code>forms</code>](#module_forms)
+**Kind**: static method of [<code>forms</code>](#module_forms)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -421,7 +417,7 @@ open form
 determine if data in form has changed
 note: convert data to plain objects, since they're reactive
 
-**Kind**: inner method of [<code>forms</code>](#module_forms)
+**Kind**: inner method of [<code>forms</code>](#module_forms)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -446,41 +442,41 @@ get the list data for a specific layout
 note: if prefix / uri is specified, this does NOT commit the data (only returns it),
 allowing the preloader to use it when doing the initial preload of data
 
-**Kind**: static method of [<code>layout-state</code>](#module_layout-state)
+**Kind**: static method of [<code>layout-state</code>](#module_layout-state)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| [preloadOptions] | <code>object</code> |
-| [preloadOptions.uri] | <code>string</code> |
-| [preloadOptions.prefix] | <code>string</code> |
-| [preloadOptions.user] | <code>object</code> |
+| store | <code>object</code> | 
+| [preloadOptions] | <code>object</code> | 
+| [preloadOptions.uri] | <code>string</code> | 
+| [preloadOptions.prefix] | <code>string</code> | 
+| [preloadOptions.user] | <code>object</code> | 
 
 <a name="module_layout-state.updateLayout"></a>
 
 ### layout-state.updateLayout(store, [data], [preloadOptions]) ⇒ <code>Promise</code>
 update a layout's title, or just the latest timestamp + user
 
-**Kind**: static method of [<code>layout-state</code>](#module_layout-state)
+**Kind**: static method of [<code>layout-state</code>](#module_layout-state)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| [data] | <code>object</code> |
-| [data.title] | <code>string</code> |
-| [preloadOptions] | <code>object</code> |
+| store | <code>object</code> | 
+| [data] | <code>object</code> | 
+| [data.title] | <code>string</code> | 
+| [preloadOptions] | <code>object</code> | 
 
 <a name="module_layout-state.scheduleLayout"></a>
 
 ### layout-state.scheduleLayout(store, timestamp) ⇒ <code>Promise</code>
 schedule the layout and update its index
 
-**Kind**: static method of [<code>layout-state</code>](#module_layout-state)
+**Kind**: static method of [<code>layout-state</code>](#module_layout-state)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| timestamp | <code>Date</code> |
+| store | <code>object</code> | 
+| timestamp | <code>Date</code> | 
 
 <a name="module_layout-state.unscheduleLayout"></a>
 
@@ -488,12 +484,12 @@ schedule the layout and update its index
 unschedule the layout
 get updated layout state if the call wasn't made during layout publish
 
-**Kind**: static method of [<code>layout-state</code>](#module_layout-state)
+**Kind**: static method of [<code>layout-state</code>](#module_layout-state)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| [publishing] | <code>Boolean</code> |
+| store | <code>object</code> | 
+| [publishing] | <code>Boolean</code> | 
 
 <a name="module_layout-state.publishLayout"></a>
 
@@ -503,11 +499,11 @@ note: layouts index is updated server-side, including unscheduling the layout
 if it's currently scheduled
 also note: this will trigger a fetch of the updated (published) layout state
 
-**Kind**: static method of [<code>layout-state</code>](#module_layout-state)
+**Kind**: static method of [<code>layout-state</code>](#module_layout-state)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
+| store | <code>object</code> | 
 
 <a name="module_lists"></a>
 
@@ -518,7 +514,14 @@ also note: this will trigger a fetch of the updated (published) layout state
 <a name="module_nav.openNav"></a>
 
 ### nav.openNav(store, nameOrConfig)
-Depreciated: See <a href="#module_drawers">Drawer</a>
+open nav tab
+
+**Kind**: static method of [<code>nav</code>](#module_nav)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| store | <code>object</code> |  |
+| nameOrConfig | <code>string</code> \| <code>object</code> | tab name, or clay menu config openNav sets the ui.currentDrawer vuex variable, this allows drawers (the right slide-in menus) as well as the "nav" (the left slide-in menu) to be deep linked to. The openNav/closeNav are functions are depreciated. Should use the openDrawer/closeDrawer/toggleDrawer actions Just leaving these here in case any legacy plugins are still calling these functions |
 
 <a name="module_page-data"></a>
 
@@ -542,7 +545,7 @@ Depreciated: See <a href="#module_drawers">Drawer</a>
 save a page's data, but do not re-render
 because, uh, that would just be reloading the page
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)
+**Kind**: static method of [<code>page-data</code>](#module_page-data)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -555,49 +558,49 @@ because, uh, that would just be reloading the page
 ### page-data.createPage(store, id) ⇒ <code>Promise</code>
 create a new page, then return its editable link
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)
+**Kind**: static method of [<code>page-data</code>](#module_page-data)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| id | <code>string</code> |
+| store | <code>object</code> | 
+| id | <code>string</code> | 
 
 <a name="module_page-data.publishPage"></a>
 
 ### page-data.publishPage(store, uri) ⇒ <code>Promise</code>
 manually publish the page
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)
+**Kind**: static method of [<code>page-data</code>](#module_page-data)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| uri | <code>string</code> |
+| store | <code>object</code> | 
+| uri | <code>string</code> | 
 
 <a name="module_page-data.unpublishPage"></a>
 
 ### page-data.unpublishPage(store, uri) ⇒ <code>Promise</code>
 remove uri from /uris/
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)
+**Kind**: static method of [<code>page-data</code>](#module_page-data)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| uri | <code>string</code> |
+| store | <code>object</code> | 
+| uri | <code>string</code> | 
 
 <a name="module_page-data.schedulePage"></a>
 
 ### page-data.schedulePage(store, uri, timestamp) ⇒ <code>Promise</code>
 schedule the page to publish
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)
+**Kind**: static method of [<code>page-data</code>](#module_page-data)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| uri | <code>string</code> |
-| timestamp | <code>Date</code> |
+| store | <code>object</code> | 
+| uri | <code>string</code> | 
+| timestamp | <code>Date</code> | 
 
 <a name="module_page-data.unschedulePage"></a>
 
@@ -605,12 +608,12 @@ schedule the page to publish
 unschedule the page
 get updated page state if the call wasn't made during a page publish
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)
+**Kind**: static method of [<code>page-data</code>](#module_page-data)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| [publishing] | <code>Boolean</code> |
+| store | <code>object</code> | 
+| [publishing] | <code>Boolean</code> | 
 
 <a name="module_page-data..shouldRender"></a>
 
@@ -618,23 +621,23 @@ get updated page state if the call wasn't made during a page publish
 iterate through the paths we're saving
 if one of them ISN'T in the internalPageProps, we should re-render
 
-**Kind**: inner method of [<code>page-data</code>](#module_page-data)
+**Kind**: inner method of [<code>page-data</code>](#module_page-data)  
 
 | Param | Type |
 | --- | --- |
-| paths | <code>array</code> |
+| paths | <code>array</code> | 
 
 <a name="module_page-data..removeURI"></a>
 
 ### page-data~removeURI(uri, store) ⇒ <code>Promise</code>
 remove uri from /uris/
 
-**Kind**: inner method of [<code>page-data</code>](#module_page-data)
+**Kind**: inner method of [<code>page-data</code>](#module_page-data)  
 
 | Param | Type |
 | --- | --- |
-| uri | <code>String</code> |
-| store | <code>Object</code> |
+| uri | <code>String</code> | 
+| store | <code>Object</code> | 
 
 <a name="module_page-state"></a>
 
@@ -655,12 +658,12 @@ note: if called without data, this just updates the updateTime and user
 (e.g. when saving components in the page)
 note: if called with a user, it adds the user (with updateTime) to the page (instead of current user)
 
-**Kind**: static method of [<code>page-state</code>](#module_page-state)
+**Kind**: static method of [<code>page-state</code>](#module_page-state)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
-| [data] | <code>object</code> |
+| store | <code>object</code> | 
+| [data] | <code>object</code> | 
 
 <a name="module_page-state.getListData"></a>
 
@@ -669,7 +672,7 @@ get the list data for a specific page
 note: if prefix is specified, this does NOT commit the data (only returns it),
 allowing the preloader to use it when doing the initial preload of data
 
-**Kind**: static method of [<code>page-state</code>](#module_page-state)
+**Kind**: static method of [<code>page-state</code>](#module_page-state)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -682,13 +685,13 @@ allowing the preloader to use it when doing the initial preload of data
 ### page-state~sequentialUpdate(prefix, uri, data) ⇒ <code>Promise</code>
 run page list updates sequentially, grabbing from the store after each to prevent race conditions
 
-**Kind**: inner method of [<code>page-state</code>](#module_page-state)
+**Kind**: inner method of [<code>page-state</code>](#module_page-state)  
 
 | Param | Type |
 | --- | --- |
-| prefix | <code>string</code> |
-| uri | <code>string</code> |
-| data | <code>object</code> |
+| prefix | <code>string</code> | 
+| uri | <code>string</code> | 
+| data | <code>object</code> | 
 
 <a name="module_preloader"></a>
 
@@ -707,25 +710,25 @@ run page list updates sequentially, grabbing from the store after each to preven
 get component models so we can mount them on window.kiln.componentModels
 if they aren't already mounted (backwards-compatability)
 
-**Kind**: inner method of [<code>preloader</code>](#module_preloader)
+**Kind**: inner method of [<code>preloader</code>](#module_preloader)  
 <a name="module_preloader..reduceComponents"></a>
 
 ### preloader~reduceComponents(result, val) ⇒ <code>obj</code>
 extract component data from preloadData obj
 
-**Kind**: inner method of [<code>preloader</code>](#module_preloader)
+**Kind**: inner method of [<code>preloader</code>](#module_preloader)  
 
 | Param | Type |
 | --- | --- |
-| result | <code>obj</code> |
-| val | <code>obj</code> |
+| result | <code>obj</code> | 
+| val | <code>obj</code> | 
 
 <a name="module_preloader..composeLayoutData"></a>
 
 ### preloader~composeLayoutData(layoutSchema, components, original) ⇒ <code>object</code>
 extract layout data from original data
 
-**Kind**: inner method of [<code>preloader</code>](#module_preloader)
+**Kind**: inner method of [<code>preloader</code>](#module_preloader)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -738,24 +741,24 @@ extract layout data from original data
 ### preloader~reduceTemplates(result, val, key) ⇒ <code>obj</code>
 make precompiled hbs templates ready for user
 
-**Kind**: inner method of [<code>preloader</code>](#module_preloader)
+**Kind**: inner method of [<code>preloader</code>](#module_preloader)  
 
 | Param | Type |
 | --- | --- |
-| result | <code>obj</code> |
-| val | <code>obj</code> |
-| key | <code>string</code> |
+| result | <code>obj</code> | 
+| val | <code>obj</code> | 
+| key | <code>string</code> | 
 
 <a name="module_preloader..getPageStatus"></a>
 
 ### preloader~getPageStatus(state) ⇒ <code>string</code>
 get string state to pass to progress bar
 
-**Kind**: inner method of [<code>preloader</code>](#module_preloader)
+**Kind**: inner method of [<code>preloader</code>](#module_preloader)  
 
 | Param | Type |
 | --- | --- |
-| state | <code>object</code> |
+| state | <code>object</code> | 
 
 <a name="module_toolbar"></a>
 
@@ -774,7 +777,7 @@ get string state to pass to progress bar
 start progress bar. if already started, this will cause a slight pause
 before continuing the progress bar
 
-**Kind**: static method of [<code>toolbar</code>](#module_toolbar)
+**Kind**: static method of [<code>toolbar</code>](#module_toolbar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -786,7 +789,7 @@ before continuing the progress bar
 ### toolbar.finishProgress(commit, type)
 finish the progress bar.
 
-**Kind**: static method of [<code>toolbar</code>](#module_toolbar)
+**Kind**: static method of [<code>toolbar</code>](#module_toolbar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -798,7 +801,7 @@ finish the progress bar.
 ### toolbar.addAlert(store, config)
 add alert to the array
 
-**Kind**: static method of [<code>toolbar</code>](#module_toolbar)
+**Kind**: static method of [<code>toolbar</code>](#module_toolbar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -810,7 +813,7 @@ add alert to the array
 ### toolbar.removeAlert(store, config)
 remove an alert from the array, specifying the index
 
-**Kind**: static method of [<code>toolbar</code>](#module_toolbar)
+**Kind**: static method of [<code>toolbar</code>](#module_toolbar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -823,7 +826,7 @@ remove an alert from the array, specifying the index
 trigger a new snackbar. note: this happens imperatively (toolbar handles the actual creation, by watching this value)
 note: if you want the snackbar to have an action, pass in both `action` (the text of the button) and `onActionClick` (a reference to the function you want invoked)
 
-**Kind**: static method of [<code>toolbar</code>](#module_toolbar)
+**Kind**: static method of [<code>toolbar</code>](#module_toolbar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -849,11 +852,11 @@ note: if you want the snackbar to have an action, pass in both `action` (the tex
 ### undo.createSnapshot(store)
 create snapshot. called from the plugin listening to batched renders
 
-**Kind**: static method of [<code>undo</code>](#module_undo)
+**Kind**: static method of [<code>undo</code>](#module_undo)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
+| store | <code>object</code> | 
 
 <a name="module_undo.setFixedPoint"></a>
 
@@ -862,40 +865,40 @@ create snapshot. called from the plugin listening to batched renders
 when doing a manual save from some point in history, we need to
 remove snapshots after that point (to preserve the expected undo functionality)
 
-**Kind**: static method of [<code>undo</code>](#module_undo)
+**Kind**: static method of [<code>undo</code>](#module_undo)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
+| store | <code>object</code> | 
 
 <a name="module_undo.undo"></a>
 
 ### undo.undo(store)
 undo: sets cursor back one, re-saves affected components with old data
 
-**Kind**: static method of [<code>undo</code>](#module_undo)
+**Kind**: static method of [<code>undo</code>](#module_undo)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
+| store | <code>object</code> | 
 
 <a name="module_undo.redo"></a>
 
 ### undo.redo(store)
 redo: sets cursor forward one, re-saves affected components with new data
 
-**Kind**: static method of [<code>undo</code>](#module_undo)
+**Kind**: static method of [<code>undo</code>](#module_undo)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
+| store | <code>object</code> | 
 
 <a name="module_undo..getChangedComponents"></a>
 
 ### undo~getChangedComponents(current, compare) ⇒ <code>object</code>
 get changed components, used by undo and redo
 
-**Kind**: inner method of [<code>undo</code>](#module_undo)
+**Kind**: inner method of [<code>undo</code>](#module_undo)  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -907,12 +910,12 @@ get changed components, used by undo and redo
 ### undo~saveChangedComponents(changedComponents, store)
 render multiple components at once
 
-**Kind**: inner method of [<code>undo</code>](#module_undo)
+**Kind**: inner method of [<code>undo</code>](#module_undo)  
 
 | Param | Type |
 | --- | --- |
-| changedComponents | <code>object</code> |
-| store | <code>object</code> |
+| changedComponents | <code>object</code> | 
+| store | <code>object</code> | 
 
 <a name="module_validators"></a>
 
@@ -932,46 +935,46 @@ render multiple components at once
 ### validators.validate(store) ⇒ <code>Promise</code>
 trigger validation
 
-**Kind**: static method of [<code>validators</code>](#module_validators)
+**Kind**: static method of [<code>validators</code>](#module_validators)  
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> |
+| store | <code>object</code> | 
 
 <a name="module_validators..isComponentInPageHeadList"></a>
 
 ### validators~isComponentInPageHeadList(uri, state) ⇒ <code>Boolean</code>
 determine if a component is in a page-specific head list
 
-**Kind**: inner method of [<code>validators</code>](#module_validators)
+**Kind**: inner method of [<code>validators</code>](#module_validators)  
 
 | Param | Type |
 | --- | --- |
-| uri | <code>string</code> |
-| state | <code>object</code> |
+| uri | <code>string</code> | 
+| state | <code>object</code> | 
 
 <a name="module_validators..runValidator"></a>
 
 ### validators~runValidator(state) ⇒ <code>function</code>
 run an individual validator. if it returns items, add the label and description
 
-**Kind**: inner method of [<code>validators</code>](#module_validators)
+**Kind**: inner method of [<code>validators</code>](#module_validators)  
 
 | Param | Type |
 | --- | --- |
-| state | <code>object</code> |
+| state | <code>object</code> | 
 
 <a name="module_validators..runValidators"></a>
 
 ### validators~runValidators(validators, state) ⇒ <code>Promise</code>
 run a list of validators
 
-**Kind**: inner method of [<code>validators</code>](#module_validators)
+**Kind**: inner method of [<code>validators</code>](#module_validators)  
 
 | Param | Type |
 | --- | --- |
-| validators | <code>array</code> |
-| state | <code>object</code> |
+| validators | <code>array</code> | 
+| state | <code>object</code> | 
 
 <a name="module_validators..hasItems"></a>
 
@@ -979,8 +982,9 @@ run a list of validators
 make sure that all errors have items that can display.
 some may have been parsed out by the isActive check in runValidator, above
 
-**Kind**: inner method of [<code>validators</code>](#module_validators)
+**Kind**: inner method of [<code>validators</code>](#module_validators)  
 
 | Param | Type |
 | --- | --- |
-| error | <code>object</code> |
+| error | <code>object</code> | 
+

--- a/docs/vuex-actions.md
+++ b/docs/vuex-actions.md
@@ -56,7 +56,7 @@
 ### component-data.saveComponent(store, uri, data, [eventID], [snapshot], [prevData]) ⇒ <code>Promise</code>
 save a component's data and re-render
 
-**Kind**: static method of [<code>component-data</code>](#module_component-data)  
+**Kind**: static method of [<code>component-data</code>](#module_component-data)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -73,7 +73,7 @@ save a component's data and re-render
 remove a component from its parent
 note: removes from parent component OR page
 
-**Kind**: static method of [<code>component-data</code>](#module_component-data)  
+**Kind**: static method of [<code>component-data</code>](#module_component-data)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -85,7 +85,7 @@ note: removes from parent component OR page
 ### component-data.removeHeadComponent(store, startNode) ⇒ <code>Promise</code>
 remove head components (from page or layout)
 
-**Kind**: static method of [<code>component-data</code>](#module_component-data)  
+**Kind**: static method of [<code>component-data</code>](#module_component-data)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -101,8 +101,8 @@ note: always creates new instances of the components you're adding
 note: allows you to replace a specific uri, or add components after it
 note: if no currentURI passed in, it will add new components to the end (and won't replace anything)
 
-**Kind**: static method of [<code>component-data</code>](#module_component-data)  
-**Returns**: <code>Promise</code> - with the last added component's el  
+**Kind**: static method of [<code>component-data</code>](#module_component-data)
+**Returns**: <code>Promise</code> - with the last added component's el
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -118,7 +118,7 @@ note: if no currentURI passed in, it will add new components to the end (and won
 ### component-data.openAddComponent(store, [currentURI], parentURI, path) ⇒ <code>Promise</code>
 open the add components pane, or add a new components
 
-**Kind**: static method of [<code>component-data</code>](#module_component-data)  
+**Kind**: static method of [<code>component-data</code>](#module_component-data)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -132,31 +132,31 @@ open the add components pane, or add a new components
 ### component-data~logSaveError(uri, e, data, [eventID], [snapshot], store)
 log errors when components save and display them to the user
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)
 
 | Param | Type |
 | --- | --- |
-| uri | <code>string</code> | 
-| e | <code>Error</code> | 
-| data | <code>object</code> | 
-| [eventID] | <code>string</code> | 
-| [snapshot] | <code>boolean</code> | 
-| store | <code>object</code> | 
+| uri | <code>string</code> |
+| e | <code>Error</code> |
+| data | <code>object</code> |
+| [eventID] | <code>string</code> |
+| [snapshot] | <code>boolean</code> |
+| store | <code>object</code> |
 
 <a name="module_component-data..revertReject"></a>
 
 ### component-data~revertReject(uri, data, [snapshot], paths, store) ⇒ <code>Promise</code>
 re-render (reverting) a component and stop the saving promise chain
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)
 
 | Param | Type |
 | --- | --- |
-| uri | <code>string</code> | 
-| data | <code>object</code> | 
-| [snapshot] | <code>boolean</code> | 
-| paths | <code>array</code> | 
-| store | <code>object</code> | 
+| uri | <code>string</code> |
+| data | <code>object</code> |
+| [snapshot] | <code>boolean</code> |
+| paths | <code>array</code> |
+| store | <code>object</code> |
 
 <a name="module_component-data..clientSave"></a>
 
@@ -165,7 +165,7 @@ save data client-side and queue up api call for the server
 note: this uses the components' model.js (if it exists) and handlebars template
 note: server-side saving and/or re-rendering has been removed in kiln v4.x
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -183,19 +183,19 @@ note: server-side saving and/or re-rendering has been removed in kiln v4.x
 find the index of a uri in a list
 this is broken out into a separate function so we don't assume an index of 0 is falsy
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)
 
 | Param | Type |
 | --- | --- |
-| data | <code>array</code> | 
-| [uri] | <code>string</code> | 
+| data | <code>array</code> |
+| [uri] | <code>string</code> |
 
 <a name="module_component-data..addComponentsToComponentList"></a>
 
 ### component-data~addComponentsToComponentList(store, data, [currentURI], parentURI, path, [replace], components) ⇒ <code>Promise</code>
 add one or more components to a component list
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -212,7 +212,7 @@ add one or more components to a component list
 ### component-data~addComponentsToComponentProp(store, data, parentURI, path, components) ⇒ <code>Promise</code>
 replace a single component in another component's property
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -227,15 +227,15 @@ replace a single component in another component's property
 ### component-data~addComponentsToPageArea(store, currentURI, path, replace, components) ⇒ <code>Promise</code>
 add one or more components to a page area
 
-**Kind**: inner method of [<code>component-data</code>](#module_component-data)  
+**Kind**: inner method of [<code>component-data</code>](#module_component-data)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| currentURI | <code>string</code> | 
-| path | <code>string</code> | 
-| replace | <code>boolean</code> | 
-| components | <code>array</code> | 
+| store | <code>object</code> |
+| currentURI | <code>string</code> |
+| path | <code>string</code> |
+| replace | <code>boolean</code> |
+| components | <code>array</code> |
 
 <a name="module_decorators"></a>
 
@@ -253,42 +253,42 @@ add one or more components to a page area
 ### decorators.unselect(store)
 unselect currently-selected component
 
-**Kind**: static method of [<code>decorators</code>](#module_decorators)  
+**Kind**: static method of [<code>decorators</code>](#module_decorators)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
+| store | <code>object</code> |
 
 <a name="module_decorators.select"></a>
 
 ### decorators.select(store, el)
 select a component
 
-**Kind**: static method of [<code>decorators</code>](#module_decorators)  
+**Kind**: static method of [<code>decorators</code>](#module_decorators)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| el | <code>element</code> | 
+| store | <code>object</code> |
+| el | <code>element</code> |
 
 <a name="module_decorators.scrollToComponent"></a>
 
 ### decorators.scrollToComponent(store, el)
 Scroll user to the component. "Weeee!" or "What the?"
 
-**Kind**: static method of [<code>decorators</code>](#module_decorators)  
+**Kind**: static method of [<code>decorators</code>](#module_decorators)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| el | <code>Element</code> | 
+| store | <code>object</code> |
+| el | <code>Element</code> |
 
 <a name="module_decorators.navigateComponents"></a>
 
 ### decorators.navigateComponents(store, direction) ⇒ <code>Promise</code>
 navigate to the previous or next component
 
-**Kind**: static method of [<code>decorators</code>](#module_decorators)  
+**Kind**: static method of [<code>decorators</code>](#module_decorators)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -300,11 +300,11 @@ navigate to the previous or next component
 ### decorators.unfocus(store) ⇒ <code>Promise</code>
 unfocus currently-focused field/group
 
-**Kind**: static method of [<code>decorators</code>](#module_decorators)  
+**Kind**: static method of [<code>decorators</code>](#module_decorators)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
+| store | <code>object</code> |
 
 <a name="module_deep-linking"></a>
 
@@ -320,37 +320,37 @@ unfocus currently-focused field/group
 ### deep-linking.parseURLHash(store) ⇒ <code>Promise</code>
 parse url hash, opening form or clay menu as necessary
 
-**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)  
+**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
+| store | <code>object</code> |
 
 <a name="module_deep-linking.setHash"></a>
 
 ### deep-linking.setHash(commit, [uri], [path], [initialFocus], [menu])
 set hash in window and store
 
-**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)  
+**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)
 
 | Param | Type |
 | --- | --- |
-| commit | <code>function</code> | 
-| [uri] | <code>string</code> | 
-| [path] | <code>string</code> | 
-| [initialFocus] | <code>string</code> | 
-| [menu] | <code>object</code> | 
+| commit | <code>function</code> |
+| [uri] | <code>string</code> |
+| [path] | <code>string</code> |
+| [initialFocus] | <code>string</code> |
+| [menu] | <code>object</code> |
 
 <a name="module_deep-linking.clearHash"></a>
 
 ### deep-linking.clearHash(commit)
 clear hash in window and store
 
-**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)  
+**Kind**: static method of [<code>deep-linking</code>](#module_deep-linking)
 
 | Param | Type |
 | --- | --- |
-| commit | <code>function</code> | 
+| commit | <code>function</code> |
 
 <a name="module_drawers"></a>
 
@@ -360,11 +360,32 @@ clear hash in window and store
 ### drawers.closeDrawer(store)
 close drawer without toggling a new drawer
 
-**Kind**: static method of [<code>drawers</code>](#module_drawers)  
+**Kind**: static method of [<code>drawers</code>](#module_drawers)
 
 | Param | Type |
 | --- | --- |
-| store | <code>Object</code> | 
+| store | <code>Object</code> |
+
+### drawers.openDrawer(store, nameOrConfig)
+open Drawer, will close any other open drawer
+
+**Kind**: static method of [<code>drawer</code>](#module_nav)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| store | <code>object</code> |  |
+| nameOrConfig | <code>string</code> \| <code>object</code> | tab name, or clay menu config |
+
+### drawers.toggleDrawer(store, nameOrConfig)
+open or close Drawer passed to it, depending upon its current state. i.e. if it's closed, it will be opened, if it's closed, it will be opened.
+
+**Kind**: static method of [<code>drawer</code>](#module_nav)
+
+| Param | Type | Description |
+| --- | --- | --- |
+| store | <code>object</code> |  |
+| nameOrConfig | <code>string</code> \| <code>object</code> | tab name, or clay menu config |
+
 
 <a name="module_forms"></a>
 
@@ -381,7 +402,7 @@ close drawer without toggling a new drawer
 ### forms.openForm(store, uri, path, [el], [offset], [appendText], [initialFocus], pos)
 open form
 
-**Kind**: static method of [<code>forms</code>](#module_forms)  
+**Kind**: static method of [<code>forms</code>](#module_forms)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -400,7 +421,7 @@ open form
 determine if data in form has changed
 note: convert data to plain objects, since they're reactive
 
-**Kind**: inner method of [<code>forms</code>](#module_forms)  
+**Kind**: inner method of [<code>forms</code>](#module_forms)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -425,41 +446,41 @@ get the list data for a specific layout
 note: if prefix / uri is specified, this does NOT commit the data (only returns it),
 allowing the preloader to use it when doing the initial preload of data
 
-**Kind**: static method of [<code>layout-state</code>](#module_layout-state)  
+**Kind**: static method of [<code>layout-state</code>](#module_layout-state)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| [preloadOptions] | <code>object</code> | 
-| [preloadOptions.uri] | <code>string</code> | 
-| [preloadOptions.prefix] | <code>string</code> | 
-| [preloadOptions.user] | <code>object</code> | 
+| store | <code>object</code> |
+| [preloadOptions] | <code>object</code> |
+| [preloadOptions.uri] | <code>string</code> |
+| [preloadOptions.prefix] | <code>string</code> |
+| [preloadOptions.user] | <code>object</code> |
 
 <a name="module_layout-state.updateLayout"></a>
 
 ### layout-state.updateLayout(store, [data], [preloadOptions]) ⇒ <code>Promise</code>
 update a layout's title, or just the latest timestamp + user
 
-**Kind**: static method of [<code>layout-state</code>](#module_layout-state)  
+**Kind**: static method of [<code>layout-state</code>](#module_layout-state)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| [data] | <code>object</code> | 
-| [data.title] | <code>string</code> | 
-| [preloadOptions] | <code>object</code> | 
+| store | <code>object</code> |
+| [data] | <code>object</code> |
+| [data.title] | <code>string</code> |
+| [preloadOptions] | <code>object</code> |
 
 <a name="module_layout-state.scheduleLayout"></a>
 
 ### layout-state.scheduleLayout(store, timestamp) ⇒ <code>Promise</code>
 schedule the layout and update its index
 
-**Kind**: static method of [<code>layout-state</code>](#module_layout-state)  
+**Kind**: static method of [<code>layout-state</code>](#module_layout-state)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| timestamp | <code>Date</code> | 
+| store | <code>object</code> |
+| timestamp | <code>Date</code> |
 
 <a name="module_layout-state.unscheduleLayout"></a>
 
@@ -467,12 +488,12 @@ schedule the layout and update its index
 unschedule the layout
 get updated layout state if the call wasn't made during layout publish
 
-**Kind**: static method of [<code>layout-state</code>](#module_layout-state)  
+**Kind**: static method of [<code>layout-state</code>](#module_layout-state)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| [publishing] | <code>Boolean</code> | 
+| store | <code>object</code> |
+| [publishing] | <code>Boolean</code> |
 
 <a name="module_layout-state.publishLayout"></a>
 
@@ -482,11 +503,11 @@ note: layouts index is updated server-side, including unscheduling the layout
 if it's currently scheduled
 also note: this will trigger a fetch of the updated (published) layout state
 
-**Kind**: static method of [<code>layout-state</code>](#module_layout-state)  
+**Kind**: static method of [<code>layout-state</code>](#module_layout-state)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
+| store | <code>object</code> |
 
 <a name="module_lists"></a>
 
@@ -497,14 +518,7 @@ also note: this will trigger a fetch of the updated (published) layout state
 <a name="module_nav.openNav"></a>
 
 ### nav.openNav(store, nameOrConfig)
-open nav tab
-
-**Kind**: static method of [<code>nav</code>](#module_nav)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| store | <code>object</code> |  |
-| nameOrConfig | <code>string</code> \| <code>object</code> | tab name, or clay menu config |
+Depreciated: See <a href="#module_drawers">Drawer</a>
 
 <a name="module_page-data"></a>
 
@@ -528,7 +542,7 @@ open nav tab
 save a page's data, but do not re-render
 because, uh, that would just be reloading the page
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)  
+**Kind**: static method of [<code>page-data</code>](#module_page-data)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -541,49 +555,49 @@ because, uh, that would just be reloading the page
 ### page-data.createPage(store, id) ⇒ <code>Promise</code>
 create a new page, then return its editable link
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)  
+**Kind**: static method of [<code>page-data</code>](#module_page-data)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| id | <code>string</code> | 
+| store | <code>object</code> |
+| id | <code>string</code> |
 
 <a name="module_page-data.publishPage"></a>
 
 ### page-data.publishPage(store, uri) ⇒ <code>Promise</code>
 manually publish the page
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)  
+**Kind**: static method of [<code>page-data</code>](#module_page-data)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| uri | <code>string</code> | 
+| store | <code>object</code> |
+| uri | <code>string</code> |
 
 <a name="module_page-data.unpublishPage"></a>
 
 ### page-data.unpublishPage(store, uri) ⇒ <code>Promise</code>
 remove uri from /uris/
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)  
+**Kind**: static method of [<code>page-data</code>](#module_page-data)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| uri | <code>string</code> | 
+| store | <code>object</code> |
+| uri | <code>string</code> |
 
 <a name="module_page-data.schedulePage"></a>
 
 ### page-data.schedulePage(store, uri, timestamp) ⇒ <code>Promise</code>
 schedule the page to publish
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)  
+**Kind**: static method of [<code>page-data</code>](#module_page-data)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| uri | <code>string</code> | 
-| timestamp | <code>Date</code> | 
+| store | <code>object</code> |
+| uri | <code>string</code> |
+| timestamp | <code>Date</code> |
 
 <a name="module_page-data.unschedulePage"></a>
 
@@ -591,12 +605,12 @@ schedule the page to publish
 unschedule the page
 get updated page state if the call wasn't made during a page publish
 
-**Kind**: static method of [<code>page-data</code>](#module_page-data)  
+**Kind**: static method of [<code>page-data</code>](#module_page-data)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| [publishing] | <code>Boolean</code> | 
+| store | <code>object</code> |
+| [publishing] | <code>Boolean</code> |
 
 <a name="module_page-data..shouldRender"></a>
 
@@ -604,23 +618,23 @@ get updated page state if the call wasn't made during a page publish
 iterate through the paths we're saving
 if one of them ISN'T in the internalPageProps, we should re-render
 
-**Kind**: inner method of [<code>page-data</code>](#module_page-data)  
+**Kind**: inner method of [<code>page-data</code>](#module_page-data)
 
 | Param | Type |
 | --- | --- |
-| paths | <code>array</code> | 
+| paths | <code>array</code> |
 
 <a name="module_page-data..removeURI"></a>
 
 ### page-data~removeURI(uri, store) ⇒ <code>Promise</code>
 remove uri from /uris/
 
-**Kind**: inner method of [<code>page-data</code>](#module_page-data)  
+**Kind**: inner method of [<code>page-data</code>](#module_page-data)
 
 | Param | Type |
 | --- | --- |
-| uri | <code>String</code> | 
-| store | <code>Object</code> | 
+| uri | <code>String</code> |
+| store | <code>Object</code> |
 
 <a name="module_page-state"></a>
 
@@ -641,12 +655,12 @@ note: if called without data, this just updates the updateTime and user
 (e.g. when saving components in the page)
 note: if called with a user, it adds the user (with updateTime) to the page (instead of current user)
 
-**Kind**: static method of [<code>page-state</code>](#module_page-state)  
+**Kind**: static method of [<code>page-state</code>](#module_page-state)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
-| [data] | <code>object</code> | 
+| store | <code>object</code> |
+| [data] | <code>object</code> |
 
 <a name="module_page-state.getListData"></a>
 
@@ -655,7 +669,7 @@ get the list data for a specific page
 note: if prefix is specified, this does NOT commit the data (only returns it),
 allowing the preloader to use it when doing the initial preload of data
 
-**Kind**: static method of [<code>page-state</code>](#module_page-state)  
+**Kind**: static method of [<code>page-state</code>](#module_page-state)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -668,13 +682,13 @@ allowing the preloader to use it when doing the initial preload of data
 ### page-state~sequentialUpdate(prefix, uri, data) ⇒ <code>Promise</code>
 run page list updates sequentially, grabbing from the store after each to prevent race conditions
 
-**Kind**: inner method of [<code>page-state</code>](#module_page-state)  
+**Kind**: inner method of [<code>page-state</code>](#module_page-state)
 
 | Param | Type |
 | --- | --- |
-| prefix | <code>string</code> | 
-| uri | <code>string</code> | 
-| data | <code>object</code> | 
+| prefix | <code>string</code> |
+| uri | <code>string</code> |
+| data | <code>object</code> |
 
 <a name="module_preloader"></a>
 
@@ -693,25 +707,25 @@ run page list updates sequentially, grabbing from the store after each to preven
 get component models so we can mount them on window.kiln.componentModels
 if they aren't already mounted (backwards-compatability)
 
-**Kind**: inner method of [<code>preloader</code>](#module_preloader)  
+**Kind**: inner method of [<code>preloader</code>](#module_preloader)
 <a name="module_preloader..reduceComponents"></a>
 
 ### preloader~reduceComponents(result, val) ⇒ <code>obj</code>
 extract component data from preloadData obj
 
-**Kind**: inner method of [<code>preloader</code>](#module_preloader)  
+**Kind**: inner method of [<code>preloader</code>](#module_preloader)
 
 | Param | Type |
 | --- | --- |
-| result | <code>obj</code> | 
-| val | <code>obj</code> | 
+| result | <code>obj</code> |
+| val | <code>obj</code> |
 
 <a name="module_preloader..composeLayoutData"></a>
 
 ### preloader~composeLayoutData(layoutSchema, components, original) ⇒ <code>object</code>
 extract layout data from original data
 
-**Kind**: inner method of [<code>preloader</code>](#module_preloader)  
+**Kind**: inner method of [<code>preloader</code>](#module_preloader)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -724,24 +738,24 @@ extract layout data from original data
 ### preloader~reduceTemplates(result, val, key) ⇒ <code>obj</code>
 make precompiled hbs templates ready for user
 
-**Kind**: inner method of [<code>preloader</code>](#module_preloader)  
+**Kind**: inner method of [<code>preloader</code>](#module_preloader)
 
 | Param | Type |
 | --- | --- |
-| result | <code>obj</code> | 
-| val | <code>obj</code> | 
-| key | <code>string</code> | 
+| result | <code>obj</code> |
+| val | <code>obj</code> |
+| key | <code>string</code> |
 
 <a name="module_preloader..getPageStatus"></a>
 
 ### preloader~getPageStatus(state) ⇒ <code>string</code>
 get string state to pass to progress bar
 
-**Kind**: inner method of [<code>preloader</code>](#module_preloader)  
+**Kind**: inner method of [<code>preloader</code>](#module_preloader)
 
 | Param | Type |
 | --- | --- |
-| state | <code>object</code> | 
+| state | <code>object</code> |
 
 <a name="module_toolbar"></a>
 
@@ -760,7 +774,7 @@ get string state to pass to progress bar
 start progress bar. if already started, this will cause a slight pause
 before continuing the progress bar
 
-**Kind**: static method of [<code>toolbar</code>](#module_toolbar)  
+**Kind**: static method of [<code>toolbar</code>](#module_toolbar)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -772,7 +786,7 @@ before continuing the progress bar
 ### toolbar.finishProgress(commit, type)
 finish the progress bar.
 
-**Kind**: static method of [<code>toolbar</code>](#module_toolbar)  
+**Kind**: static method of [<code>toolbar</code>](#module_toolbar)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -784,7 +798,7 @@ finish the progress bar.
 ### toolbar.addAlert(store, config)
 add alert to the array
 
-**Kind**: static method of [<code>toolbar</code>](#module_toolbar)  
+**Kind**: static method of [<code>toolbar</code>](#module_toolbar)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -796,7 +810,7 @@ add alert to the array
 ### toolbar.removeAlert(store, config)
 remove an alert from the array, specifying the index
 
-**Kind**: static method of [<code>toolbar</code>](#module_toolbar)  
+**Kind**: static method of [<code>toolbar</code>](#module_toolbar)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -809,7 +823,7 @@ remove an alert from the array, specifying the index
 trigger a new snackbar. note: this happens imperatively (toolbar handles the actual creation, by watching this value)
 note: if you want the snackbar to have an action, pass in both `action` (the text of the button) and `onActionClick` (a reference to the function you want invoked)
 
-**Kind**: static method of [<code>toolbar</code>](#module_toolbar)  
+**Kind**: static method of [<code>toolbar</code>](#module_toolbar)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -835,11 +849,11 @@ note: if you want the snackbar to have an action, pass in both `action` (the tex
 ### undo.createSnapshot(store)
 create snapshot. called from the plugin listening to batched renders
 
-**Kind**: static method of [<code>undo</code>](#module_undo)  
+**Kind**: static method of [<code>undo</code>](#module_undo)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
+| store | <code>object</code> |
 
 <a name="module_undo.setFixedPoint"></a>
 
@@ -848,40 +862,40 @@ create snapshot. called from the plugin listening to batched renders
 when doing a manual save from some point in history, we need to
 remove snapshots after that point (to preserve the expected undo functionality)
 
-**Kind**: static method of [<code>undo</code>](#module_undo)  
+**Kind**: static method of [<code>undo</code>](#module_undo)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
+| store | <code>object</code> |
 
 <a name="module_undo.undo"></a>
 
 ### undo.undo(store)
 undo: sets cursor back one, re-saves affected components with old data
 
-**Kind**: static method of [<code>undo</code>](#module_undo)  
+**Kind**: static method of [<code>undo</code>](#module_undo)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
+| store | <code>object</code> |
 
 <a name="module_undo.redo"></a>
 
 ### undo.redo(store)
 redo: sets cursor forward one, re-saves affected components with new data
 
-**Kind**: static method of [<code>undo</code>](#module_undo)  
+**Kind**: static method of [<code>undo</code>](#module_undo)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
+| store | <code>object</code> |
 
 <a name="module_undo..getChangedComponents"></a>
 
 ### undo~getChangedComponents(current, compare) ⇒ <code>object</code>
 get changed components, used by undo and redo
 
-**Kind**: inner method of [<code>undo</code>](#module_undo)  
+**Kind**: inner method of [<code>undo</code>](#module_undo)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -893,12 +907,12 @@ get changed components, used by undo and redo
 ### undo~saveChangedComponents(changedComponents, store)
 render multiple components at once
 
-**Kind**: inner method of [<code>undo</code>](#module_undo)  
+**Kind**: inner method of [<code>undo</code>](#module_undo)
 
 | Param | Type |
 | --- | --- |
-| changedComponents | <code>object</code> | 
-| store | <code>object</code> | 
+| changedComponents | <code>object</code> |
+| store | <code>object</code> |
 
 <a name="module_validators"></a>
 
@@ -918,46 +932,46 @@ render multiple components at once
 ### validators.validate(store) ⇒ <code>Promise</code>
 trigger validation
 
-**Kind**: static method of [<code>validators</code>](#module_validators)  
+**Kind**: static method of [<code>validators</code>](#module_validators)
 
 | Param | Type |
 | --- | --- |
-| store | <code>object</code> | 
+| store | <code>object</code> |
 
 <a name="module_validators..isComponentInPageHeadList"></a>
 
 ### validators~isComponentInPageHeadList(uri, state) ⇒ <code>Boolean</code>
 determine if a component is in a page-specific head list
 
-**Kind**: inner method of [<code>validators</code>](#module_validators)  
+**Kind**: inner method of [<code>validators</code>](#module_validators)
 
 | Param | Type |
 | --- | --- |
-| uri | <code>string</code> | 
-| state | <code>object</code> | 
+| uri | <code>string</code> |
+| state | <code>object</code> |
 
 <a name="module_validators..runValidator"></a>
 
 ### validators~runValidator(state) ⇒ <code>function</code>
 run an individual validator. if it returns items, add the label and description
 
-**Kind**: inner method of [<code>validators</code>](#module_validators)  
+**Kind**: inner method of [<code>validators</code>](#module_validators)
 
 | Param | Type |
 | --- | --- |
-| state | <code>object</code> | 
+| state | <code>object</code> |
 
 <a name="module_validators..runValidators"></a>
 
 ### validators~runValidators(validators, state) ⇒ <code>Promise</code>
 run a list of validators
 
-**Kind**: inner method of [<code>validators</code>](#module_validators)  
+**Kind**: inner method of [<code>validators</code>](#module_validators)
 
 | Param | Type |
 | --- | --- |
-| validators | <code>array</code> | 
-| state | <code>object</code> | 
+| validators | <code>array</code> |
+| state | <code>object</code> |
 
 <a name="module_validators..hasItems"></a>
 
@@ -965,9 +979,8 @@ run a list of validators
 make sure that all errors have items that can display.
 some may have been parsed out by the isActive check in runValidator, above
 
-**Kind**: inner method of [<code>validators</code>](#module_validators)  
+**Kind**: inner method of [<code>validators</code>](#module_validators)
 
 | Param | Type |
 | --- | --- |
-| error | <code>object</code> | 
-
+| error | <code>object</code> |

--- a/docs/vuex-actions.md
+++ b/docs/vuex-actions.md
@@ -358,7 +358,7 @@ clear hash in window and store
 <a name="module_drawers.closeDrawer"></a>
 
 ### drawers.closeDrawer(store)
-close drawer without toggling a new drawer
+close drawer without toggling a new drawer, calls <a href="#module_deep-linking">clearHash</a>
 
 **Kind**: static method of [<code>drawers</code>](#module_drawers)
 
@@ -367,7 +367,7 @@ close drawer without toggling a new drawer
 | store | <code>Object</code> |
 
 ### drawers.openDrawer(store, nameOrConfig)
-open Drawer, will close any other open drawer
+open Drawer, will close any other open drawer, calls <a href="#module_deep-linking">setHash</a> so drawer is automatically deep-linked to
 
 **Kind**: static method of [<code>drawer</code>](#module_nav)
 

--- a/edit.js
+++ b/edit.js
@@ -86,7 +86,7 @@ function isStuffOpen(store) {
     _.get(store, 'state.ui.currentModal') ||
     _.get(store, 'state.ui.currentAddComponentModal') ||
     _.get(store, 'state.ui.currentConfirm') ||
-    _.get(store, 'state.ui.currentNav');
+    _.get(store, 'state.ui.currentDrawer');
 }
 
 // kick off loading when DOM is ready

--- a/lib/core-data/groups.js
+++ b/lib/core-data/groups.js
@@ -127,11 +127,9 @@ export function get(uri, path) {
  * @return {Boolean}
  */
 export function has(uri, path) {
-  try {
-    get(uri, path); // this will return a field/group or throw an error
-
+  if (get(uri, path)) {
     return true;
-  } catch (e) {
-    return false;
   }
+
+  return false;
 }

--- a/lib/core-data/groups.js
+++ b/lib/core-data/groups.js
@@ -116,7 +116,7 @@ export function get(uri, path) {
 
     return { fields: expandFields(parsed.fields, data), schema: _.assign({}, groupSchema, { sections: parsed.sections, [labelProp]: groupLabel }) };
   } else {
-    throw new Error(`No group or field found at '${path}' (in ${getComponentName(uri)})`);
+    return null;
   }
 }
 

--- a/lib/core-data/groups.test.js
+++ b/lib/core-data/groups.test.js
@@ -100,7 +100,7 @@ describe('groups', () => {
       components.getData.mockReturnValueOnce(bar);
       components.getSchema.mockReturnValueOnce({});
       components.getSchema.mockReturnValueOnce(undefined);
-      expect(() => fn('foo', 'bar')).toThrow(Error);
+      expect(fn('foo', 'bar')).toBeNull();
     });
 
     test('returns undefined if field not found in data', () => {

--- a/lib/deep-linking/actions.js
+++ b/lib/deep-linking/actions.js
@@ -12,14 +12,8 @@ import label from '../utils/label';
  * @module deep-linking
  */
 
-function openHashedForm(store, urlProps) {
-  let isAdmin, component, instance, path, foundComponent, uri, el, group, groupEl, initialFocus;
-
-  // get user permissions
-  // note: as clay always opens pages in page edit mode (not layout),
-  // we'll have to switch modes if the deep link is to a layout component
-  // (and the user has permission to edit it)
-  isAdmin = _.get(store, 'state.user.auth') === 'admin';
+function checkHashedForm(store, urlProps) {
+  let component, instance, path, foundComponent, initialFocus;
 
   // If we've got `urlProps`, let's access them
   component = _.get(urlProps, 'component', null);
@@ -30,11 +24,25 @@ function openHashedForm(store, urlProps) {
   // Get the URI and grab the component element based on the name
   // of the component and the instance name
   foundComponent = getComponentByNameAndInstance(store, component, instance);
-  uri = foundComponent.uri;
-  el = foundComponent.el;
 
-  // Get the group from the schema with the `path`
-  group = get(uri, path);
+  if (!foundComponent) {
+    return null; // if the hash in the url doesn't result in a found component, return null to avoid an error being thrown
+  } else {
+    return openHashedForm(store, foundComponent, path, initialFocus);
+  }
+}
+
+function openHashedForm(store, foundComponent, path, initialFocus) {
+  let uri = foundComponent.uri,
+    el = foundComponent.el,
+    groupEl = null,
+    group = get(uri, path); // Get the group from the schema with the `path`
+
+  // get user permissions
+  // note: as clay always opens pages in page edit mode (not layout),
+  // we'll have to switch modes if the deep link is to a layout component
+  // (and the user has permission to edit it)
+  const isAdmin = _.get(store, 'state.user.auth') === 'admin';
 
   // If it's an inline wysiwyg we need to open the form on the
   // element with `data-editable`, not the component itself
@@ -91,7 +99,7 @@ export function parseURLHash(store) {
   }
 
   if (urlProps.component) {
-    return openHashedForm(store, urlProps);
+    return checkHashedForm(store, urlProps);
   } else {
     return openClayMenu(store, urlProps);
   }

--- a/lib/deep-linking/actions.js
+++ b/lib/deep-linking/actions.js
@@ -4,7 +4,6 @@ import { find } from '@nymag/dom';
 import { getComponentInstance } from 'clayutils';
 import { getComponentName, refAttr, editAttr, getComponentByNameAndInstance, getLayoutNameAndInstance } from '../utils/references';
 import { UPDATE_HASH, CLEAR_HASH } from './mutationTypes';
-import { CLOSE_DRAWER } from '../drawers/mutationTypes';
 import { TOGGLE_EDIT_MODE } from '../toolbar/mutationTypes';
 import { isComponentInPage } from '../utils/component-elements';
 import label from '../utils/label';
@@ -125,7 +124,6 @@ export function setHash({ commit }, { uri, path, initialFocus, menu }) {
 
     urlObj = { component, instance, path, initialFocus };
     hashString = `#${component}~${instance}~${path}${initialFocus ? '~' + initialFocus : ''}`;
-    commit(CLOSE_DRAWER);
   } else if (menu) {
     // set has for the clay menu
     urlObj = {

--- a/lib/deep-linking/actions.js
+++ b/lib/deep-linking/actions.js
@@ -4,6 +4,7 @@ import { find } from '@nymag/dom';
 import { getComponentInstance } from 'clayutils';
 import { getComponentName, refAttr, editAttr, getComponentByNameAndInstance, getLayoutNameAndInstance } from '../utils/references';
 import { UPDATE_HASH, CLEAR_HASH } from './mutationTypes';
+import { CLOSE_DRAWER } from '../drawers/mutationTypes';
 import { TOGGLE_EDIT_MODE } from '../toolbar/mutationTypes';
 import { isComponentInPage } from '../utils/component-elements';
 import label from '../utils/label';
@@ -83,7 +84,7 @@ function openHashedForm(store, foundComponent, path, initialFocus) {
 }
 
 function openClayMenu(store, urlProps) {
-  return store.dispatch('openNav', urlProps);
+  return store.dispatch('openDrawer', urlProps);
 }
 
 /**
@@ -101,7 +102,7 @@ export function parseURLHash(store) {
   if (urlProps.component) {
     return checkHashedForm(store, urlProps);
   } else {
-    return openClayMenu(store, urlProps);
+    return openClayMenu(store, urlProps.tab);
   }
 }
 
@@ -118,11 +119,13 @@ export function setHash({ commit }, { uri, path, initialFocus, menu }) {
 
   if (uri && path) {
     // set hash for a form
+
     const component = getComponentName(uri),
       instance = getComponentInstance(uri);
 
     urlObj = { component, instance, path, initialFocus };
     hashString = `#${component}~${instance}~${path}${initialFocus ? '~' + initialFocus : ''}`;
+    commit(CLOSE_DRAWER);
   } else if (menu) {
     // set has for the clay menu
     urlObj = {
@@ -136,6 +139,7 @@ export function setHash({ commit }, { uri, path, initialFocus, menu }) {
 
   // Set the hash on the window
   window.history.replaceState(null, null, hashString);
+
 
   commit(UPDATE_HASH, urlObj);
 }

--- a/lib/deep-linking/actions.js
+++ b/lib/deep-linking/actions.js
@@ -12,18 +12,13 @@ import label from '../utils/label';
  * @module deep-linking
  */
 
-function checkHashedForm(store, urlProps) {
-  let component, instance, path, foundComponent, initialFocus;
-
+export function checkHashedForm(store, urlProps) {
   // If we've got `urlProps`, let's access them
-  component = _.get(urlProps, 'component', null);
-  instance = _.get(urlProps, 'instance', null);
-  path = _.get(urlProps, 'path', null);
-  initialFocus = _.get(urlProps, 'initialFocus', null);
+  let {component = null, instance = null, path = null, initialFocus = null} = urlProps;
 
   // Get the URI and grab the component element based on the name
   // of the component and the instance name
-  foundComponent = getComponentByNameAndInstance(store, component, instance);
+  const foundComponent = getComponentByNameAndInstance(store, component, instance);
 
   if (!foundComponent) {
     return null; // if the hash in the url doesn't result in a found component, return null to avoid an error being thrown
@@ -32,7 +27,7 @@ function checkHashedForm(store, urlProps) {
   }
 }
 
-function openHashedForm(store, foundComponent, path, initialFocus) {
+export function openHashedForm(store, foundComponent, path, initialFocus) {
   let uri = foundComponent.uri,
     el = foundComponent.el,
     groupEl = null,
@@ -79,10 +74,12 @@ function openHashedForm(store, foundComponent, path, initialFocus) {
   // If we have a uri, an element and a path then we can open the form
   if (uri && path) {
     return store.dispatch('focus', { uri, path, initialFocus, el: groupEl || el, offset: 0 });
+  } else {
+    return true;
   }
 }
 
-function openClayMenu(store, urlProps) {
+export function openClayMenu(store, urlProps) {
   return store.dispatch('openDrawer', urlProps);
 }
 

--- a/lib/deep-linking/actions.test.js
+++ b/lib/deep-linking/actions.test.js
@@ -1,0 +1,24 @@
+import * as lib from './actions';
+import { refAttr } from '../utils/references';
+
+describe('deep-linking actions', () => {
+  const store = { state: { site: { prefix: 'domain.com' }}};
+
+  describe('checkHashedForm', () => {
+    const fn = lib.checkHashedForm;
+
+    test('returns null when component not found', () => {
+      expect(fn(store, {component: 'aComponentThatDoesNotExist', instance: null, path: null, initialFocus: null})).toBeNull();
+    });
+
+    test('returns found component when passed a component', () => {
+      let name = 'found-instance',
+        instance = '1';
+
+      document.body.innerHTML = `<div ${refAttr}="nymag.com/_components/${name}/instances/${instance}"></div>`;
+
+      expect(fn(store, {component: name, instance: instance, path: null, initialFocus: null})).toBeTruthy();
+    });
+
+  });
+});

--- a/lib/drawers/actions.js
+++ b/lib/drawers/actions.js
@@ -29,3 +29,11 @@ export function toggleDrawer(store, name) {
 export function closeDrawer(store) {
   store.commit(CLOSE_DRAWER);
 }
+
+/**
+ * open drawer without closing a drawer
+ * @param  {Object} store
+ */
+export function openDrawer(store) {
+  store.commit(OPEN_DRAWER);
+}

--- a/lib/drawers/actions.js
+++ b/lib/drawers/actions.js
@@ -5,13 +5,14 @@ import { OPEN_DRAWER, CLOSE_DRAWER } from './mutationTypes';
  * @module drawers
  */
 
-export function toggleDrawer(store, name) {
-  const currentDrawer = _.get(store, 'state.ui.currentDrawer');
+export function toggleDrawer(store, nameOrConfig) {
+  const currentDrawer = _.get(store, 'state.ui.currentDrawer'),
+    name = _.isString(nameOrConfig) ? nameOrConfig : nameOrConfig.tab;
 
   if (currentDrawer && currentDrawer === name) {
     store.dispatch('closeDrawer');
   } else {
-    store.dispatch('openDrawer', name);
+    store.dispatch('openDrawer', nameOrConfig);
   }
 }
 

--- a/lib/drawers/actions.js
+++ b/lib/drawers/actions.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import Vue from 'vue';
 import { OPEN_DRAWER, CLOSE_DRAWER } from './mutationTypes';
 
 /**
@@ -10,15 +9,9 @@ export function toggleDrawer(store, name) {
   const currentDrawer = _.get(store, 'state.ui.currentDrawer');
 
   if (currentDrawer && currentDrawer === name) {
-    store.commit(CLOSE_DRAWER);
-  } else if (currentDrawer) {
-    // close the current drawer, THEN open the new one
-    store.commit(CLOSE_DRAWER);
-    Vue.nextTick(() => {
-      store.commit(OPEN_DRAWER, name);
-    });
+    store.dispatch('closeDrawer');
   } else {
-    store.commit(OPEN_DRAWER, name);
+    store.dispatch('openDrawer', name);
   }
 }
 
@@ -27,13 +20,20 @@ export function toggleDrawer(store, name) {
  * @param  {Object} store
  */
 export function closeDrawer(store) {
+  store.dispatch('clearHash');
+  store.dispatch('hideNavBackground');
   store.commit(CLOSE_DRAWER);
 }
 
 /**
- * open drawer without closing a drawer
+ * open drawer
  * @param  {Object} store
+ * @param  {(string|object)} nameOrConfig - either just the tab name or a json object for deeper linking
  */
-export function openDrawer(store) {
-  store.commit(OPEN_DRAWER);
+export function openDrawer(store, nameOrConfig) {
+  const name = _.isString(nameOrConfig) ? nameOrConfig : nameOrConfig.tab,
+    config = _.isObject(nameOrConfig) ? nameOrConfig : { tab: name, sites: '', status: '', query: ''};
+
+  store.dispatch('setHash', { menu: config });
+  store.commit(OPEN_DRAWER, name);
 }

--- a/lib/drawers/actions.js
+++ b/lib/drawers/actions.js
@@ -33,7 +33,17 @@ export function closeDrawer(store) {
  */
 export function openDrawer(store, nameOrConfig) {
   const name = _.isString(nameOrConfig) ? nameOrConfig : nameOrConfig.tab,
-    config = _.isObject(nameOrConfig) ? nameOrConfig : { tab: name, sites: '', status: '', query: ''};
+    currentURLState = store.state.url;
+
+  let config = null;
+
+  if (_.isObject(nameOrConfig)) {
+    config = nameOrConfig;
+  }  else if (currentURLState && name === currentURLState.tab) {
+    config = { tab: name, ...currentURLState };
+  } else {
+    config = { tab: name, sites: '', status: '', query: ''};
+  }
 
   store.dispatch('setHash', { menu: config });
   store.commit(OPEN_DRAWER, name);

--- a/lib/drawers/drawer.vue
+++ b/lib/drawers/drawer.vue
@@ -52,7 +52,7 @@
 </style>
 
 <template>
-  <transition name="drawer" mode="out-in" @after-enter="refreshTabs">
+  <transition name="drawer" mode="out-in">
     <ui-tabs :key="name" ref="tabs" v-if="isDrawerOpen" class="right-drawer" backgroundColor="clear" :fullwidth="true">
       <ui-tab v-for="(tab, tabIndex) in activeDrawer.tabs" :key="`${tab.component}-${tabIndex}`" :title="tab.title" :selected="tab.selected" :disabled="tab.disabled" @select="onTabChange(tab)">
         <keep-alive>
@@ -246,17 +246,6 @@
       }
     },
     methods: {
-      refreshTabs() {
-        // refresh the tabs when we switch drawers,
-        // because it doesn't want to set the active tab automatically
-        if (this.$refs.tabs) {
-          const activeTab = _.find(this.$refs.tabs.tabs, (tab) => tab.selected);
-
-          if (activeTab) {
-            this.$nextTick(() => this.$refs.tabs.setActiveTab(activeTab.id));
-          }
-        }
-      },
       onTabChange(tab) {
         const currentUrl = _.get(this.$store, 'state.url');
 

--- a/lib/drawers/drawer.vue
+++ b/lib/drawers/drawer.vue
@@ -54,7 +54,7 @@
 <template>
   <transition name="drawer" mode="out-in" @after-enter="refreshTabs">
     <ui-tabs ref="tabs" v-if="isDrawerOpen" class="right-drawer" backgroundColor="clear" :fullwidth="true">
-      <ui-tab v-for="(tab, tabIndex) in tabs" :key="tabIndex" :title="tab.title" :selected="tab.selected" :disabled="tab.disabled" @select="onTabChange(tab.title)">
+      <ui-tab v-for="(tab, tabIndex) in activeDrawer.tabs" :key="`${tab.component}-${tabIndex}`" :title="tab.title" :selected="tab.selected" :disabled="tab.disabled" @select="onTabChange(tab)">
         <keep-alive>
           <component :is="tab.component" :args="tab.args" @selectTab="onSelectTab"></component>
         </keep-alive>
@@ -92,7 +92,8 @@
     const layoutURI = _.get(state, 'page.data.layout'),
       schema = getSchema(layoutURI),
       lists = getListsInHead(),
-      isPageEditMode = state.editMode === 'page';
+      isPageEditMode = state.editMode === 'page',
+      hashTabName = _.get(state, 'url.sites');
 
     return _.reduce(lists, (result, list) => {
       const isPageList = _.get(schema, `${list.path}.${componentListProp}.page`);
@@ -101,7 +102,7 @@
         result.push({
           title: label(list.path, schema[list.path]),
           component: 'head-components',
-          selected: false,
+          selected: hashTabName === 'head-components',
           args: {
             isPage: isPageList,
             path: list.path,
@@ -125,13 +126,14 @@
 
     return _.reduce(schema, (result, field, fieldName) => {
       const isPageList = _.get(field, `${componentListProp}.page`),
-        isInvisibleList = _.has(field, `${componentListProp}.invisible`);
+        isInvisibleList = _.has(field, `${componentListProp}.invisible`),
+        hashTabName = _.get(state, 'url.sites');
 
       if (isInvisibleList && (isPageEditMode && isPageList || !isPageEditMode && !isPageList)) {
         result.push({
           title: label(fieldName, field),
           component: 'invisible-components',
-          selected: false,
+          selected: hashTabName === 'visible-components',
           args: {
             path: fieldName,
             schema: field
@@ -145,71 +147,102 @@
   export default {
     computed: {
       name() {
-        return _.get(this.$store, 'state.ui.currentDrawer');
+        return _.get(this.$store, 'state.ui.currentNav');
       },
       isDrawerOpen() {
-        return !!this.name;
+        return !!this.name && this.activeDrawer;
       },
       tabType() {
         return this.name === 'publish-page' || 'publish-layout' ? 'icon-and-text' : 'text';
       },
       tabs() {
-        const errors = _.get(this.$store, 'state.validation.errors', []),
-          warnings = _.get(this.$store, 'state.validation.warnings', []),
-          openHealth = errors.length > 0 || warnings.length > 0;
+        const state = _.get(this.$store, 'state'),
+          errors = _.get(state, 'validation.errors', []),
+          warnings = _.get(state, 'validation.warnings', []),
+          hashTabName = _.get(state, 'url.sites'), // state.url.sites is just the second param in the url hash object
+          openHealth = errors.length > 0 || warnings.length > 0 || hashTabName === 'health';
 
-        if (this.name === 'contributors') {
-          return [{
-            title: 'Contributors',
-            component: 'contributors',
-            selected: true
-          },{
-            title: 'Page History',
-            component: 'page-history'
-          }];
-        } else if (this.name === 'layout-history') {
-          return [{
-            title: 'Layout History',
-            component: 'layout-history',
-            selected: true
-          }];
-        } else if (this.name === 'components') {
-          const state = _.get(this.$store, 'state'),
-            headLists = getHeadComponentLists(state),
-            invisibleLists = getInvisibleComponentLists(state);
 
-          return [{
-            title: 'Visible',
-            component: 'visible-components',
-            selected: true
-          }].concat(headLists).concat(invisibleLists);
-        } else if (this.name === 'preview') {
-          return [{
-            title: 'Preview',
-            component: 'preview',
-            selected: true
-          }];
-        } else if (this.name === 'publish-page') {
-          return [{
-            title: 'Health',
-            component: 'health',
-            selected: openHealth
-          }, {
-            title: 'Publish',
-            component: 'publish-page',
-            selected: !openHealth
-          }];
-        } else if (this.name === 'publish-layout') {
-          return [{
-            title: 'Health',
-            component: 'health',
-            selected: openHealth
-          }, {
-            title: 'Publish',
-            component: 'publish-layout',
-            selected: !openHealth
-          }];
-        }
+        let tabs = [
+          {
+            name: 'contributors',
+            tabs: [
+              {
+                title: 'Contributors',
+                component: 'contributors',
+                selected: hashTabName === 'contributors'
+              },
+              {
+                title: 'Page History',
+                component: 'page-history',
+                selected: hashTabName === 'page-history'
+              }
+            ]
+          },
+          {
+            name: 'layout-history',
+            tabs: [{
+              title: 'Layout History',
+              component: 'layout-history',
+              selected: true
+            }]
+          },
+          {
+            name: 'find-on-a-page',
+            tabs: [{
+              title: 'Visible',
+              component: 'visible-components',
+              selected: hashTabName === 'visible-components',
+            }].concat(getHeadComponentLists(state)).concat(getInvisibleComponentLists(state))
+          },
+          {
+            name: 'find-on-layout',
+            tabs: [{
+              title: 'Visible',
+              component: 'visible-components',
+              selected: hashTabName === 'visible-components',
+            }].concat(getHeadComponentLists(state)).concat(getInvisibleComponentLists(state))
+          },
+          {
+            name: 'preview',
+            tabs: [{
+              title: 'Preview',
+              component: 'preview',
+              selected: true
+            }]
+          },
+          {
+            name: 'publish-page',
+            tabs: [{
+              title: 'Health',
+              component: 'health',
+              selected: openHealth
+            },
+            {
+              title: 'Publish',
+              component: 'publish-page',
+              selected: !openHealth
+            }]
+          },
+          {
+            name: 'publish-layout',
+            tabs: [{
+              title: 'Health',
+              component: 'health',
+              selected: openHealth
+            },
+            {
+              title: 'Publish',
+              component: 'publish-layout',
+              selected: !openHealth
+            }]
+          }
+        ];
+
+        return tabs;
+      },
+      activeDrawer() {
+        return this.tabs.find((tab)=> tab.name === this.name);
       }
     },
     methods: {
@@ -222,8 +255,11 @@
           this.$nextTick(() => this.$refs.tabs.setActiveTab(activeTab.id));
         }
       },
-      onTabChange(title) {
-        this.$store.commit('SWITCH_TAB', title);
+      onTabChange(tab) {
+        const currentUrl = _.get(this.$store, 'state.url');
+
+        this.$store.dispatch('setHash', { menu: { tab: currentUrl.tab, sites: tab.component, status: '', query: ''} });
+        this.$store.commit('SWITCH_TAB', tab.title);
       },
       onSelectTab(title) {
         const tab = _.find(_.get(this, '$refs.tabs.tabs', []), (tab) => tab.title === title);

--- a/lib/drawers/drawer.vue
+++ b/lib/drawers/drawer.vue
@@ -53,7 +53,7 @@
 
 <template>
   <transition name="drawer" mode="out-in" @after-enter="refreshTabs">
-    <ui-tabs ref="tabs" v-if="isDrawerOpen" class="right-drawer" backgroundColor="clear" :fullwidth="true">
+    <ui-tabs :key="name" ref="tabs" v-if="isDrawerOpen" class="right-drawer" backgroundColor="clear" :fullwidth="true">
       <ui-tab v-for="(tab, tabIndex) in activeDrawer.tabs" :key="`${tab.component}-${tabIndex}`" :title="tab.title" :selected="tab.selected" :disabled="tab.disabled" @select="onTabChange(tab)">
         <keep-alive>
           <component :is="tab.component" :args="tab.args" @selectTab="onSelectTab"></component>

--- a/lib/drawers/drawer.vue
+++ b/lib/drawers/drawer.vue
@@ -147,7 +147,7 @@
   export default {
     computed: {
       name() {
-        return _.get(this.$store, 'state.ui.currentNav');
+        return _.get(this.$store, 'state.ui.currentDrawer');
       },
       isDrawerOpen() {
         return !!this.name && this.activeDrawer;
@@ -252,13 +252,23 @@
         if (this.$refs.tabs) {
           const activeTab = _.find(this.$refs.tabs.tabs, (tab) => tab.selected);
 
-          this.$nextTick(() => this.$refs.tabs.setActiveTab(activeTab.id));
+          if (activeTab) {
+            this.$nextTick(() => this.$refs.tabs.setActiveTab(activeTab.id));
+          }
         }
       },
       onTabChange(tab) {
         const currentUrl = _.get(this.$store, 'state.url');
 
-        this.$store.dispatch('setHash', { menu: { tab: currentUrl.tab, sites: tab.component, status: '', query: ''} });
+        let urlTab = null;
+
+        if (!currentUrl || !currentUrl.tab) {
+          urlTab = this.name || '';
+        } else {
+          urlTab = currentUrl.tab;
+        }
+
+        this.$store.dispatch('setHash', { menu: { tab: urlTab, sites: tab.component, status: '', query: ''} });
         this.$store.commit('SWITCH_TAB', tab.title);
       },
       onSelectTab(title) {

--- a/lib/drawers/page-history.vue
+++ b/lib/drawers/page-history.vue
@@ -96,7 +96,7 @@
         >{{event.formattedAction}}</div>
         <div class="page-history-event-time">{{event.formattedTime}}</div>
         <div class="page-history-event-users">
-          <p v-for="(user, index) in event.users.reverse()">
+          <p v-for="(user, index) in event.users.reverse()" :key="index">
             <span v-if="index === 0">By </span>{{user.name || user.username}}<span v-if="index+1 < event.users.length">, <br/></span>
           </p>
         </div>

--- a/lib/nav/actions.js
+++ b/lib/nav/actions.js
@@ -1,5 +1,5 @@
-import _ from 'lodash';
-import { OPEN_NAV, CLOSE_NAV, SHOW_NAV_BACKGROUND, HIDE_NAV_BACKGROUND } from './mutationTypes';
+import { SHOW_NAV_BACKGROUND, HIDE_NAV_BACKGROUND } from './mutationTypes';
+import { OPEN_DRAWER, CLOSE_DRAWER } from '../nav/mutationTypes';
 
 /**
  * @module nav
@@ -9,19 +9,15 @@ import { OPEN_NAV, CLOSE_NAV, SHOW_NAV_BACKGROUND, HIDE_NAV_BACKGROUND } from '.
  * open nav tab
  * @param  {object} store
  * @param  {string|object} nameOrConfig tab name, or clay menu config
+ * openNav sets the ui.currentDrawer vuex variable, this allows drawers (the right slide-in menus)
+ * as well as the "nav" (the left slide-in menu) to be deep linked to
  */
 export function openNav(store, nameOrConfig) {
-  const currentNav = _.get(store, 'state.ui.currentNav'),
-    name = _.isString(nameOrConfig) ? nameOrConfig : nameOrConfig.tab,
-    config = _.isObject(nameOrConfig) ? nameOrConfig : null;
-
-  if (currentNav !== name) {
-    store.commit(OPEN_NAV, { name, config });
-  }
+  store.commit(OPEN_DRAWER, nameOrConfig);
 }
 
 export function closeNav(store) {
-  store.commit(CLOSE_NAV);
+  store.commit(CLOSE_DRAWER);
   store.dispatch('clearHash'); // Update page url hash
 }
 

--- a/lib/nav/actions.js
+++ b/lib/nav/actions.js
@@ -1,5 +1,4 @@
 import { SHOW_NAV_BACKGROUND, HIDE_NAV_BACKGROUND } from './mutationTypes';
-import { OPEN_DRAWER, CLOSE_DRAWER } from '../nav/mutationTypes';
 
 /**
  * @module nav
@@ -17,12 +16,11 @@ import { OPEN_DRAWER, CLOSE_DRAWER } from '../nav/mutationTypes';
  * Just leaving these here in case any legacy plugins are still calling these functions
  */
 export function openNav(store, nameOrConfig) {
-  store.commit(OPEN_DRAWER, nameOrConfig);
+  store.dispatch('openDrawer', nameOrConfig);
 }
 
 export function closeNav(store) {
-  store.commit(CLOSE_DRAWER);
-  store.dispatch('clearHash'); // Update page url hash
+  store.dispatch('closeDrawer');
 }
 
 export function hideNavBackground(store) {

--- a/lib/nav/actions.js
+++ b/lib/nav/actions.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { OPEN_NAV, CLOSE_NAV } from './mutationTypes';
+import { OPEN_NAV, CLOSE_NAV, SHOW_NAV_BACKGROUND, HIDE_NAV_BACKGROUND } from './mutationTypes';
 
 /**
  * @module nav
@@ -23,4 +23,12 @@ export function openNav(store, nameOrConfig) {
 export function closeNav(store) {
   store.commit(CLOSE_NAV);
   store.dispatch('clearHash'); // Update page url hash
+}
+
+export function hideNavBackground(store) {
+  store.commit(HIDE_NAV_BACKGROUND);
+}
+
+export function showNavBackground(store) {
+  store.commit(SHOW_NAV_BACKGROUND);
 }

--- a/lib/nav/actions.js
+++ b/lib/nav/actions.js
@@ -10,7 +10,11 @@ import { OPEN_DRAWER, CLOSE_DRAWER } from '../nav/mutationTypes';
  * @param  {object} store
  * @param  {string|object} nameOrConfig tab name, or clay menu config
  * openNav sets the ui.currentDrawer vuex variable, this allows drawers (the right slide-in menus)
- * as well as the "nav" (the left slide-in menu) to be deep linked to
+ * as well as the "nav" (the left slide-in menu) to be deep linked to.
+ *
+ * The openNav/closeNav are functions are depreciated.
+ * Should use the openDrawer/closeDrawer/toggleDrawer actions
+ * Just leaving these here in case any legacy plugins are still calling these functions
  */
 export function openNav(store, nameOrConfig) {
   store.commit(OPEN_DRAWER, nameOrConfig);

--- a/lib/nav/mutationTypes.js
+++ b/lib/nav/mutationTypes.js
@@ -1,7 +1,5 @@
 /* eslint-disable one-var */
-// show and hide left nav
-export const OPEN_NAV = 'OPEN_NAV';
-export const CLOSE_NAV = 'CLOSE_NAV';
+// show and hide transparent shaded background
 export const HIDE_NAV_BACKGROUND = 'HIDE_NAV_BACKGROUND';
 export const SHOW_NAV_BACKGROUND = 'SHOW_NAV_BACKGROUND';
 export const CHANGE_FAVORITE_PAGE_CATEGORY = 'CHANGE_FAVORITE_PAGE_CATEGORY';

--- a/lib/nav/mutationTypes.js
+++ b/lib/nav/mutationTypes.js
@@ -2,4 +2,6 @@
 // show and hide left nav
 export const OPEN_NAV = 'OPEN_NAV';
 export const CLOSE_NAV = 'CLOSE_NAV';
+export const HIDE_NAV_BACKGROUND = 'HIDE_NAV_BACKGROUND';
+export const SHOW_NAV_BACKGROUND = 'SHOW_NAV_BACKGROUND';
 export const CHANGE_FAVORITE_PAGE_CATEGORY = 'CHANGE_FAVORITE_PAGE_CATEGORY';

--- a/lib/nav/mutations.js
+++ b/lib/nav/mutations.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { OPEN_NAV, CLOSE_NAV, CHANGE_FAVORITE_PAGE_CATEGORY } from './mutationTypes';
+import { OPEN_NAV, CLOSE_NAV, CHANGE_FAVORITE_PAGE_CATEGORY, SHOW_NAV_BACKGROUND, HIDE_NAV_BACKGROUND } from './mutationTypes';
 
 export default {
   [OPEN_NAV]: (state, { name, config }) => {
@@ -16,6 +16,14 @@ export default {
   },
   [CHANGE_FAVORITE_PAGE_CATEGORY]: (state, id) => {
     _.set(state, 'ui.favoritePageCategory', id);
+    return state;
+  },
+  [SHOW_NAV_BACKGROUND]: (state) => {
+    _.set(state, 'ui.showNavBackground', true);
+    return state;
+  },
+  [HIDE_NAV_BACKGROUND]: (state) => {
+    _.set(state, 'ui.showNavBackground', false);
     return state;
   }
 };

--- a/lib/nav/mutations.js
+++ b/lib/nav/mutations.js
@@ -1,19 +1,7 @@
 import _ from 'lodash';
-import { OPEN_NAV, CLOSE_NAV, CHANGE_FAVORITE_PAGE_CATEGORY, SHOW_NAV_BACKGROUND, HIDE_NAV_BACKGROUND } from './mutationTypes';
+import { CHANGE_FAVORITE_PAGE_CATEGORY, SHOW_NAV_BACKGROUND, HIDE_NAV_BACKGROUND } from './mutationTypes';
 
 export default {
-  [OPEN_NAV]: (state, { name, config }) => {
-    _.set(state, 'ui.currentNav', name);
-    if (config) {
-      _.set(state, 'ui.currentNavConfig', config);
-    }
-    return state;
-  },
-  [CLOSE_NAV]: (state) => {
-    _.set(state, 'ui.currentNav', null);
-    _.set(state, 'ui.currentNavConfig', null);
-    return state;
-  },
   [CHANGE_FAVORITE_PAGE_CATEGORY]: (state, id) => {
     _.set(state, 'ui.favoritePageCategory', id);
     return state;

--- a/lib/nav/nav-background.vue
+++ b/lib/nav/nav-background.vue
@@ -26,7 +26,7 @@
     opacity: 0;
   }
 
-  /* don't scroll the page when left nav is open */
+  /* dont scroll the page when left nav is open */
   .nav-noscroll {
     height: 100%;
     overflow: hidden;
@@ -66,7 +66,7 @@
     },
     computed: {
       displayBackground() {
-        const navIsOpen = !!_.get(this.$store, 'state.ui.currentNav');
+        const navIsOpen = _.get(this.$store, 'state.ui.showNavBackground');
 
         // Toggle the `noscroll` class
         toggleNoScroll(navIsOpen);
@@ -76,6 +76,7 @@
     },
     methods: {
       closeNav() {
+        this.$store.dispatch('hideNavBackground');
         return this.$store.dispatch('closeNav');
       }
     }

--- a/lib/nav/nav-background.vue
+++ b/lib/nav/nav-background.vue
@@ -35,7 +35,7 @@
 
 <template>
   <transition name="nav-fade" v-if="displayBackground">
-      <div class="nav-background" @click.stop="closeNav">
+      <div class="nav-background" @click.stop="closeDrawer">
         <slot></slot>
       </div>
   </transition>
@@ -66,18 +66,18 @@
     },
     computed: {
       displayBackground() {
-        const navIsOpen = _.get(this.$store, 'state.ui.showNavBackground');
+        const drawerIsOpen = _.get(this.$store, 'state.ui.showNavBackground');
 
         // Toggle the `noscroll` class
-        toggleNoScroll(navIsOpen);
+        toggleNoScroll(drawerIsOpen);
         // Return test
-        return navIsOpen;
+        return drawerIsOpen;
       }
     },
     methods: {
-      closeNav() {
+      closeDrawer() {
         this.$store.dispatch('hideNavBackground');
-        return this.$store.dispatch('closeNav');
+        return this.$store.dispatch('closeDrawer');
       }
     }
   };

--- a/lib/nav/nav-content.vue
+++ b/lib/nav/nav-content.vue
@@ -41,7 +41,7 @@
 <template>
   <transition name="nav-content" mode="out-in">
     <keep-alive>
-      <component class="nav-content" v-if="currentNav" :is="currentNav"></component>
+      <component class="nav-content" v-if="currentNav" :is="currentNavComponent"></component>
     </keep-alive>
   </transition>
 </template>
@@ -55,8 +55,14 @@
 
   export default {
     computed: {
+      currentNavComponent() {
+        return this.showNav ? this.currentNav : null;
+      },
       currentNav() {
         return _.get(this.$store, 'state.ui.currentNav');
+      },
+      showNav() {
+        return !!this.$options.components[this.currentNav];
       }
     },
     components: _.merge({

--- a/lib/nav/nav-content.vue
+++ b/lib/nav/nav-content.vue
@@ -41,7 +41,7 @@
 <template>
   <transition name="nav-content" mode="out-in">
     <keep-alive>
-      <component class="nav-content" v-if="currentNav" :is="currentNavComponent"></component>
+      <component class="nav-content" v-if="currentDrawer" :is="currentDrawerComponent"></component>
     </keep-alive>
   </transition>
 </template>
@@ -55,14 +55,14 @@
 
   export default {
     computed: {
-      currentNavComponent() {
-        return this.showNav ? this.currentNav : null;
+      currentDrawerComponent() {
+        return this.showDrawer ? this.currentDrawer : null;
       },
-      currentNav() {
-        return _.get(this.$store, 'state.ui.currentNav');
+      currentDrawer() {
+        return _.get(this.$store, 'state.ui.currentDrawer');
       },
-      showNav() {
-        return !!this.$options.components[this.currentNav];
+      showDrawer() {
+        return !!this.$options.components[this.currentDrawer];
       }
     },
     components: _.merge({

--- a/lib/nav/nav-menu-button.vue
+++ b/lib/nav/nav-menu-button.vue
@@ -56,7 +56,7 @@
     props: ['id', 'icon', 'size'],
     computed: {
       isSelected() {
-        return _.get(this.$store, 'state.ui.currentNav') === this.id;
+        return _.get(this.$store, 'state.ui.currentDrawer') === this.id;
       }
     },
     methods: {

--- a/lib/nav/nav-menu.vue
+++ b/lib/nav/nav-menu.vue
@@ -147,12 +147,14 @@
         return Object.keys(_.get(window, 'kiln.navButtons', {}));
       },
       displayNavMenu() {
-        const navShouldBeOpen = this.menuOptions.findIndex( (option) => option.id === this.currentDrawer ) >= 0 || this.customButtons.find((button) => button === this.currentDrawer);
-
-        if (navShouldBeOpen && !this.navBackgroundIsOpen) {
+        if (this.navShouldBeOpen && !this.navBackgroundIsOpen) {
           this.$store.dispatch('showNavBackground');
         }
-        return navShouldBeOpen;
+
+        return this.navShouldBeOpen;
+      },
+      navShouldBeOpen() {
+        return this.menuOptions.find( (option) => option.id === this.currentDrawer ) || this.customButtons.find((button) => button === this.currentDrawer);
       },
       navBackgroundIsOpen() {
         return _.get(this.$store, 'state.ui.showNavBackground');

--- a/lib/nav/nav-menu.vue
+++ b/lib/nav/nav-menu.vue
@@ -102,29 +102,28 @@
     <nav class="nav-menu">
       <!-- nav menu buttons on small viewport (< 600px) -->
       <ui-icon-button class="nav-menu-button-small" buttonType="button" type="secondary" color="white" icon="arrow_back" @click="closeNav"></ui-icon-button>
+
       <ui-button buttonType="button" class="nav-menu-button-small nav-menu-button-small-white" type="primary" color="none" has-dropdown>
-        <span class="nav-button-small-text">{{ currentNav }}</span>
-        <ui-menu slot="dropdown" :options="navOptions" @select="selectNavOption"></ui-menu>
+        <span class="nav-button-small-text">{{ currentNavName }}</span>
+        <ui-menu slot="dropdown" :options="mobileNavOptions" @select="openNav"></ui-menu>
       </ui-button>
       <div class="nav-menu-divider-small"></div>
-      <ui-icon-button class="nav-menu-button-small" buttonType="button" color="white" type="secondary" icon="add" tooltip="New Page" @click="openNav('new-page')"></ui-icon-button>
+      <ui-icon-button class="nav-menu-button-small" buttonType="button" color="white" type="secondary" :icon="newPageOption.icon" tooltip="newPageOption.label" @click="newPageOption.action(newPageOption.id)"></ui-icon-button>
       <ui-icon-button class="nav-menu-button-small" buttonType="button" color="white" type="secondary" icon="more_vert" has-dropdown ref="dropdownButton">
         <ui-menu slot="dropdown" :options="settingsOptions" @close="$refs.dropdownButton.closeDropdown()" @select="selectSettingsOption"></ui-menu>
       </ui-icon-button>
+
       <!-- nav menu buttons on large viewport (600px+) -->
       <nav-menu-button id="close" icon="arrow_back" size="large" @nav-click="closeNav">Clay</nav-menu-button>
-      <nav-menu-button id="my-pages" @nav-click="openNav">My Pages</nav-menu-button>
-      <nav-menu-button id="all-pages" @nav-click="openNav">All Pages</nav-menu-button>
-      <nav-menu-button id="new-page" icon="add" @nav-click="openNav">New Page</nav-menu-button>
+      <nav-menu-button v-for="option in desktopNavOptions" :id="option.id" @nav-click="option.action" :key="option.id">{{option.label}}</nav-menu-button>
+
       <!-- custom nav buttons -->
       <component v-for="(button, index) in customButtons" :is="button" :key="index"></component>
       <div class="nav-menu-divider"></div>
-      <nav-menu-button v-if="isAdmin" id="users" @nav-click="openNav">Users</nav-menu-button>
-      <nav-menu-button id="signout" @nav-click="signout">Sign Out</nav-menu-button>
+      <nav-menu-button v-for="option in settingsOptions" :id="option.id" @nav-click="option.action" :key="option.id">{{ option.label }}</nav-menu-button>
     </nav>
   </transition>
 </template>
-
 
 <script>
   import _ from 'lodash';
@@ -141,41 +140,82 @@
         return Object.keys(_.get(window, 'kiln.navButtons', {}));
       },
       displayNavMenu() {
-        return !!_.get(this.$store, 'state.ui.currentNav');
+        const navShouldBeOpen = this.menuOptions.findIndex( (option) => option.id === this.currentNav ) >= 0;
+
+        if (navShouldBeOpen && !this.navBackgroundIsOpen) {
+          this.$store.dispatch('showNavBackground');
+        }
+        return navShouldBeOpen;
+      },
+      navBackgroundIsOpen() {
+        return _.get(this.$store, 'state.ui.showNavBackground');
       },
       isAdmin() {
         return _.get(this.$store, 'state.user.auth') === 'admin';
       },
       currentNav() {
-        const val = _.get(this.$store, 'state.ui.currentNav');
-
-        switch (val) {
-          case 'my-pages': return 'My Pages';
-          case 'all-pages': return 'All Pages';
-          case 'new-page': return 'New Page';
-          case 'users': return 'Users';
-          default: return 'Clay';
-        }
+        return _.get(this.$store, 'state.ui.currentNav');
       },
-      navOptions() {
-        return [{
-          label: 'My Pages',
-          disabled: this.currentNav === 'My Pages'
-        }, {
-          label: 'All Pages',
-          disabled: this.currentNav === 'All Pages'
-        }];
+      currentNavName() {
+        return this.menuOptions.find((option) => option.id === this.currentNav).label;
+      },
+      desktopNavOptions() {
+        return this.menuOptions.filter((option) => option.desktopNav);
+      },
+      mobileNavOptions() {
+        return this.menuOptions.filter((option) => option.mobileNav);
       },
       settingsOptions() {
-        if (this.isAdmin) {
-          return ['Users', 'Sign Out'];
-        } else {
-          return ['Sign Out'];
+        return this.menuOptions.filter((option) => option.settings && (option.adminOnly && this.isAdmin || !option.adminOnly));
+      },
+      newPageOption() {
+        return this.menuOptions.find((option) => option.id === 'new-page');
+      },
+      menuOptions() {
+        return [{
+          id: 'my-pages',
+          label: 'My Pages',
+          disabled: this.currentNav === 'my-pages',
+          action: this.openNav,
+          desktopNav: true,
+          mobileNav: true
+        },
+        {
+          id: 'all-pages',
+          label: 'All Pages',
+          disabled: this.currentNav === 'all-pages',
+          action: this.openNav,
+          desktopNav: true,
+          mobileNav: true
+        },
+        {
+          id: 'new-page',
+          label: 'New Page',
+          action: this.openNav,
+          desktopNav: true,
+          icon: 'add'
+        },
+        {
+          id: 'users',
+          label: 'Users',
+          action: this.openNav,
+          settings: true,
+          adminOnly: true
+        },
+        {
+          id: 'signout',
+          label: 'Sign Out',
+          action: this.signout,
+          settings: true
         }
+        ];
       }
     },
     methods: {
       openNav(id) {
+
+        id = _.isString(id) ? id : id.id;
+
         setItem('claymenu:activetab', id);
         this.$store.dispatch('openNav', id);
       },
@@ -184,22 +224,29 @@
       },
       closeNav() {
         this.$store.dispatch('closeNav');
+        this.$store.dispatch('hideNavBackground');
       },
-      selectNavOption(option) {
-        const value = option.label;
+      selectSettingsOption(settingsOption) {
+        if (settingsOption) {
+          settingsOption.action(settingsOption.id);
+        }
+      },
+      currentNavForAdminsOnly() {
+        if (!this.currentNav) {
+          return false;
+        }
 
-        switch (value) {
-          case 'My Pages': return this.openNav('my-pages');
-          case 'All Pages': return this.openNav('all-pages');
-          default: return this.closeNav();
-        }
+        let requiresAdmin = this.menuOptions.find((option) => option.adminOnly && option.id === this.currentNav);
+
+        return !!requiresAdmin;
       },
-      selectSettingsOption(value) {
-        if (value === 'Users') {
-          this.openNav('users');
-        } else {
-          this.signout();
-        }
+      openFirstAllowedNav() {
+        this.openNav(this.menuOptions.find((option) => !option.adminOnly).id);
+      }
+    },
+    updated() {
+      if (!this.isAdmin && this.currentNavForAdminsOnly()) {
+        this.openFirstAllowedNav();
       }
     },
     components: _.merge({

--- a/lib/nav/new-page.vue
+++ b/lib/nav/new-page.vue
@@ -6,7 +6,7 @@
 
 <template>
   <filterable-list v-if="isAdmin" class="new-page-nav" :content="pages" :secondaryActions="secondaryActions" :initialExpanded="initialExpanded" filterLabel="Search Page Templates" :addTitle="addTitle" :addIcon="addIcon" header="Page Template" @child-action="itemClick" @add="addTemplate"></filterable-list>
-  <filterable-list v-else  class="new-page-nav":content="pages" :initialExpanded="initialExpanded" filterLabel="Search Page Templates" header="Page Template" @child-action="itemClick"></filterable-list>
+  <filterable-list v-else  class="new-page-nav" :content="pages" :initialExpanded="initialExpanded" filterLabel="Search Page Templates" header="Page Template" @child-action="itemClick"></filterable-list>
 </template>
 
 <script>
@@ -124,6 +124,15 @@
     },
     components: {
       'filterable-list': filterableList
+    },
+    activated() {
+    // set the url hash
+      this.$store.dispatch('setHash', { menu: {
+        tab: 'new-page',
+        sites: '',
+        status: '',
+        query: ''
+      }});
     }
   };
 </script>

--- a/lib/nav/new-page.vue
+++ b/lib/nav/new-page.vue
@@ -124,15 +124,6 @@
     },
     components: {
       'filterable-list': filterableList
-    },
-    activated() {
-    // set the url hash
-      this.$store.dispatch('setHash', { menu: {
-        tab: 'new-page',
-        sites: '',
-        status: '',
-        query: ''
-      }});
     }
   };
 </script>

--- a/lib/nav/page-list.vue
+++ b/lib/nav/page-list.vue
@@ -192,7 +192,7 @@
    * @return {array}
    */
   function getInitialSites() {
-    const configSites = _.get(this.$store, 'state.ui.currentNavConfig.sites'),
+    const configSites = _.get(this.$store, 'state.url.sites'),
       selectedSites = configSites ? configSites.split(',') : [];
 
     // make an array of all sites, sorted by slug
@@ -353,12 +353,12 @@
     props: ['isMyPages'],
     data() {
       return {
-        query: _.get(this.$store, 'state.ui.currentNavConfig.query', ''),
+        query: _.get(this.$store, 'state.url.query', ''),
         offset: 0,
         total: null,
         sites: getInitialSites.call(this),
         pages: [],
-        selectedStatus: _.get(this.$store, 'state.ui.currentNavConfig.status', 'all'),
+        selectedStatus: _.get(this.$store, 'state.url.status', 'all'),
         isPopoverOpen: false
       };
     },

--- a/lib/nav/page-list.vue
+++ b/lib/nav/page-list.vue
@@ -469,12 +469,14 @@
           // (it's used to hide the "load more" button)
 
           // set the url hash
-          this.$store.dispatch('setHash', { menu: {
-            tab: isMyPages ? 'my-pages' : 'all-pages',
-            sites: siteFilter.join(','),
-            status: statusFilter,
-            query: this.query
-          }});
+          if (_.get(this.$store, 'state.ui.currentDrawer')) {
+            this.$store.dispatch('setHash', { menu: {
+              tab: isMyPages ? 'my-pages' : 'all-pages',
+              sites: siteFilter.join(','),
+              status: statusFilter,
+              query: this.query
+            }});
+          }
         });
       }
     },

--- a/lib/nav/users.vue
+++ b/lib/nav/users.vue
@@ -241,6 +241,15 @@
       person,
       UiTextbox,
       UiButton
+    },
+    activated() {
+      // set the url hash to allow deep-linking
+      this.$store.dispatch('setHash', { menu: {
+        tab: 'users',
+        sites: '',
+        status: '',
+        query: ''
+      }});
     }
   };
 </script>

--- a/lib/nav/users.vue
+++ b/lib/nav/users.vue
@@ -77,7 +77,7 @@
     </div>
     <div class="users-list">
       <person
-        v-for="(user, index) in users"
+        v-for="(user) in users"
         :key="user.id"
         :id="user.id"
         :image="user.imageUrl"

--- a/lib/nav/users.vue
+++ b/lib/nav/users.vue
@@ -241,15 +241,6 @@
       person,
       UiTextbox,
       UiButton
-    },
-    activated() {
-      // set the url hash to allow deep-linking
-      this.$store.dispatch('setHash', { menu: {
-        tab: 'users',
-        sites: '',
-        status: '',
-        query: ''
-      }});
     }
   };
 </script>

--- a/lib/preloader/default-state.js
+++ b/lib/preloader/default-state.js
@@ -17,9 +17,7 @@ export default {
     currentAddComponentModal: null, // current "add component" modal, gets { currentURI, parentURI, path, available }
     currentModal: null, // current "simple" modal, gets { title, type, size, data }
     currentConfirm: null, // current "confirmation" modal, gets { title, text, button, onConfirm }
-    currentDrawer: null, // current right-hand drawer
-    currentNav: null, // current left-hand nav
-    currentNavConfig: null, // special config to open clay menu, used by deep linking
+    currentDrawer: null, // current drawer menu
     currentSelection: null, // currently selected component, gets uri
     currentFocus: null, // currently focused field/group, gets { uri, path }
     showNavBackground: false, // show/hide the shaded semi-transparent background, used when some drawers are open

--- a/lib/preloader/default-state.js
+++ b/lib/preloader/default-state.js
@@ -22,6 +22,7 @@ export default {
     currentNavConfig: null, // special config to open clay menu, used by deep linking
     currentSelection: null, // currently selected component, gets uri
     currentFocus: null, // currently focused field/group, gets { uri, path }
+    showNavBackground: false, // show/hide the shaded semi-transparent background, used when some drawers are open
     currentProgress: 0, // progress bar, gets random number (to prevent flashes)
     currentlySaving: false, // don't focus components while forms are saving, gets boolean
     metaKey: false, // set to true when meta key is pressed, enables additional functionality in kiln

--- a/lib/toolbar/edit-toolbar.vue
+++ b/lib/toolbar/edit-toolbar.vue
@@ -37,6 +37,10 @@
   .toolbar-action-menu.ui-icon-button {
     display: inline-flex;
 
+    &.drawerOpen {
+      background:  rgba(0, 0, 0, 0.1);
+    }
+
     @media screen and (min-width: 600px) {
       display: none;
     }
@@ -71,6 +75,11 @@
       }
     }
   }
+
+  .ui-menu-option__content.activeMenuButton {
+    background: $md-grey-200;
+  }
+
 </style>
 
 <template>
@@ -88,8 +97,12 @@
         <component v-for="(button, index) in customButtons" :is="button" :key="index"></component>
 
         <!-- display a dropdown menu of actions on smaller screens (viewport < 600px) -->
-        <ui-icon-button class="toolbar-action-menu" color="white" size="large" type="secondary" icon="more_vert" tooltip="Actions" has-dropdown ref="dropdownButton" @click="closeDrawer">
-          <ui-menu contain-focus has-icons slot="dropdown" :options="activeToolBarOptions" @close="$refs.dropdownButton.closeDropdown()" @select="optionAction"></ui-menu>
+        <ui-icon-button class="toolbar-action-menu" :class="{drawerOpen: !!currentDrawer}" color="white" size="large" type="secondary" icon="more_vert" tooltip="Actions" has-dropdown ref="dropdownButton" @click="closeDrawer">
+          <ui-menu class="toolbar-action-menu" contain-focus has-icons slot="dropdown" :options="activeToolBarOptions" @close="$refs.dropdownButton.closeDropdown()" @select="optionAction">
+            <template slot-scope="props" slot="option">
+              <div class="ui-menu-option__content" :class="{activeMenuButton: currentDrawer === props.option.id}"><span class="ui-icon ui-menu-option__icon material-icons" :class="props.option.icon">{{ props.option.icon }}</span> <div class="ui-menu-option__text">{{ props.option.label }}</div></div>
+            </template>
+          </ui-menu>
         </ui-icon-button>
 
         <!-- display individual buttons on larger screens (viewport >= 600px) -->
@@ -342,6 +355,7 @@
     methods: {
       toggleEditMode(option) {
         this.$store.dispatch('clearHash');
+        this.$store.dispatch('closeNav');
         const val = option.value,
           { message } = getLayoutNameAndInstance(this.$store),
           layoutAlert = { type: 'warning', text: message },

--- a/lib/toolbar/edit-toolbar.vue
+++ b/lib/toolbar/edit-toolbar.vue
@@ -403,7 +403,6 @@
         return getItem('claymenu:activetab').then((savedTab) => {
           const activeNav = savedTab || 'all-pages';
 
-          this.$store.dispatch('closeDrawer');
           this.$store.dispatch('showNavBackground', true);
           return this.$store.dispatch('openDrawer', activeNav);
         });

--- a/lib/toolbar/edit-toolbar.vue
+++ b/lib/toolbar/edit-toolbar.vue
@@ -83,7 +83,7 @@
 </style>
 
 <template>
-  <div class="kiln-wrapper">
+  <div class="kiln-wrapper"  @keyup.esc.stop="closeDrawer">
     <alert-container></alert-container>
     <drawer></drawer>
     <ui-toolbar type="colored" text-color="white" @nav-icon-click="openNav">
@@ -341,7 +341,7 @@
         return _.get(this.$store, 'state.ui.snackbar') && _.toPlainObject(_.get(this.$store, 'state.ui.snackbar'));
       },
       currentDrawer() {
-        return _.get(this.$store, 'state.ui.currentNav');
+        return _.get(this.$store, 'state.ui.currentDrawer');
       }
     }),
     watch: {
@@ -389,25 +389,7 @@
         return this.$store.dispatch('redo');
       },
       toggleDrawer(name) {
-        const currentTab = _.get(this.$store, 'state.url.tab'),
-          currentNav = _.get(this.$store, 'state.ui.currentNav');
-
-        if (name !== currentTab) {
-          this.$store.dispatch('closeNav');
-          this.$nextTick(() => {
-            this.setHash({ tab: name, sites: '', status: '', query: ''});
-            return this.$store.dispatch('openNav', name);
-          });
-
-        } else if (currentNav) {
-          return this.$store.dispatch('closeNav');
-        }
-
-
-      },
-      setHash(hashObj) {
-        // set the url hash to allow deep-linking
-        this.$store.dispatch('setHash', { menu: hashObj });
+        return this.$store.dispatch('toggleDrawer', name);
       },
       optionAction(option) {
         if (option.action) {
@@ -423,7 +405,7 @@
 
           this.$store.dispatch('closeDrawer');
           this.$store.dispatch('showNavBackground', true);
-          return this.$store.dispatch('openNav', activeNav);
+          return this.$store.dispatch('openDrawer', activeNav);
         });
       }
     },

--- a/lib/toolbar/edit-toolbar.vue
+++ b/lib/toolbar/edit-toolbar.vue
@@ -354,8 +354,7 @@
     },
     methods: {
       toggleEditMode(option) {
-        this.$store.dispatch('clearHash');
-        this.$store.dispatch('closeNav');
+        this.$store.dispatch('closeDrawer');
         const val = option.value,
           { message } = getLayoutNameAndInstance(this.$store),
           layoutAlert = { type: 'warning', text: message },

--- a/lib/toolbar/view-toolbar.vue
+++ b/lib/toolbar/view-toolbar.vue
@@ -127,11 +127,11 @@
         return getItem('claymenu:activetab').then((savedTab) => {
           const activeNav = savedTab || 'all-pages';
 
-          return this.$store.dispatch('openNav', activeNav);
+          return this.$store.dispatch('openDrawer', activeNav);
         });
       },
       openNewPage() {
-        return this.$store.dispatch('openNav', 'new-page');
+        return this.$store.dispatch('openDrawer', 'new-page');
       }
     },
     components: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "8.3.4",
+  "version": "8.3.5-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "8.3.4-1",
+  "version": "8.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "8.3.5-0",
+  "version": "8.3.5",
   "description": "Editor tools for Clay",
   "template": "template.handlebars",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-kiln",
-  "version": "8.3.4",
+  "version": "8.3.5-0",
   "description": "Editor tools for Clay",
   "template": "template.handlebars",
   "scripts": {


### PR DESCRIPTION
https://app.zenhub.com/workspaces/clay-repos-596524da4a8a0769f2f03175/issues/clay/clay-kiln/1377

Opening nav/drawers now sets the url-hash so all drawers can be deep linked to, including plugins, if they are opened using the openDrawer or toggleDrawer action.  Any element can also set the url hash by calling the setHash action and passing it an url object, which can be read and reacted to from store.state.url to enable even deeper linking. 

These changes also combine the openNav and openDrawer functionality, and combines the data for the mobile and desktop nav buttons, so updating nav items no longer needs to be done in two places.

Feature Branch:
http://deep-linking-test.nymag.sites.aws.nymetro.com/
