### PR TITLE
include full option in case "store raw data" is being used

### DIFF
--- a/inputs/select.vue
+++ b/inputs/select.vue
@@ -170,8 +170,7 @@
 
           return {
             ...option, // spread the whole object in case it has extra properties
-            [this.valueKey]: this.equalLabelValueKeys ? option[label] : option[this.valueKey],
-            [label]: option[label]
+            [this.valueKey]: this.equalLabelValueKeys ? option[label] : option[this.valueKey]
           };
         });
 

--- a/inputs/select.vue
+++ b/inputs/select.vue
@@ -169,6 +169,7 @@
           }
 
           return {
+            ...option, // spread the whole object in case it has extra properties
             [this.valueKey]: this.equalLabelValueKeys ? option[label] : option[this.valueKey],
             [label]: option[label]
           };


### PR DESCRIPTION
this very slightly breaking change was made awhile back but we only just started updating to this version today https://github.com/clay/clay-kiln/commit/13e22e3f0ee8dca89c7a4cb6826078575db847f5#diff-4ad3b161a1d611815c7cb663762b272b194ef75ed42580f277119fd706dd0206L167 

we noticed that only a few of the properties from our "raw" objects were being plucked out for the stored value, this PR should fix that by including _all_ the properties of the original object.