### PR TITLE
restores X-Clay-User header value

### DIFF
--- a/lib/core-data/api.js
+++ b/lib/core-data/api.js
@@ -26,14 +26,13 @@ import {
 
 /**
  * @param {object} obj
- * @param {string} username
  * @returns {object}
  */
-function addJsonHeader(obj, username) {
+function addJsonHeader(obj) {
   _.assign(obj, {
     headers: {
       [contentHeader]: contentJSON,
-      [userHeader]: username
+      [userHeader]: _.get(store, 'state.user.username')
     }
   });
 
@@ -42,14 +41,13 @@ function addJsonHeader(obj, username) {
 
 /**
  * @param {object} obj
- * @param {string} username
  * @returns {object}
  */
-function addTextHeader(obj, username) {
+function addTextHeader(obj) {
   _.assign(obj, {
     headers: {
       [contentHeader]: contentText,
-      [userHeader]: username
+      [userHeader]: _.get(store, 'state.user.username')
     }
   });
 
@@ -59,15 +57,14 @@ function addTextHeader(obj, username) {
 /**
  * add headers to all GET requests
  * @param {string} url
- * @param {string} username
  * @returns {object}
  */
-function addGetHeader(url, username) {
+function addGetHeader(url) {
   return {
     method: 'GET',
     url: url,
     headers: {
-      [userHeader]: username
+      [userHeader]: _.get(store, 'state.user.username')
     }
   };
 }


### PR DESCRIPTION
Somewhere way back in #744 a new header called `X-Clay-User` was added to help audit request activity.
A refactor later on wiped out this feature, leaving only references to the functionality through an unused `username` positional argument.

This commit restores the `X-Clay-User` header by (safely) pulling it from the global state.