### PR TITLE
🍕 Fix scheduling/unscheduling workflow

### DIFF
--- a/lib/drawers/publish-layout.vue
+++ b/lib/drawers/publish-layout.vue
@@ -274,6 +274,8 @@
           })
           .then(() => {
             store.commit(FINISH_PROGRESS);
+            // reset date and time values
+            this.clearScheduleForm();
             store.dispatch('showSnackbar', 'Unscheduled Layout');
           });
       },
@@ -324,6 +326,7 @@
       },
       clearScheduleForm() {
         this.dateValue = null;
+        this.timeValue = null;
         this.$refs.timepicker.clear();
       },
       saveTitle() {

--- a/lib/drawers/publish-page.vue
+++ b/lib/drawers/publish-page.vue
@@ -228,7 +228,7 @@
         const store = this.$store;
 
         store.commit(START_PROGRESS);
-        store.dispatch('unschedulePage', this.uri)
+        store.dispatch('unschedulePage')
           .catch((e) => {
             store.commit(FINISH_PROGRESS, 'error');
             log.error(`Error unscheduling page: ${e.message}`, { action: 'unschedulePage' });
@@ -241,6 +241,8 @@
           })
           .then(() => {
             store.commit(FINISH_PROGRESS);
+            // reset date and time values
+            this.clearScheduleForm();
             store.dispatch('showSnackbar', 'Unscheduled Page');
           });
       },
@@ -326,6 +328,7 @@
       },
       clearScheduleForm() {
         this.dateValue = null;
+        this.timeValue = null;
         this.$refs.timepicker.clear();
       },
       saveLocation(undoUrl) {

--- a/lib/layout-state/actions.js
+++ b/lib/layout-state/actions.js
@@ -103,13 +103,13 @@ export function scheduleLayout(store, { timestamp }) {
  */
 export function unscheduleLayout(store, publishing = false) {
   const layoutUri = _.get(store, 'state.layout.uri'),
-    scheduleId = btoa(layoutUri),
+    scheduledId = btoa(layoutUri),
     prefix = _.get(store, 'state.site.prefix'),
-    scheduleUri = `${prefix}${scheduleRoute}/${scheduleId}`;
+    scheduledUri = `${prefix}${scheduleRoute}/${scheduledId}`;
 
-  store.dispatch('startProgress', 'scheduled');
+  store.dispatch('startProgress', 'unscheduled');
 
-  return remove(scheduleUri)
+  return remove(scheduledUri)
     .then(() => {
       if (publishing) {
         return Promise.resolve();
@@ -118,7 +118,7 @@ export function unscheduleLayout(store, publishing = false) {
       return getMeta(layoutUri);
     })
     .then((layoutMeta) => {
-      store.dispatch('finishProgress', 'scheduled');
+      store.dispatch('finishProgress', 'unscheduled');
 
       if (publishing) {
         return;

--- a/lib/page-data/actions.js
+++ b/lib/page-data/actions.js
@@ -220,13 +220,13 @@ export function schedulePage(store, { uri, timestamp }) {
  */
 export function unschedulePage(store, publishing = false) {
   const pageUri = _.get(store, 'state.page.uri'),
-    scheduleId = btoa(pageUri),
+    scheduledId = btoa(pageUri),
     prefix = _.get(store, 'state.site.prefix'),
-    scheduleUri = `${prefix}${scheduleRoute}/${scheduleId}`;
+    scheduledUri = `${prefix}${scheduleRoute}/${scheduledId}`;
 
-  store.dispatch('startProgress', 'scheduled');
+  store.dispatch('startProgress', 'unscheduled');
 
-  return remove(scheduleUri)
+  return remove(scheduledUri)
     .then(() => {
       if (publishing) {
         return Promise.resolve();
@@ -236,7 +236,7 @@ export function unschedulePage(store, publishing = false) {
       return getMeta(pageUri);
     })
     .then((updatedState) => {
-      store.dispatch('finishProgress', 'scheduled');
+      store.dispatch('finishProgress', 'unscheduled');
 
       if (publishing) {
         return;


### PR DESCRIPTION
The UI when scheduling/rescheduling/unscheduling was not being updated as it should have been because of a few pieces of state that needed to be changed! 

Those things are addressed here, plus the linter decided to fix some files.

Before this, when clicking `unschedule`, the UI wouldn't react and it wouldn't show the UI back to its default state (where the page is not scheduled).