### PR TITLE
Wysiwyg/sortable conflicts

### DIFF
--- a/lib/decorators/complex-list.js
+++ b/lib/decorators/complex-list.js
@@ -69,7 +69,42 @@ function isDraggable(handle, container) {
 
 function addSortable(el) {
   const trash = document.createElement('div'),
-    trashIcon = document.createElement('span');
+    trashIcon = document.createElement('span'),
+    sortElement = sortable.create(el, {
+      group: 'complexList',
+      delay: getDragDelay(),
+      scroll: true,
+      scrollSensitivity: 40,
+      onStart(evt) {
+        evt.item.classList.add(dragItemClass);
+        evt.srcElement.classList.add(dropAreaClass);
+        trash.classList.add(dropAreaClass);
+      },
+      onMove(evt) {
+        const isInsideField = evt.dragged.classList.contains('kiln-field');
+
+        if (isInsideField) {
+          // set isInvalidDrag if user is selecting text inside form fields.
+          // it's unset when they either click another thing in the form
+          // OR if the document click event fires (when they mouseup outside of the form)
+          window.kiln.isInvalidDrag = true;
+
+          // returning false reverts to the original order
+          return false;
+        }
+
+        return isDraggable(evt.dragged, evt.from);
+      },
+      onEnd(evt) {
+        evt.item.classList.remove(dragItemClass);
+        evt.from.classList.remove(dropAreaClass);
+        trash.classList.remove(dropAreaClass);
+
+        updateOrder(el).then(() => {
+          evt.item.classList.remove(dragItemUnsavedClass);
+        });
+      }
+    });
 
   trash.classList.add('complex-list-trash');
   trashIcon.classList.add('material-icons', 'delete');
@@ -82,39 +117,16 @@ function addSortable(el) {
     group: 'complexList'
   });
 
-  sortable.create(el, {
-    group: 'complexList',
-    delay: getDragDelay(),
-    scroll: true,
-    scrollSensitivity: 40,
-    onStart(evt) {
-      evt.item.classList.add(dragItemClass);
-      evt.srcElement.classList.add(dropAreaClass);
-      trash.classList.add(dropAreaClass);
-    },
-    onMove(evt) {
-      const isInsideField = evt.dragged.classList.contains('kiln-field');
-
-      if (isInsideField) {
-        // set isInvalidDrag if user is selecting text inside form fields.
-        // it's unset when they either click another thing in the form
-        // OR if the document click event fires (when they mouseup outside of the form)
-        window.kiln.isInvalidDrag = true;
-
-        // returning false reverts to the original order
-        return false;
-      }
-
-      return isDraggable(evt.dragged, evt.from);
-    },
-    onEnd(evt) {
-      evt.item.classList.remove(dragItemClass);
-      evt.from.classList.remove(dropAreaClass);
-      trash.classList.remove(dropAreaClass);
-
-      updateOrder(el).then(() => {
-        evt.item.classList.remove(dragItemUnsavedClass);
-      });
+  store.subscribe((mutation) => {
+    // When an element has focus, i.e. is being edited, the sortable is disabled so it doesn't interfere with the wysiwyg editor
+    switch (mutation.type) {
+      case 'FOCUS':
+        sortElement.option('disabled', true);
+        break;
+      case 'UN_FOCUS':
+        sortElement.option('disabled', false);
+        break;
+      default:
     }
   });
 }

--- a/lib/decorators/complex-list.js
+++ b/lib/decorators/complex-list.js
@@ -5,7 +5,7 @@ import { getData, getSchema } from '../core-data/components';
 import { getComponentEl } from '../utils/component-elements';
 import store from '../core-data/store';
 import logger from '../utils/log';
-import { getDragDelay } from './helpers';
+import { getDragDelay, disableSortableWhenFocused } from './helpers';
 
 const log = logger(__filename);
 
@@ -117,18 +117,7 @@ function addSortable(el) {
     group: 'complexList'
   });
 
-  store.subscribe((mutation) => {
-    // When an element has focus, i.e. is being edited, the sortable is disabled so it doesn't interfere with the wysiwyg editor
-    switch (mutation.type) {
-      case 'FOCUS':
-        sortElement.option('disabled', true);
-        break;
-      case 'UN_FOCUS':
-        sortElement.option('disabled', false);
-        break;
-      default:
-    }
-  });
+  disableSortableWhenFocused(sortElement);
 }
 
 function validChildElements(el, uri, path) {

--- a/lib/decorators/component-list.js
+++ b/lib/decorators/component-list.js
@@ -93,7 +93,7 @@ function addSortableJS(el) {
     return false;
   }
 
-  sortable.create(el, {
+  const sortElement = sortable.create(el, {
     delay: getDragDelay(),
     scroll: true,
     scrollSensitivity: 40,
@@ -151,6 +151,19 @@ function addSortableJS(el) {
         document.dispatchEvent(mouseUpEvent);
         evt.item.classList.remove(dragItemUnsavedClass);
       }
+    }
+  });
+
+  store.subscribe((mutation) => {
+    // When an element has focus, i.e. is being edited, the sortable is disabled so it doesn't interfere with the wysiwyg editor
+    switch (mutation.type) {
+      case 'FOCUS':
+        sortElement.option('disabled', true);
+        break;
+      case 'UN_FOCUS':
+        sortElement.option('disabled', false);
+        break;
+      default:
     }
   });
 }

--- a/lib/decorators/component-list.js
+++ b/lib/decorators/component-list.js
@@ -6,7 +6,7 @@ import { getData, getSchema } from '../core-data/components';
 import { getComponentEl, isComponentInPage } from '../utils/component-elements';
 import store from '../core-data/store';
 import logger from '../utils/log';
-import { getDragDelay } from './helpers';
+import { getDragDelay, disableSortableWhenFocused } from './helpers';
 
 const log = logger(__filename);
 
@@ -154,18 +154,7 @@ function addSortableJS(el) {
     }
   });
 
