### PR TITLE
Change regular function to arrow function

### DIFF
--- a/inputs/magic-button.vue
+++ b/inputs/magic-button.vue
@@ -370,7 +370,7 @@
         // (not field, component, or moreMagic)
         if (moreMagic.length) {
           return promise
-            .then(function (res) {
+            .then((res) => {
               return reducePromise(moreMagic, doMoreMagic.bind(this), res);
             })
             .then((finalRes) => {


### PR DESCRIPTION
# Fix

This PR fixes error of `Cannot read property '$store' of undefined` when using moreMagic in the magic button component.