### PR TITLE
Improve support for underscores in field names

### DIFF
--- a/lib/core-data/components.js
+++ b/lib/core-data/components.js
@@ -31,20 +31,19 @@ export function getDefaultData(uri, testStore) {
 }
 
 /**
- * check to see if a string is camelCased
+ * Check if a string contains non-letter, non-number, or non-underscore chars
+ *
  * @param  {string} str
  * @return {boolean}
  */
-function isCamelCase(str) {
-  // note: we're lowercasing everything because we don't care about 100% perfect camelCase (e.g. imageURL is valid),
-  // we just want to make sure that people aren't using weird characters that cannot be used as properties in dot notation
+function isValidKilnDotNotation(str) {
+  // https://regex101.com/r/wapXTM/2 for an example of this regex in action
 
-  // Lodash camelCase strips underscores
-  // Allow for n number of underscores at the beginning of a schema field name
-  const camel = _.camelCase(str);
-  const strippedStr = str.replace(/^_*/, '');
+  // This function is used after "toDotNotation()" in "assertCamelCasedProps()" below
+  // "toDotNotation" actually allows numbers, which are not valid property accessors in dot notation, but which is why we permit numbers here
 
-  return strippedStr.toLowerCase() === camel.toLowerCase();
+  // If the regex returns false, it means that the string is valid
+  return !(/[^\w\$_]/g.test(str));
 }
 
 /**
@@ -57,16 +56,16 @@ function isCamelCase(str) {
 function assertCamelCasedProps(item, name) {
   if (_.isString(item) && _.includes(toDotNotation(item), '.')) {
     // deep path! make sure all parts of it are camelcased
-    const nonCamelCasedPart = _.find(toDotNotation(item).split('.'), part => !isCamelCase(part));
+    const nonCamelCasedPart = _.find(toDotNotation(item).split('.'), part => !isValidKilnDotNotation(part));
 
     if (nonCamelCasedPart) {
       log.error(`Properties in component data must be camelCased: ${name} → ${item} (try "${_.camelCase(nonCamelCasedPart)}")`);
     }
-  } else if (_.isString(item) && !isCamelCase(item)) {
+  } else if (_.isString(item) && !isValidKilnDotNotation(item)) {
     log.error(`Properties in component data must be camelCased: ${name} → ${item} (try "${_.camelCase(item)}")`);
   } else if (_.isObject(item)) {
     _.forOwn(item, (val, prop) => {
-      if (!isCamelCase(prop)) {
+      if (!isValidKilnDotNotation(prop)) {
         log.error(`Properties in component data must be camelCased: ${name} → ${prop} (try "${_.camelCase(prop)}")`);
       }
     });

--- a/lib/core-data/components.js
+++ b/lib/core-data/components.js
@@ -36,11 +36,15 @@ export function getDefaultData(uri, testStore) {
  * @return {boolean}
  */
 function isCamelCase(str) {
-  const camel = _.camelCase(str);
-
   // note: we're lowercasing everything because we don't care about 100% perfect camelCase (e.g. imageURL is valid),
   // we just want to make sure that people aren't using weird characters that cannot be used as properties in dot notation
-  return str.toLowerCase() === camel.toLowerCase() || str.toLowerCase() === `_${camel}`.toLowerCase(); // lodash's camelCase() will remove leading underscores, which we allow in things like _version, _description, and _devDescription
+
+  // Lodash camelCase strips underscores
+  // Allow for n number of underscores at the beginning of a schema field name
+  const camel = _.camelCase(str);
+  const strippedStr = str.replace(/^_*/, '');
+
+  return strippedStr.toLowerCase() === camel.toLowerCase();
 }
 
 /**

--- a/lib/core-data/components.test.js
+++ b/lib/core-data/components.test.js
@@ -17,6 +17,11 @@ const uri = '/_components/foo',
                 _has: 'text'
               }]
             }
+          },
+          __doubleUnderscoredProp: {
+            _has: {
+              help: 'Some sample help text'
+            }
           }
         }
       },


### PR DESCRIPTION
## Description

This PR: 
1. Fixes an issue where schema fields prefixed with more than one underscore are recognized as invalid. 
2. Renames `isCamelCase()` to more accurately describe the function's intended purpose, which is to check for the presence of invalid characters in property names. 

Re 1): our team has a code convention where certain properties begin with double underscores. When components using these properties are rendered, we get something like the following:

<img width="918" alt="Screen Shot 2020-12-09 at 2 05 43 PM" src="https://user-images.githubusercontent.com/16308025/101691986-86910880-3a3d-11eb-9524-f1897a5e5d67.png">

This is because `isCamelCase()` only accounted for single underscores. 

Re: 2), I realized that `isCamelCase()` was not actually checking that a key was camelCase, but instead verifying that it didn't have any characters that would be invalid for Kiln's `dotNotation()` function (which allows numbers for some reason, even though these aren't valid in dot notation). I renamed `isCamelCase` to `isValidKilnDotNotation` to reflect this.

## Testing
To test, add a schema field beginning with multiple underscores to a component and use that field in your template. Confirm that there are no errors. Here's an example of how we're actually using a double underscored field, `__isUniqueInstance`, in our app: 

```yml
strapline:
  _reveal:
    field: __isUniqueInstance
    operator: falsy
  _has:
    input: text
    validate:
      required:
        field: straplineUrl
        operator: truthy

__isUniqueInstance:
  _has:
    help: |
      Indicates whether this is a unique instance e.g. for jazzy cover stories

_groups:
  notableLinksInfo:
    _label: Notable Links
    _placeholder:
      ifEmpty: notableLinks
    fields:
      - notableLinks
      - __isUniqueInstance #put here cause _label only works with 2+ fields grouped -- todo test this is still true
```
 