### PR TITLE
Add keypress prop to simple-list-input

### DIFF
--- a/inputs/simple-list-input.vue
+++ b/inputs/simple-list-input.vue
@@ -32,6 +32,7 @@
       @keydown.right="focusFirstItem"
       @keydown.down="autocompleteFocus(false)"
       @keydown.up.prevent="autocompleteFocus(true)"
+      @keypress="(event) => $emit('keypress', event)"
       @focus="onFocus"
       @blur="onBlur"
       v-conditional-focus="focusOnInput" />
@@ -54,7 +55,7 @@
   import autocomplete from './autocomplete.vue';
 
   export default {
-    props: ['items', 'allowRepeatedItems', 'autocomplete', 'currentItem', 'disabled', 'isInitialFocus', 'ignoreComma'],
+    props: ['items', 'allowRepeatedItems', 'autocomplete', 'currentItem', 'disabled', 'isInitialFocus', 'ignoreComma', 'keypress'],
     data() {
       return {
         val: '',

--- a/inputs/simple-list-input.vue
+++ b/inputs/simple-list-input.vue
@@ -55,7 +55,7 @@
   import autocomplete from './autocomplete.vue';
 
   export default {
-    props: ['items', 'allowRepeatedItems', 'autocomplete', 'currentItem', 'disabled', 'isInitialFocus', 'ignoreComma', 'keypress'],
+    props: ['items', 'allowRepeatedItems', 'autocomplete', 'currentItem', 'disabled', 'isInitialFocus', 'ignoreComma'],
     data() {
       return {
         val: '',


### PR DESCRIPTION
This PR closes: https://github.com/clay/clay-kiln/issues/1394

# Feature
Adding keypress prop

## Example

Now anywhere you use `simple-list-input` you are able to handle keypress event

```js
...
<simple-list-input
    :items="items"
    @add="add"
    @focus="onFocus"
    @blur="onBlur"
    @keypress="onKeyPress"
>

...

methods: {
  ...
  onKeyPress(event): {
      if (!event.key.match(/^[\w ]+$/)) {
        event.preventDefault();
      }
  },
  ...
}
```