-  store.subscribe((mutation) => {
-    // When an element has focus, i.e. is being edited, the sortable is disabled so it doesn't interfere with the wysiwyg editor
-    switch (mutation.type) {
-      case 'FOCUS':
-        sortElement.option('disabled', true);
-        break;
-      case 'UN_FOCUS':
-        sortElement.option('disabled', false);
-        break;
-      default:
-    }
-  });
+  disableSortableWhenFocused(sortElement);
 }
 
 /**

--- a/lib/decorators/helpers.js
+++ b/lib/decorators/helpers.js
@@ -1,16 +1,32 @@
+import store from '../core-data/store';
+
 const getDragDelay = () => {
   // Elements that use SortableJS have a dragDelay property which is the ms
   // the user must hold the element before they can drag it.  On desktop this
   // should be 0.
-  let dragDelay = 0;
+    let dragDelay = 0;
 
-  if (window.matchMedia && window.matchMedia('(hover: none)').matches || 'ontouchstart' in document.documentElement) {
-    // for devices that don't support hover (i.e. mobile devices), dragDelay is set to 200 so users
-    //  can scroll without triggering drags every time their finger touches a draggable element
-    dragDelay = 200;
-  }
+    if (window.matchMedia && window.matchMedia('(hover: none)').matches || 'ontouchstart' in document.documentElement) {
+      // for devices that don't support hover (i.e. mobile devices), dragDelay is set to 200 so users
+      //  can scroll without triggering drags every time their finger touches a draggable element
+      dragDelay = 200;
+    }
 
-  return dragDelay;
-};
+    return dragDelay;
+  },
+  disableSortableWhenFocused = (sortable) => {
+    store.subscribe((mutation) => {
+      // When an element has focus, i.e. is being edited, the sortable is disabled so it doesn't interfere with the wysiwyg editor
+      switch (mutation.type) {
+        case 'FOCUS':
+          sortable.option('disabled', true);
+          break;
+        case 'UN_FOCUS':
+          sortable.option('disabled', false);
+          break;
+        default:
+      }
+    });
+  };
 
-export { getDragDelay };
+export { getDragDelay, disableSortableWhenFocused };


### PR DESCRIPTION
When an element is inline editable and sortable, the sort touch/drag action was interfering with the wysiwyg formatting.  When you clicked on the toolbar to remove the bold/italics/etc. the sortable would think you were trying to move the element and the formatting wouldn't be removed.  This fix disables the sortable while an editable element has 'focus', so you can't sort and edit at the same time so the two don't interfere with each other.