### PR TITLE
protects against invalid Quill links

### DIFF
--- a/inputs/wysiwyg.vue
+++ b/inputs/wysiwyg.vue
@@ -170,10 +170,18 @@
   Link.sanitize = (value) => {
     if (!(/^\w+:/).test(value) && !(/^#/).test(value)) {
       // no protocol, and the link doesn't start with a hash (in-page links),
-      // so add http://
+      // so add https://
       // note: links that start with // are an antipattern, and this will NOT handle them
       // https://jeremywagner.me/blog/stop-using-the-protocol-relative-url
-      value = `http://${value}`;
+      value = `https://${value}`;
+
+      // modified links that still don't pass for valid urls will default to
+      // the default quill behavior (using about:blank)
+      try {
+        new URL(value);
+      } catch (err) {
+        value = 'about:blank';
+      }
     }
 
     return originalLinkSanitize.call(Link, value);


### PR DESCRIPTION
The default behavior when parsing a link in Quill:

1. Check if link matches a list of valid protocols.
2. If not, change link text to `about:blank`.

Kiln wraps the `Link.sanitize` function to prepend `http://` in front
of any link missing a protocol.

As a result we can end up with invalid links like this:

```
"http://one two three"
```

This commit preserves the convenience factor of not **requiring** end
users to enter a protocol, but validates that the link produced is a
valid URL. Invalid URLs will revert to `about:blank`.

This commit also changes the default protocol to `https://` which is a
reasonable expectation and more secure default.