### PR TITLE
feat: set focus on toolbar buttons when they are clicked to unfocus a…

### DIFF
--- a/lib/toolbar/edit-toolbar.vue
+++ b/lib/toolbar/edit-toolbar.vue
@@ -107,6 +107,7 @@
 
         <!-- display individual buttons on larger screens (viewport >= 600px) -->
         <component
+          :ref="option.id"
           size="large"
           v-for="option in activeToolBarOptions"
           :color="option.color || 'white'"
@@ -394,6 +395,7 @@
       },
       optionAction(option) {
         if (option.action) {
+          this.$refs[action].focus();
           option.action(option.id);
         }
       },
@@ -405,7 +407,6 @@
           const activeNav = savedTab || 'all-pages';
 
           this.$store.dispatch('showNavBackground', true);
-  
           return this.$store.dispatch('openDrawer', activeNav);
         });
       }

--- a/lib/toolbar/edit-toolbar.vue
+++ b/lib/toolbar/edit-toolbar.vue
@@ -407,6 +407,7 @@
           const activeNav = savedTab || 'all-pages';
 
           this.$store.dispatch('showNavBackground', true);
+
           return this.$store.dispatch('openDrawer', activeNav);
         });
       }


### PR DESCRIPTION
## Feature

This PR helps the toolbar button to gain focus when is clicked. This way any input that is being edited will loose focus and as result will be saved.

Issue: https://github.com/clay/clay-kiln/issues/1474