### PR TITLE
replaces deprecated GitHub Actions filter

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,8 @@
-on: push
+on:
+  push:
+    branches:
+      - master
+
 name: Deploy to GitHub Pages
 jobs:
   filterBranch:
@@ -6,10 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Filter branch
-      uses: actions/bin/filter@master
-      with:
-        args: branch master
     - name: Install
       uses: actions/npm@master
       with:


### PR DESCRIPTION
The method used to restrict 'docusaurus' actions to the main branch was
deprecated and replaced with a new YAML syntax.

https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filtering-for-specific-branches-tags-and-paths

This commit uses the new syntax.