### PR TITLE
fix: Handle keys args in select input

### DIFF
--- a/inputs/select.test.js
+++ b/inputs/select.test.js
@@ -1,0 +1,42 @@
+import Select from './select.vue';
+
+describe('select input', () => {
+  const filterBySite = jest.fn(),
+    options = {
+      propsData: {
+        name: 'foo',
+        data: null,
+        schema: {},
+        args: { options: [1, 2, 3] }
+      },
+      mocks: {
+        $store: {
+          state: { site: { slug: 'test' } }
+        }
+      }
+    };
+
+  let wrapper;
+
+  filterBySite.mockReturnValue([1, 2, 3]);
+
+  test('Should use default computed keys when no keys are sent in args', () => {
+    options.propsData.args.keys = {};
+    wrapper = shallowMount(Select, options);
+
+    expect(wrapper.vm.keys).toStrictEqual({
+      label: 'name',
+      value: 'value'
+    });
+  });
+
+  test('Should set valueKey to "value" when the label and value value in args.keys are equal', () => {
+    options.propsData.args.keys = {
+      label: 'text',
+      value: 'text'
+    };
+    wrapper = shallowMount(Select, options);
+
+    expect(wrapper.vm.valueKey).toEqual('value');
+  });
+});

--- a/inputs/select.test.js
+++ b/inputs/select.test.js
@@ -30,7 +30,7 @@ describe('select input', () => {
     });
   });
 
-  test('Should set valueKey to "value" when the label and value value in args.keys are equal', () => {
+  test('Should set valueKey to "value" when the label and value in args.keys are equal', () => {
     options.propsData.args.keys = {
       label: 'text',
       value: 'text'

--- a/inputs/select.vue
+++ b/inputs/select.vue
@@ -132,21 +132,46 @@
           value: 'value'
         }, this.args.keys || {});
       },
+      equalLabelValueKeys() {
+        return this.keys.label === this.keys.value;
+      },
+      valueKey() {
+        return this.equalLabelValueKeys ? 'value' : this.keys.value;
+      },
       NULL_OPTION() {
         return {
           [this.keys.label]: 'None',
-          [this.keys.value]: null
+          [this.valueKey]: null
         };
       },
       // combine arg/prop options, fetched list options, and a null option for non-multiple selects
       options() {
         const propOptions = this.args.options || [],
           currentSlug = _.get(this.$store, 'state.site.slug'),
+          { label } = this.keys,
           noneOption = propOptions.find((val) => {
-            return val.name === 'None' || val.name === 'Default';
+            return val[label] === 'None' || val[label] === 'Default';
           });
 
         let fullOptions = propOptions.concat(this.listOptions);
+
+        // filter by site specificity
+        fullOptions = filterBySite(fullOptions, currentSlug);
+
+        // format the options for the UI
+        fullOptions = _.map(fullOptions, (option) => {
+          if (_.isString(option) || _.isNumber(option)) {
+            return {
+              [this.valueKey]: option,
+              [label]: _.startCase(option)
+            };
+          }
+
+          return {
+            [this.valueKey]: this.equalLabelValueKeys ? option[label] : option[this.valueKey],
+            [label]: option[label]
+          };
+        });
 
         // if there is no 'None' option defined then add a null option because
         // single-select must have null option, if there is no null option
@@ -154,20 +179,7 @@
           fullOptions = [this.NULL_OPTION].concat(fullOptions);
         }
 
-        // filter by site specificity
-        fullOptions = filterBySite(fullOptions, currentSlug);
-
-        // format the options for the UI
-        return _.map(fullOptions, (option) => {
-          if (_.isString(option) || _.isNumber(option)) {
-            return {
-              [this.keys.value]: option,
-              [this.keys.label]: _.startCase(option)
-            };
-          } else {
-            return option;
-          }
-        });
+        return fullOptions;
       },
       // convert store data into a format suitable for Keen UiSelect.value prop
       value() {
@@ -175,11 +187,11 @@
           // defaults to pass Keen's type check
           return this.args.multiple ? [] : this.NULL_OPTION;
         } else if (this.args.multiple) {
-          return _.filter(this.options, option => !!this.data[option.value]);
+          return _.filter(this.options, option => !!this.data[option[this.valueKey]]);
         } else if (this.args.storeRawData) {
           return this.data;
         } else {
-          return _.find(this.options, option => this.data === option.value);
+          return _.find(this.options, option => this.data === option[this.valueKey]);
         }
       },
       hasOptions() {
@@ -214,11 +226,11 @@
           // set all existing options in data to false
           data = _.mapValues(_.cloneDeep(this.data), () => false);
           // for each of the selected options, set the related key in the data to true
-          _.forEach(value, option => data[option.value] = true);
+          _.forEach(value, option => data[option[this.valueKey]] = true);
         } else if (this.args.storeRawData) {
           data = _.cloneDeep(value);
         } else {
-          data = value.value;
+          data = value[this.valueKey];
         }
 
         this.$store.commit(UPDATE_FORMDATA, { path: this.name, data });

--- a/test/setupFile.js
+++ b/test/setupFile.js
@@ -19,6 +19,8 @@ jest.mock('clay-log', () => ({
   meta: () => mockLogger
 }));
 
+global.window.kiln = { inputs: {} };
+
 // mock cuid because it doesn't like being run in jsdom
 jest.mock('cuid');
 cuid.default.mockReturnValue('abc');


### PR DESCRIPTION
# FIX

This PR:
- Allows keys args.
- Allows same keys for label and value (helps specially with `_lists` that only have `text` and `count`).

