### PR TITLE
use correct property name in "triggerModelRender" dispatch

### DIFF
--- a/inputs/kiln-input.js
+++ b/inputs/kiln-input.js
@@ -147,8 +147,8 @@ export default class KilnInput {
   reRenderInstance(uri) {
     const url = addProtocol(uri);
 
-    return api.getJSON(url).then((component) => {
-      store.dispatch('triggerModelRender', { uri, component });
+    return api.getJSON(url).then((data) => {
+      store.dispatch('triggerModelRender', { uri, data });
     });
   }
 


### PR DESCRIPTION
I was just noticing that [`reRenderInstance`](https://github.com/clay/clay-kiln/blob/231e4eb7d3842506af5796c1c843fff901b25a7e/inputs/kiln-input.js#L147) does not work because it is sending a property named `component` https://github.com/clay/clay-kiln/blob/231e4eb7d3842506af5796c1c843fff901b25a7e/inputs/kiln-input.js#L151
but [`triggerModelRender`](https://github.com/clay/clay-kiln/blob/2adb7bb602a31928c30fb153360e9dedd08973a4/lib/component-data/actions.js#L126) is expecting a property named `data`: https://github.com/clay/clay-kiln/blob/2adb7bb602a31928c30fb153360e9dedd08973a4/lib/component-data/actions.js#L126