### PR TITLE
Issue 1375: Add veux plugin docs

### DIFF
--- a/docs/veux_plugin.md
+++ b/docs/veux_plugin.md
@@ -1,0 +1,44 @@
+---
+id: vuex_plugin
+title: Vuex Plugins
+sidebar_label: Vuex Plugins
+---
+
+When you're working with plugins is slightly tricky to get access to the vue object and its context because you don't have direct access to it. The best way to get around this limitation is to dynamically register a store in a created hook on your root component. It is also necessary to namespace your store due to the module nature of Kiln plugins. For more info on `Vuex modules` see official [documentation](https://vuex.vuejs.org/guide/modules.html)
+
+Example:
+
+```js
+
+const store = {
+  // important!
+  namespaced: true,
+  state: {...}
+  actions: {...},
+  mutations: {...},
+  getters: {...}
+}
+
+// The main component
+Main = {
+  data: () => {...},
+  components: {...},
+
+  // register the store under MyStoreNamespace in the created callback
+  created() {
+      this.$store.registerModule('MyStoreNamespace', store)
+  }
+
+  computed: {
+     someStateVal() {
+       return this.$store.state.MyStoreNamespace.someValue
+    }
+  },
+
+  methods: {
+    updateSomeValue() {
+      this.$store.dispatch('MyStoreNamespace/updateSomeValue')
+    }
+  }
+}
+```

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -23,7 +23,8 @@
         "label": "Kiln API",
         "ids": [
           "api_kiln",
-          "vuex_actions"
+          "vuex_actions",
+          "vuex_plugin"
         ]
       }
     ]

--- a/website/versioned_docs/version-8.6.0/veux_plugin.md
+++ b/website/versioned_docs/version-8.6.0/veux_plugin.md
@@ -1,0 +1,45 @@
+---
+id: version-8.6.0-vuex_plugin
+title: Vuex Plugins
+sidebar_label: Vuex Plugins
+original_id: vuex_plugin
+---
+
+When you're working with plugins is slightly tricky to get access to the vue object and its context because you don't have direct access to it. The best way to get around this limitation is to dynamically register a store in a created hook on your root component. It is also necessary to namespace your store due to the module nature of Kiln plugins. For more info on `Vuex modules` see official [documentation](https://vuex.vuejs.org/guide/modules.html)
+
+Example:
+
+```js
+
+const store = {
+  // important!
+  namespaced: true,
+  state: {...}
+  actions: {...},
+  mutations: {...},
+  getters: {...}
+}
+
+// The main component
+Main = {
+  data: () => {...},
+  components: {...},
+
+  // register the store under MyStoreNamespace in the created callback
+  created() {
+      this.$store.registerModule('MyStoreNamespace', store)
+  }
+
+  computed: {
+     someStateVal() {
+       return this.$store.state.MyStoreNamespace.someValue
+    }
+  },
+
+  methods: {
+    updateSomeValue() {
+      this.$store.dispatch('MyStoreNamespace/updateSomeValue')
+    }
+  }
+}
+```

--- a/website/versioned_sidebars/version-8.6.0-sidebars.json
+++ b/website/versioned_sidebars/version-8.6.0-sidebars.json
@@ -23,7 +23,8 @@
         "label": "Kiln API",
         "ids": [
           "version-8.6.0-api_kiln",
-          "version-8.6.0-vuex_actions"
+          "version-8.6.0-vuex_actions",
+          "version-8.6.0-vuex_plugin"
         ]
       }
     ]


### PR DESCRIPTION
Add the `Veux plugins` docs

Issue:  https://github.com/clay/clay-kiln/issues/1375

# Steps for testing the site locally:
- Go to the `website` folder
- Install all dependencies using `npm install`
- Start your local server using `npm run start`
- Test locally at [Veux Plugin](http://localhost:3000/clay-kiln/docs/vuex_plugin)
- Test locally at [Veux Plugin master](http://localhost:3000/clay-kiln/docs/next/vuex_plugin)