### PR TITLE
add disable input support for ui-select

### DIFF
--- a/inputs/select.vue
+++ b/inputs/select.vue
@@ -83,7 +83,7 @@
     :label="label"
     :floatingLabel="true"
     :help="args.help"
-    :disabled="disabled"
+    :disabled="isDisabled"
     :error="errorMessage"
     :invalid="isInvalid"
     iconPosition="right"
@@ -114,7 +114,7 @@
     data() {
       return {
         listOptions: [],
-        isDisabled: false
+        userDisabled: false
       };
     },
     mounted() {
@@ -209,6 +209,9 @@
       },
       isInvalid() {
         return !!this.errorMessage;
+      },
+      isDisabled() {
+        return this.disabled || this.userDisabled;
       }
     },
     methods: {
@@ -252,10 +255,10 @@
         return promise;
       },
       disableInput() {
-        this.isDisabled = true;
+        this.userDisabled = true;
       },
       enableInput() {
-        this.isDisabled = false;
+        this.userDisabled = false;
       }
     },
     components: {


### PR DESCRIPTION
Looks like this was implemented in a half-baked way - the `disabled` prop was being respected but the `isDisabled` value in `data` was being ignored. It has been updated to respect both values, with the prop taking precedence over the component state - I believe this is the intended behavior.


<video src="https://user-images.githubusercontent.com/1163/128879569-ce81100c-1eb9-4d4c-821d-93c9c56529ff.mp4
"></video>

closes #1531 