### PR TITLE
ON-2506: allow for $el to be undefined

### DIFF
--- a/lib/forms/overlay.vue
+++ b/lib/forms/overlay.vue
@@ -316,7 +316,11 @@
       onResize() {
         // when resizing, we can let css do its work. we don't have to worry about animation or anything,
         // since we've already animated the form opening
-        this.$el.style.height = 'auto';
+        const style = _.get(this, '$el.style');
+
+        if (style) {
+          style.height = 'auto';
+        }
       },
       onTabChange() {
         // call the resizer when changing tabs, in case something should have triggered a resize in the background


### PR DESCRIPTION
$el will be undefined when certain kiln inputs are used outside
the overlay.  Using kiln inputs outside the overlay is helpful
when writing a simple custom interface whose inputs should be
familiar to the editor.  Ideally the kiln inputs would be generic
enough to be used outside the context of kiln, however that is
surely a "nice to have" rather than a necessary feature.

Specifically the simple-list component caused this issue.